### PR TITLE
Route stress Reader handoffs through output experiments

### DIFF
--- a/docs/studies/stress_ethanol_cipro_growth/contexts/opal/response-metastudy.md
+++ b/docs/studies/stress_ethanol_cipro_growth/contexts/opal/response-metastudy.md
@@ -3,7 +3,7 @@ id: stress-ethanol-cipro-growth-opal-response-metastudy
 title: Response assay and objective comparison
 owner: dnadesign-maintainers
 status: source_evidence
-last_verified: 2026-07-21
+last_verified: 2026-07-28
 audience:
   - scientist
   - maintainer
@@ -274,7 +274,7 @@ From `dnadesign/`:
 ```bash
 uv run python -m \
   dnadesign.studies.units.stress_ethanol_cipro_growth.decision.opal.response_metastudy \
-  --reader-bundle ../reader/outputs/reviews/stress_response_window/latest \
+  --reader-bundle ../reader/experiments/2026/20260717_stress_response_window_aggregate/outputs \
   --candidate-bindings src/dnadesign/studies/units/stress_ethanol_cipro_growth/workbench/outputs/promoter_candidate_bindings/latest \
   --overwrite \
   --json

--- a/docs/studies/stress_ethanol_cipro_growth/contexts/opal/response-metastudy.md
+++ b/docs/studies/stress_ethanol_cipro_growth/contexts/opal/response-metastudy.md
@@ -14,7 +14,7 @@ audience:
 
 **Status:** frozen comparative evidence
 **Owner:** `stress_ethanol_cipro_growth` study
-**Last verified:** 2026-07-21
+**Last verified:** 2026-07-28
 **Implementation:** `src/dnadesign/studies/units/stress_ethanol_cipro_growth/decision/opal/response_metastudy`
 **Generated evidence:** `src/dnadesign/studies/units/stress_ethanol_cipro_growth/workbench/outputs/response_metastudy/latest`
 

--- a/src/dnadesign/studies/units/stress_ethanol_cipro_growth/decision/opal/response_metastudy/README.md
+++ b/src/dnadesign/studies/units/stress_ethanol_cipro_growth/decision/opal/response_metastudy/README.md
@@ -3,7 +3,7 @@ id: stress-ethanol-cipro-growth-response-metastudy-package
 title: Response assay and objective comparison package
 owner: stress_ethanol_cipro_growth
 status: source_evidence
-last_verified: 2026-07-21
+last_verified: 2026-07-28
 ---
 
 # Response assay and objective comparison
@@ -78,7 +78,7 @@ publisher:
 BUNDLE=src/dnadesign/studies/units/stress_ethanol_cipro_growth/workbench/outputs/multistate_response_behavior_shadow/latest
 PREDICTION_RUN_ID=$(jq -r '.source.prediction.run_id' "$BUNDLE/manifest.json")
 uv run python -m dnadesign.studies.units.stress_ethanol_cipro_growth.decision.opal.response_metastudy.multistate_behavior_cli publish \
-  --reader-bundle ../reader/outputs/reviews/stress_response_window/latest \
+  --reader-bundle ../reader/experiments/2026/20260717_stress_response_window_aggregate/outputs \
   --candidate-bindings src/dnadesign/studies/units/stress_ethanol_cipro_growth/workbench/outputs/promoter_candidate_bindings/latest \
   --prediction-run-id "$PREDICTION_RUN_ID" \
   --out-dir "$BUNDLE" \
@@ -105,20 +105,28 @@ is hand-edited.
 First materialize the Reader bundle from `reader/`:
 
 ```bash
+uv run reader init \
+  experiments/2026/20260717_stress_response_window_aggregate \
+  --protocol workbench/generic \
+  --title "Stress response-window cross-experiment aggregate"
+
 uv run reader response-window build \
   ../dnadesign/src/dnadesign/studies/units/stress_ethanol_cipro_growth/response_window_observations/config/reader_response_window.yaml \
   --reader-root . \
-  --out-dir outputs/reviews/stress_response_window/latest \
+  --output-experiment experiments/2026/20260717_stress_response_window_aggregate \
   --overwrite \
   --format json
 ```
+
+The `init` command is a one-time step. On later runs, reuse the existing output
+experiment and rebuild its generated `outputs/`.
 
 Then run the metastudy from `dnadesign/`:
 
 ```bash
 uv run python -m \
   dnadesign.studies.units.stress_ethanol_cipro_growth.decision.opal.response_metastudy \
-  --reader-bundle ../reader/outputs/reviews/stress_response_window/latest \
+  --reader-bundle ../reader/experiments/2026/20260717_stress_response_window_aggregate/outputs \
   --candidate-bindings src/dnadesign/studies/units/stress_ethanol_cipro_growth/workbench/outputs/promoter_candidate_bindings/latest \
   --calibration-preview \
   --json
@@ -136,7 +144,7 @@ Publish the complete review bundle:
 ```bash
 uv run python -m \
   dnadesign.studies.units.stress_ethanol_cipro_growth.decision.opal.response_metastudy \
-  --reader-bundle ../reader/outputs/reviews/stress_response_window/latest \
+  --reader-bundle ../reader/experiments/2026/20260717_stress_response_window_aggregate/outputs \
   --candidate-bindings src/dnadesign/studies/units/stress_ethanol_cipro_growth/workbench/outputs/promoter_candidate_bindings/latest \
   --overwrite \
   --json


### PR DESCRIPTION
## Why

Reader PR [#11](https://github.com/e-south/reader/pull/11) makes cross-experiment publication explicitly experiment-owned and removes the root `reader/outputs/` destination. The stress response-metastudy runbooks are the known downstream callers and must point at the canonical Reader aggregate experiment.

## What Changed

- Route all response-metastudy and multistate-shadow examples to `reader/experiments/2026/20260717_stress_response_window_aggregate/outputs`.
- Replace the retired Reader `--out-dir` example with the one-time generic aggregate-experiment scaffold plus `--output-experiment`.
- Refresh verification dates on both owner docs.

No study math, output artifacts, campaign state, or label semantics changed.

## How to Review

1. Confirm the Reader build command matches Reader PR #11.
2. Confirm every study consumer uses the same experiment-owned bundle path.
3. Confirm the change remains documentation-only and preserves the Reader/study ownership boundary.

## Validation

- `uv run python -m dnadesign.devtools.docs.checks`: 511 Markdown files passed.
- `git diff --check`: passed.
- Repository pre-commit hooks passed, including secrets and whitespace checks.
- The PhD Reader–OPAL bridge audit and generic skill audit both passed after route synchronization.

## Risk and Rollout

Low and documentation-only. Merge after Reader PR #11 so the documented CLI and path exist on the Reader default branch. No generated outputs or data migrations are included.