### PR TITLE
Harden Ops discovery budgets

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,12 +26,12 @@ jobs:
       external-integration-tools-csv: ${{ steps.scope.outputs.external_integration_tools_csv }}
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version-file: ".python-version"
 
@@ -60,15 +60,15 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version-file: ".python-version"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           enable-cache: true
 
@@ -97,12 +97,12 @@ jobs:
       MPLCONFIGDIR: ${{ github.workspace }}/.tmp/matplotlib
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version-file: ".python-version"
 
@@ -116,7 +116,7 @@ jobs:
             --output-file .ci_changed_files.txt
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           enable-cache: true
 
@@ -245,14 +245,14 @@ jobs:
 
       - name: Upload quality-score coverage summary artifact
         if: needs.detect-ci-scope.outputs.run-full-core == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: quality-score-coverage-summary
           path: quality-score-coverage-summary.json
 
       - name: Upload core-lane coverage to Codecov
         if: needs.detect-ci-scope.outputs.run-coverage-gate == 'true'
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5
         with:
           files: coverage-core.xml
           flags: core
@@ -277,12 +277,12 @@ jobs:
       MPLCONFIGDIR: ${{ github.workspace }}/.tmp/matplotlib
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           fetch-depth: 0
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version-file: ".python-version"
 
@@ -296,12 +296,12 @@ jobs:
             --output-file .ci_changed_files.txt
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           enable-cache: true
 
       - name: Set up pixi (cached)
-        uses: prefix-dev/setup-pixi@v0.9.4
+        uses: prefix-dev/setup-pixi@a0af7a228712d6121d37aba47adf55c1332c9c2e # v0.9.4
         with:
           cache: true
           cache-write: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
@@ -364,7 +364,7 @@ jobs:
             --required-tools-csv "${{ needs.detect-ci-scope.outputs.external-integration-tools-csv }}"
 
       - name: Upload external-integration coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5
         with:
           files: coverage-external-integration.xml
           flags: external_integration
@@ -384,15 +384,15 @@ jobs:
       (needs.external-integration.result == 'success' || needs.external-integration.result == 'skipped')
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version-file: ".python-version"
 
       - name: Download quality-score coverage summary artifact
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
         with:
           name: quality-score-coverage-summary
           path: .
@@ -408,7 +408,7 @@ jobs:
             --output-json quality-score-inputs.json
 
       - name: Upload quality score inputs artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: quality-score-inputs
           path: quality-score-inputs.json

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -252,7 +252,7 @@ jobs:
 
       - name: Upload core-lane coverage to Codecov
         if: needs.detect-ci-scope.outputs.run-coverage-gate == 'true'
-        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: coverage-core.xml
           flags: core
@@ -364,7 +364,7 @@ jobs:
             --required-tools-csv "${{ needs.detect-ci-scope.outputs.external-integration-tools-csv }}"
 
       - name: Upload external-integration coverage to Codecov
-        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac # v5
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: coverage-external-integration.xml
           flags: external_integration

--- a/.github/workflows/dependency-review.yaml
+++ b/.github/workflows/dependency-review.yaml
@@ -1,0 +1,27 @@
+name: Dependency review
+
+on:
+  pull_request:
+
+concurrency:
+  group: dependency-review-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    name: Dependency review
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Review dependency changes
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          fail-on-severity: moderate

--- a/.github/workflows/quality-entropy.yaml
+++ b/.github/workflows/quality-entropy.yaml
@@ -19,10 +19,10 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version-file: ".python-version"
 
@@ -37,7 +37,7 @@ jobs:
 
       - name: Upload quality entropy artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: quality-entropy-report
           path: quality-entropy-report.md

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -7,7 +7,7 @@
 **Exit artifact:** Ops schema, plan, execute, or read-only progress docs
 
 **Owner:** dnadesign-maintainers
-**Last verified:** 2026-06-24
+**Last verified:** 2026-07-30
 
 Batch orchestration and read-only Ops status checks start here. Dataset
 assembly, construct realization, and infer write-back stay in the shared USR
@@ -120,8 +120,8 @@ uv run ops progress campaign --repo-root <repo-root> --manifest <manifest.yaml>
 - The dry run above is the smallest working status example because it emits the audit JSON that `ops progress show ops.control-plane.orchestration` reads. On non-SCC workstations, add `--allow-missing-qstat` so queue readiness degrades explicitly instead of failing opaquely.
 - Keep `<project>` aligned with the scheduler account or project configured for the workspace or study. Presets are explicit shortcuts, not hidden defaults.
 - Do not create transient operational working directories at repo root (`.codex_tmp/`, `.tmp_ops/`, `tmp_ops/`); use `/scratch` for disposable state.
-- For manual chaining, `--active-job-id` accepts repeat flags or a comma-delimited list and normalizes before `-hold_jid` submit wiring.
-- `ops runbook active-jobs` returns `runtime_visibility`, `plan_command_hint`, and active-job arg hints so you can paste manual chaining arguments directly.
+- For manual chaining, `--active-job-id` accepts repeat flags or a comma-delimited list and normalizes candidate ids before `-hold_jid` wiring. Manual ids do not replace queue discovery; disabling discovery leaves visibility unknown and requires `--allow-unknown-active-jobs` before submission.
+- `ops runbook active-jobs` returns `runtime_visibility`, `plan_command_hint`, and active-job arg hints. Its pasteable manual plan hint includes the explicit unknown-visibility acknowledgement required after discovery is disabled.
 - `ops runbook plan` may still return a usable dry-run plan when runtime visibility is degraded, but `ops runbook execute --submit` blocks by default when active-job posture is unknown.
 - Notify-enabled routes require a readable webhook file contract before `ops runbook execute`:
   `NOTIFY_WEBHOOK_FILE` (`<webhook_env>_FILE`) or a profile webhook `secret_ref` that resolves to `file://...`.

--- a/docs/operations/orchestration/runbooks.md
+++ b/docs/operations/orchestration/runbooks.md
@@ -11,7 +11,7 @@
 **Status-kind:** ops-audit-json
 
 **Owner:** dnadesign-maintainers
-**Last verified:** 2026-06-29
+**Last verified:** 2026-07-30
 
 This contract defines machine-readable runbooks for cross-tool BU SCC control-plane orchestration.
 It does not own durable USR-backed data-plane workflows; return to the root docs router or USR operations docs when the next procedure is about shared datasets rather than scheduler sequencing.
@@ -341,6 +341,9 @@ uv run ops runbook active-jobs --runbook <path-to-runbook.yaml> --repo-root <rep
 `active-jobs` emits `active_job_ids` plus ready-to-paste chaining hints: `active_job_ids_csv`, `active_job_id_args`, and `plan_command_hint`.
 OPS-submitted jobs also carry explicit scheduler identity tags so automatic matching does not rely on workspace-path token scraping alone. The visible job name remains operator-friendly, while the machine-readable identity carries the stable run-group and workspace ids used by active-job discovery and audit correlation.
 The payload also includes `runtime_visibility` so `no_match`, `multiple_matches`, and degraded scheduler visibility stay explicit in both JSON and CLI-adjacent tooling.
+Discovery bounds both the number of `qstat -j` detail probes and their combined
+wall-clock budget. If either bound prevents a complete queue inspection, OPS
+reports degraded `unknown` visibility instead of claiming that no job matched.
 
 Supported scheduler diagnostics:
 

--- a/docs/operations/orchestration/runbooks.md
+++ b/docs/operations/orchestration/runbooks.md
@@ -393,12 +393,12 @@ uv run ops runbook execute \
 2. DenseGen `mode=auto` uses explicit workspace-state classification: `none -> fresh`, `resume_ready -> resume`, `partial -> contract error`; `resume_ready` includes run manifest, non-empty DenseGen attempts artifacts (`attempts.parquet` or `attempts_part-*.parquet`), or non-empty DenseGen-shaped records (`records.parquet` or `records__part-*.parquet`) validated against Arrow logical field names.
 3. DenseGen `mode=auto` treats registry-only reset state (`outputs/usr_datasets/registry.yaml` with no run manifest and no non-empty records) as `none`, so dry-run scaffolds can proceed without an explicit mode override.
 4. Active-job behavior is explicit from `mode_policy.on_active_job` (`hold_jid` or `stop`), never implicit.
-5. `ops runbook plan` and `ops runbook execute` auto-discover matching active jobs by default from explicit OPS scheduler identity tags carried in job metadata; disable with `--no-discover-active-jobs`.
+5. `ops runbook plan` and `ops runbook execute` auto-discover matching active jobs by default from explicit OPS scheduler identity tags carried in job metadata; disabling discovery with `--no-discover-active-jobs` leaves visibility `unknown` even when manual job ids are supplied.
 6. The scheduler-visible job name is for operators; automatic matching uses the machine-readable run-group and workspace identity tags rather than name or path heuristics alone.
 7. `ops runbook plan` and `ops runbook active-jobs` expose `runtime_visibility` with explicit `scheduler_probe_state` and `active_job_resolution_state` values.
 8. `ops runbook plan` may still return a useful dry-run plan when runtime visibility is degraded, but it records that degraded posture explicitly, emits an operator-visible warning, and does not silently collapse `unknown` into `no_match`.
 9. `ops runbook execute --submit` fails closed by default when `runtime_visibility.active_job_resolution_state=unknown`; use `--allow-unknown-active-jobs` only when degraded submit is intentionally accepted and audit JSON should record that override.
-10. Manual active-job input (`--active-job-id`) accepts repeat flags or comma-delimited values and normalizes to a deduplicated job-id set before `-hold_jid` chaining.
+10. Manual active-job input (`--active-job-id`) accepts repeat flags or comma-delimited values and normalizes to a deduplicated candidate set. It does not replace queue discovery; with discovery disabled, `--allow-unknown-active-jobs` is required before those ids may be used for `-hold_jid` chaining.
 11. Execution is fail-fast by phase: `preflight`, optional `notify_smoke`, then optional `submit`.
 12. `--command-timeout-seconds` applies per command and fails phase on timeout; default is `300`.
 13. DenseGen `mode=fresh` is blocked when resume artifacts already exist unless `--allow-fresh-reset` is explicitly provided.

--- a/docs/operations/status/runtime-visibility.md
+++ b/docs/operations/status/runtime-visibility.md
@@ -1,7 +1,7 @@
 ## OPS runtime visibility
 
 **Owner:** dnadesign-maintainers
-**Last verified:** 2026-06-29
+**Last verified:** 2026-07-30
 
 Scheduler probes, active-job resolution, and degraded submit behavior in
 `ops runbook` follow this contract.
@@ -57,10 +57,13 @@ workspace-path token guessing.
 
 ### Manual overrides
 
-- `--active-job-id` remains the safe manual fallback when operators already know
-  the job ids that should be chained or blocked against.
-- `--no-discover-active-jobs` with no manual ids leaves active-job posture
-  unknown, so submit is blocked by default.
+- `--active-job-id` records job ids already known to the operator. Manual ids are
+  candidates for chaining or blocking; they do not prove that the queue contains
+  no other matching jobs.
+- `--no-discover-active-jobs` always leaves active-job posture unknown, including
+  when manual ids are supplied. Submission is blocked unless the operator also
+  supplies `--allow-unknown-active-jobs`; known ids remain available for an
+  explicitly authorized `hold_jid` chain.
 
 ### Supported diagnostics
 

--- a/src/dnadesign/devtools/tests/ci/test_workflow_contract.py
+++ b/src/dnadesign/devtools/tests/ci/test_workflow_contract.py
@@ -141,6 +141,20 @@ def test_third_party_workflow_actions_are_pinned_to_full_commit_shas() -> None:
     assert unpinned == []
 
 
+def test_codecov_uploads_use_node24_compatible_action() -> None:
+    workflow = _workflow()
+    expected_ref = "codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f"
+
+    upload_refs = [
+        str(step.get("uses", ""))
+        for job in workflow["jobs"].values()
+        for step in job.get("steps", ())
+        if str(step.get("uses", "")).startswith("codecov/codecov-action@")
+    ]
+
+    assert upload_refs == [expected_ref, expected_ref]
+
+
 def test_quality_entropy_job_uses_stdlib_only_runtime() -> None:
     workflow = _workflow("quality-entropy.yaml")
     steps = workflow["jobs"]["report"]["steps"]

--- a/src/dnadesign/devtools/tests/ci/test_workflow_contract.py
+++ b/src/dnadesign/devtools/tests/ci/test_workflow_contract.py
@@ -115,11 +115,30 @@ def test_fresh_ci_lanes_recreate_changed_file_list_before_resolving_test_targets
             if "dnadesign.devtools.ci.test_targets" in str(step.get("run", ""))
         )
         collect_run = str(steps[collect_index].get("run", ""))
-        checkout_step = next(step for step in steps[:collect_index] if step.get("uses") == "actions/checkout@v5")
+        checkout_step = next(
+            step for step in steps[:collect_index] if str(step.get("uses", "")).startswith("actions/checkout@")
+        )
         assert checkout_step.get("with", {}).get("fetch-depth") == 0
         assert "dnadesign.devtools.ci.changed_files" in collect_run
         assert "--output-file .ci_changed_files.txt" in collect_run
         assert collect_index < target_index
+
+
+def test_third_party_workflow_actions_are_pinned_to_full_commit_shas() -> None:
+    current = Path(__file__).resolve()
+    repo_root = next(parent for parent in current.parents if (parent / "pyproject.toml").exists())
+    workflow_paths = sorted((repo_root / ".github" / "workflows").glob("*.yaml"))
+
+    unpinned: list[str] = []
+    for workflow_path in workflow_paths:
+        workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+        for job_id, job in workflow.get("jobs", {}).items():
+            for step in job.get("steps", ()):
+                action_ref = str(step.get("uses", "")).strip()
+                if action_ref and re.fullmatch(r"[^@\s]+@[0-9a-f]{40}", action_ref) is None:
+                    unpinned.append(f"{workflow_path.name}:{job_id}:{action_ref}")
+
+    assert unpinned == []
 
 
 def test_quality_entropy_job_uses_stdlib_only_runtime() -> None:

--- a/src/dnadesign/devtools/tests/ci/test_workflow_contract.py
+++ b/src/dnadesign/devtools/tests/ci/test_workflow_contract.py
@@ -141,6 +141,22 @@ def test_third_party_workflow_actions_are_pinned_to_full_commit_shas() -> None:
     assert unpinned == []
 
 
+def test_dependency_review_workflow_is_pr_only_and_least_privilege() -> None:
+    workflow = _workflow("dependency-review.yaml")
+    triggers = workflow.get("on", workflow.get(True))
+
+    assert set(triggers) == {"pull_request"}
+    assert workflow["permissions"] == {"contents": "read"}
+    assert workflow["concurrency"]["cancel-in-progress"] is True
+    assert "pull_request.number" in workflow["concurrency"]["group"]
+    assert set(workflow["jobs"]) == {"dependency-review"}
+
+    job = workflow["jobs"]["dependency-review"]
+    assert "permissions" not in job
+    review_step = next(step for step in job["steps"] if step["uses"].startswith("actions/dependency-review-action@"))
+    assert review_step["with"]["fail-on-severity"] == "moderate"
+
+
 def test_codecov_uploads_use_node24_compatible_action() -> None:
     workflow = _workflow()
     expected_ref = "codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f"

--- a/src/dnadesign/ops/catalog/loader.py
+++ b/src/dnadesign/ops/catalog/loader.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from .metadata import (
+    discover_catalog_metadata_paths,
     index_catalog_procedures,
     index_catalog_tool_routes,
     index_catalog_tool_sources,
@@ -32,13 +33,17 @@ def load_runbook_catalog(*, repo_root: Path | None = None) -> RunbookCatalog:
     if not catalog_path.exists():
         raise ValueError("runbook catalog missing: docs/runbooks/README.md")
 
+    metadata_paths = discover_catalog_metadata_paths(resolved_repo_root)
+
     procedures, procedure_relations = load_catalog_procedures(
         repo_root=resolved_repo_root,
         catalog_path=catalog_path,
+        metadata_paths=metadata_paths.registry_paths,
     )
     tool_sources = load_catalog_tool_sources(
         repo_root=resolved_repo_root,
         catalog_path=catalog_path,
+        metadata_paths=metadata_paths.tool_source_paths,
     )
     procedure_index = index_catalog_procedures(procedures)
     tool_source_index = index_catalog_tool_sources(tool_sources)

--- a/src/dnadesign/ops/catalog/metadata.py
+++ b/src/dnadesign/ops/catalog/metadata.py
@@ -11,9 +11,12 @@ Module Author(s): Eric J. South
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
 
 import yaml
+
+from dnadesign.ops.discovery import discover_suffixed_files
 
 from .constants import (
     ALLOWED_RELATION_TYPES,
@@ -30,6 +33,7 @@ from .models import (
     CatalogToolSourceEntry,
 )
 from .paths import (
+    catalog_metadata_search_roots,
     load_catalog_doc_title,
     relative_catalog_doc_link,
     resolve_doc_path_for_metadata,
@@ -61,12 +65,33 @@ _RELATED_TOOL_ROUTE_KEYS = frozenset({"tool", "route"})
 _TOOL_SOURCE_ROUTE_KEYS = frozenset({"id", "path", "summary"})
 
 
+@dataclass(frozen=True)
+class CatalogMetadataPaths:
+    registry_paths: tuple[Path, ...]
+    tool_source_paths: tuple[Path, ...]
+
+
+def discover_catalog_metadata_paths(repo_root: Path) -> CatalogMetadataPaths:
+    """Discover both catalog sidecar kinds in one bounded traversal."""
+
+    candidates = discover_suffixed_files(
+        roots=catalog_metadata_search_roots(repo_root),
+        suffixes=(REGISTRY_METADATA_SUFFIX, TOOL_SOURCE_METADATA_SUFFIX),
+    )
+    return CatalogMetadataPaths(
+        registry_paths=tuple(path for path in candidates if path.name.endswith(REGISTRY_METADATA_SUFFIX)),
+        tool_source_paths=tuple(path for path in candidates if path.name.endswith(TOOL_SOURCE_METADATA_SUFFIX)),
+    )
+
+
 def load_catalog_procedures(
     *,
     repo_root: Path,
     catalog_path: Path,
+    metadata_paths: tuple[Path, ...] | None = None,
 ) -> tuple[tuple[CatalogProcedureEntry, ...], dict[str, tuple[CatalogProcedureRelation, ...]]]:
-    metadata_paths = tuple(sorted(_discover_registry_metadata_paths(repo_root)))
+    if metadata_paths is None:
+        metadata_paths = discover_catalog_metadata_paths(repo_root).registry_paths
     if not metadata_paths:
         raise ValueError("runbook catalog requires at least one '*.registry.yaml' procedure metadata file")
 
@@ -105,8 +130,10 @@ def load_catalog_tool_sources(
     *,
     repo_root: Path,
     catalog_path: Path,
+    metadata_paths: tuple[Path, ...] | None = None,
 ) -> tuple[CatalogToolSourceEntry, ...]:
-    metadata_paths = tuple(sorted(_discover_tool_source_metadata_paths(repo_root)))
+    if metadata_paths is None:
+        metadata_paths = discover_catalog_metadata_paths(repo_root).tool_source_paths
     if not metadata_paths:
         return ()
 
@@ -208,43 +235,6 @@ def validate_related_tool_routes(
                     "registry related tool route missing from catalog: "
                     f"{entry.registry_id} -> {reference.tool}/{reference.route_id}"
                 )
-
-
-def _discover_registry_metadata_paths(repo_root: Path) -> list[Path]:
-    candidates: list[Path] = []
-    for search_root in _registry_metadata_search_roots(repo_root):
-        for metadata_path in search_root.rglob(f"*{REGISTRY_METADATA_SUFFIX}"):
-            if any(segment in {"archived", "prototypes", "__pycache__"} for segment in metadata_path.parts):
-                continue
-            candidates.append(metadata_path.resolve())
-    return candidates
-
-
-def _discover_tool_source_metadata_paths(repo_root: Path) -> list[Path]:
-    candidates: list[Path] = []
-    for search_root in _registry_metadata_search_roots(repo_root):
-        for metadata_path in search_root.rglob(f"*{TOOL_SOURCE_METADATA_SUFFIX}"):
-            if any(segment in {"archived", "prototypes", "__pycache__"} for segment in metadata_path.parts):
-                continue
-            candidates.append(metadata_path.resolve())
-    return candidates
-
-
-def _registry_metadata_search_roots(repo_root: Path) -> tuple[Path, ...]:
-    search_roots: list[Path] = []
-
-    top_level_docs_root = (repo_root / "docs").resolve()
-    if top_level_docs_root.exists():
-        search_roots.append(top_level_docs_root)
-
-    tool_src_root = (repo_root / "src" / "dnadesign").resolve()
-    if tool_src_root.exists():
-        for tool_root in sorted(path for path in tool_src_root.iterdir() if path.is_dir()):
-            docs_root = (tool_root / "docs").resolve()
-            if docs_root.exists():
-                search_roots.append(docs_root)
-
-    return tuple(search_roots)
 
 
 def _load_registry_metadata_file(

--- a/src/dnadesign/ops/catalog/paths.py
+++ b/src/dnadesign/ops/catalog/paths.py
@@ -64,6 +64,23 @@ def resolve_catalog_repo_root(repo_root: Path | None) -> Path:
     raise ValueError("runbook catalog requires a dnadesign repository checkout; pass --repo-root")
 
 
+def catalog_metadata_search_roots(repo_root: Path) -> tuple[Path, ...]:
+    """Return the checked-in documentation roots that may publish catalog metadata."""
+
+    search_roots: list[Path] = []
+    top_level_docs_root = (repo_root / "docs").resolve()
+    if top_level_docs_root.exists():
+        search_roots.append(top_level_docs_root)
+
+    tool_src_root = (repo_root / "src" / "dnadesign").resolve()
+    if tool_src_root.exists():
+        for tool_root in sorted(path for path in tool_src_root.iterdir() if path.is_dir()):
+            docs_root = (tool_root / "docs").resolve()
+            if docs_root.exists():
+                search_roots.append(docs_root)
+    return tuple(search_roots)
+
+
 def resolve_doc_path_for_metadata(*, metadata_path: Path, repo_root: Path) -> Path:
     relative_metadata = metadata_path.resolve().relative_to(repo_root.resolve())
     if relative_metadata.parent.name == "registry":

--- a/src/dnadesign/ops/cli/commands/runbook.py
+++ b/src/dnadesign/ops/cli/commands/runbook.py
@@ -269,7 +269,10 @@ def _render_active_job_hints(*, runbook_path: Path, active_job_ids: Sequence[str
     repeat_args = " ".join(f"--active-job-id {shlex.quote(job_id)}" for job_id in deduped_job_ids)
     runbook_arg = shlex.quote(str(runbook_path.expanduser()))
     if repeat_args:
-        plan_hint = f"uv run ops runbook plan --runbook {runbook_arg} --no-discover-active-jobs {repeat_args}"
+        plan_hint = (
+            f"uv run ops runbook plan --runbook {runbook_arg} --no-discover-active-jobs "
+            f"{repeat_args} --allow-unknown-active-jobs"
+        )
     else:
         plan_hint = f"uv run ops runbook plan --runbook {runbook_arg}"
     return {
@@ -623,9 +626,7 @@ def runbook_plan(
         list[str] | None,
         typer.Option(
             "--active-job-id",
-            help=(
-                "Existing active job id(s) for hold_jid policy decisions; repeat option or pass a comma-delimited list."
-            ),
+            help=("Known active job id(s) for hold_jid candidates; manual ids do not prove complete queue visibility."),
         ),
     ] = None,
     discover_active_jobs: Annotated[
@@ -644,6 +645,13 @@ def runbook_plan(
         typer.Option(
             "--allow-fresh-reset/--no-allow-fresh-reset",
             help="Allow --mode fresh when resume artifacts already exist in the workspace.",
+        ),
+    ] = False,
+    allow_unknown_active_jobs: Annotated[
+        bool,
+        typer.Option(
+            "--allow-unknown-active-jobs/--no-allow-unknown-active-jobs",
+            help="Allow a plan to chain known job ids despite incomplete active-job visibility.",
         ),
     ] = False,
     allow_missing_qstat: Annotated[
@@ -682,6 +690,7 @@ def runbook_plan(
             runtime_visibility=active_job_resolution.runtime_visibility,
             allow_fresh_reset=allow_fresh_reset,
             allow_missing_qstat=allow_missing_qstat,
+            allow_unknown_active_jobs=allow_unknown_active_jobs,
         )
     except ValueError as exc:
         raise_contract_error(f"Runbook contract error: {exc}")
@@ -726,9 +735,7 @@ def runbook_fill_infer(
         list[str] | None,
         typer.Option(
             "--active-job-id",
-            help=(
-                "Existing active job id(s) for hold_jid policy decisions; repeat option or pass a comma-delimited list."
-            ),
+            help=("Known active job id(s) for hold_jid candidates; manual ids do not prove complete queue visibility."),
         ),
     ] = None,
     discover_active_jobs: Annotated[
@@ -910,9 +917,7 @@ def runbook_execute(
         list[str] | None,
         typer.Option(
             "--active-job-id",
-            help=(
-                "Existing active job id(s) for hold_jid policy decisions; repeat option or pass a comma-delimited list."
-            ),
+            help=("Known active job id(s) for hold_jid candidates; manual ids do not prove complete queue visibility."),
         ),
     ] = None,
     discover_active_jobs: Annotated[

--- a/src/dnadesign/ops/discovery.py
+++ b/src/dnadesign/ops/discovery.py
@@ -1,0 +1,73 @@
+"""
+--------------------------------------------------------------------------------
+dnadesign
+src/dnadesign/ops/discovery.py
+
+Bounded filesystem discovery for checked-in OPS metadata.
+
+Module Author(s): Eric J. South
+--------------------------------------------------------------------------------
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterable
+from pathlib import Path
+
+_PRUNED_DIRECTORY_NAMES = frozenset(
+    {
+        ".git",
+        ".mypy_cache",
+        ".pytest_cache",
+        ".ruff_cache",
+        ".venv",
+        "__pycache__",
+        "archived",
+        "batch_results",
+        "node_modules",
+        "outputs",
+        "prototypes",
+        "runs",
+    }
+)
+
+
+def _discover_files(
+    *,
+    roots: Iterable[Path],
+    names: frozenset[str] = frozenset(),
+    suffixes: tuple[str, ...] = (),
+) -> tuple[Path, ...]:
+    if not names and not suffixes:
+        return ()
+
+    discovered: set[Path] = set()
+    for root in sorted({path.expanduser().resolve() for path in roots}):
+        if not root.is_dir():
+            continue
+        for directory, child_directories, filenames in os.walk(root, topdown=True, followlinks=False):
+            child_directories[:] = sorted(
+                name
+                for name in child_directories
+                if name not in _PRUNED_DIRECTORY_NAMES and not (Path(directory) / name).is_symlink()
+            )
+            for filename in sorted(filenames):
+                if filename not in names and not filename.endswith(suffixes):
+                    continue
+                candidate = Path(directory) / filename
+                if candidate.is_file():
+                    discovered.add(candidate.resolve())
+    return tuple(sorted(discovered))
+
+
+def discover_named_files(*, roots: Iterable[Path], names: frozenset[str]) -> tuple[Path, ...]:
+    """Find exact filenames without entering generated, archived, or cache trees."""
+
+    return _discover_files(roots=roots, names=names)
+
+
+def discover_suffixed_files(*, roots: Iterable[Path], suffixes: tuple[str, ...]) -> tuple[Path, ...]:
+    """Find suffix-matched files without entering generated, archived, or cache trees."""
+
+    return _discover_files(roots=roots, suffixes=suffixes)

--- a/src/dnadesign/ops/orchestrator/state.py
+++ b/src/dnadesign/ops/orchestrator/state.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import hashlib
 import os
 import subprocess
+import time
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from enum import StrEnum
@@ -31,27 +32,33 @@ SubmitBehavior = Literal["submit", "hold_jid", "blocked"]
 ResumeState = Literal["none", "resume_ready", "partial"]
 _OPS_IDENTITY_KEYS = ("ops_run_group_id", "ops_workspace_id", "ops_workflow_id")
 _SCHEDULER_PROBE_TIMEOUT_SECONDS = 10.0
+_SCHEDULER_DISCOVERY_BUDGET_SECONDS = 10.0
 _SUBMIT_HOST_DENIED_TOKENS = (
     "is no submit host",
     "neither submit nor admin host",
 )
 
 
-def _run_probe(argv: Sequence[str]) -> tuple[int, str, str]:
+def _run_probe(
+    argv: Sequence[str],
+    *,
+    timeout_seconds: float | None = None,
+) -> tuple[int, str, str]:
+    effective_timeout = _SCHEDULER_PROBE_TIMEOUT_SECONDS if timeout_seconds is None else timeout_seconds
     try:
         result = subprocess.run(
             list(argv),
             check=False,
             capture_output=True,
             text=True,
-            timeout=_SCHEDULER_PROBE_TIMEOUT_SECONDS,
+            timeout=effective_timeout,
         )
     except OSError as exc:
         cmd = str(argv[0]) if argv else "command"
         return 127, "", f"{cmd} unavailable: {exc}"
     except subprocess.TimeoutExpired:
         cmd = str(argv[0]) if argv else "command"
-        return 124, "", f"{cmd} unavailable: timed out after {_SCHEDULER_PROBE_TIMEOUT_SECONDS:g} seconds"
+        return 124, "", f"{cmd} unavailable: timed out after {effective_timeout:g} seconds"
     return int(result.returncode), result.stdout, result.stderr
 
 
@@ -82,6 +89,7 @@ class SchedulerProbeState(StrEnum):
     UNAVAILABLE = "unavailable"
     UNSUPPORTED = "unsupported"
     ERROR = "error"
+    BUDGET_EXHAUSTED = "budget_exhausted"
 
 
 class ActiveJobResolutionState(StrEnum):
@@ -295,6 +303,7 @@ def probe_active_jobs_for_runbook(
     runbook: OrchestrationRunbookV1,
     *,
     max_jobs: int = 24,
+    budget_seconds: float = _SCHEDULER_DISCOVERY_BUDGET_SECONDS,
 ) -> ActiveJobResolution:
     if max_jobs <= 0:
         return ActiveJobResolution(
@@ -308,15 +317,36 @@ def probe_active_jobs_for_runbook(
             ),
         )
 
+    if budget_seconds <= 0:
+        return ActiveJobResolution(
+            explicit_job_ids=(),
+            discovered_job_ids=(),
+            effective_job_ids=(),
+            runtime_visibility=RuntimeVisibility(
+                scheduler_probe_state=SchedulerProbeState.BUDGET_EXHAUSTED,
+                active_job_resolution_state=ActiveJobResolutionState.UNKNOWN,
+                degraded=True,
+                degraded_reasons=("active-job discovery requires an overall probe budget greater than zero",),
+            ),
+        )
+
     identity = resolve_ops_job_identity(runbook)
+    deadline = time.monotonic() + budget_seconds
     user = os.environ.get("USER", "")
-    return_code, stdout, stderr = _run_probe(("qstat", "-u", user))
+    return_code, stdout, stderr = _run_probe(
+        ("qstat", "-u", user),
+        timeout_seconds=max(0.001, deadline - time.monotonic()),
+    )
     if return_code != 0:
         message = stderr.strip() or stdout.strip() or "qstat -u failed"
         probe_state = (
-            SchedulerProbeState.HOST_DENIED
-            if _is_submit_host_denied_message(message)
-            else SchedulerProbeState.UNAVAILABLE
+            SchedulerProbeState.BUDGET_EXHAUSTED
+            if return_code == 124
+            else (
+                SchedulerProbeState.HOST_DENIED
+                if _is_submit_host_denied_message(message)
+                else SchedulerProbeState.UNAVAILABLE
+            )
         )
         return ActiveJobResolution(
             explicit_job_ids=(),
@@ -333,13 +363,39 @@ def probe_active_jobs_for_runbook(
     active_job_ids: list[str] = []
     degraded_reasons: list[str] = []
     scheduler_probe_state = SchedulerProbeState.OK
-    for job_id in _parse_job_ids_from_qstat_output(stdout):
-        if len(active_job_ids) >= max_jobs:
+    queued_job_ids = _parse_job_ids_from_qstat_output(stdout)
+    inspected_jobs = 0
+    for job_id in queued_job_ids:
+        if inspected_jobs >= max_jobs:
+            degraded_reasons.append(
+                f"active-job discovery inspected {inspected_jobs} of {len(queued_job_ids)} queued jobs; "
+                f"--max-discovery-jobs={max_jobs} exhausted"
+            )
+            scheduler_probe_state = SchedulerProbeState.BUDGET_EXHAUSTED
             break
-        rc, job_stdout, job_stderr = _run_probe(("qstat", "-j", str(job_id)))
+        remaining_seconds = deadline - time.monotonic()
+        if remaining_seconds <= 0:
+            degraded_reasons.append(
+                f"active-job discovery exceeded its {budget_seconds:g} second overall probe budget "
+                f"after inspecting {inspected_jobs} of {len(queued_job_ids)} queued jobs"
+            )
+            scheduler_probe_state = SchedulerProbeState.BUDGET_EXHAUSTED
+            break
+        inspected_jobs += 1
+        rc, job_stdout, job_stderr = _run_probe(
+            ("qstat", "-j", str(job_id)),
+            timeout_seconds=max(0.001, remaining_seconds),
+        )
         if rc != 0:
             message = job_stderr.strip() or job_stdout.strip() or f"qstat -j {job_id} failed"
             degraded_reasons.append(f"active-job detail probe failed for job {job_id}: {message}")
+            if rc == 124:
+                degraded_reasons.append(
+                    f"active-job discovery exceeded its {budget_seconds:g} second overall probe budget "
+                    f"after inspecting {inspected_jobs} of {len(queued_job_ids)} queued jobs"
+                )
+                scheduler_probe_state = SchedulerProbeState.BUDGET_EXHAUSTED
+                break
             scheduler_probe_state = SchedulerProbeState.ERROR
             continue
         job_name, tags = _parse_qstat_job_metadata(job_stdout)

--- a/src/dnadesign/ops/orchestrator/state.py
+++ b/src/dnadesign/ops/orchestrator/state.py
@@ -481,7 +481,10 @@ def resolve_active_job_resolution(
         )
     effective_job_ids = _dedupe_job_ids((*normalized_explicit_job_ids, *auto_resolution.discovered_job_ids))
     runtime_visibility = auto_resolution.runtime_visibility
-    if normalized_explicit_job_ids:
+    if (
+        normalized_explicit_job_ids
+        and auto_resolution.runtime_visibility.active_job_resolution_state is not ActiveJobResolutionState.UNKNOWN
+    ):
         runtime_visibility = RuntimeVisibility(
             scheduler_probe_state=auto_resolution.runtime_visibility.scheduler_probe_state,
             active_job_resolution_state=_active_job_resolution_state_for_job_ids(effective_job_ids),

--- a/src/dnadesign/ops/orchestrator/state.py
+++ b/src/dnadesign/ops/orchestrator/state.py
@@ -461,24 +461,7 @@ def resolve_active_job_resolution(
         )
 
     try:
-        discovered_job_ids = discover_active_job_ids_for_runbook(runbook, max_jobs=max_jobs)
-        auto_resolution = ActiveJobResolution(
-            explicit_job_ids=(),
-            discovered_job_ids=discovered_job_ids,
-            effective_job_ids=discovered_job_ids,
-            runtime_visibility=RuntimeVisibility(
-                scheduler_probe_state=SchedulerProbeState.OK,
-                active_job_resolution_state=_active_job_resolution_state_for_job_ids(discovered_job_ids),
-                degraded=False,
-            ),
-        )
-    except ActiveJobProbeError as exc:
-        auto_resolution = ActiveJobResolution(
-            explicit_job_ids=(),
-            discovered_job_ids=(),
-            effective_job_ids=(),
-            runtime_visibility=exc.runtime_visibility,
-        )
+        auto_resolution = probe_active_jobs_for_runbook(runbook, max_jobs=max_jobs)
     except RuntimeError as exc:
         probe_state = (
             SchedulerProbeState.HOST_DENIED

--- a/src/dnadesign/ops/orchestrator/state.py
+++ b/src/dnadesign/ops/orchestrator/state.py
@@ -774,7 +774,21 @@ def resolve_mode_decision(
 
     selected_runtime_visibility = runtime_visibility or _default_runtime_visibility_for_job_ids(active_job_ids)
     hold_jid_candidates = _normalize_hold_jid(active_job_ids)
-    if hold_jid_candidates is not None:
+    active_job_visibility_unknown = (
+        selected_runtime_visibility.active_job_resolution_state == ActiveJobResolutionState.UNKNOWN
+    )
+    if (
+        active_job_visibility_unknown
+        and selected_runtime_visibility.scheduler_probe_state == SchedulerProbeState.HOST_DENIED
+    ):
+        submit_behavior = "blocked"
+        reason = f"{reason}; current_host_not_submit_host"
+    elif active_job_visibility_unknown and not allow_unknown_active_jobs:
+        submit_behavior = "blocked"
+        reason = f"{reason}; active_job_visibility_unknown; submission_blocked_by_runtime_visibility"
+    elif hold_jid_candidates is not None:
+        if active_job_visibility_unknown:
+            reason = f"{reason}; active_job_visibility_unknown; submission_override_allow_unknown_active_jobs=true"
         if runbook.mode_policy.on_active_job == "hold_jid":
             submit_behavior = "hold_jid"
             hold_jid = hold_jid_candidates
@@ -782,15 +796,8 @@ def resolve_mode_decision(
         else:
             submit_behavior = "blocked"
             reason = f"{reason}; active_jobs_detected; submission_blocked_by_policy"
-    elif selected_runtime_visibility.active_job_resolution_state == ActiveJobResolutionState.UNKNOWN:
-        if selected_runtime_visibility.scheduler_probe_state == SchedulerProbeState.HOST_DENIED:
-            submit_behavior = "blocked"
-            reason = f"{reason}; current_host_not_submit_host"
-        elif allow_unknown_active_jobs:
-            reason = f"{reason}; active_job_visibility_unknown; submission_override_allow_unknown_active_jobs=true"
-        else:
-            submit_behavior = "blocked"
-            reason = f"{reason}; active_job_visibility_unknown; submission_blocked_by_runtime_visibility"
+    elif active_job_visibility_unknown:
+        reason = f"{reason}; active_job_visibility_unknown; submission_override_allow_unknown_active_jobs=true"
     else:
         reason = f"{reason}; active_job_visibility={selected_runtime_visibility.active_job_resolution_state.value}"
 

--- a/src/dnadesign/ops/orchestrator/state.py
+++ b/src/dnadesign/ops/orchestrator/state.py
@@ -435,27 +435,20 @@ def resolve_active_job_resolution(
 ) -> ActiveJobResolution:
     normalized_explicit_job_ids = _dedupe_job_ids(explicit_job_ids)
     if not discover_active_jobs:
-        if normalized_explicit_job_ids:
-            return ActiveJobResolution(
-                explicit_job_ids=normalized_explicit_job_ids,
-                discovered_job_ids=(),
-                effective_job_ids=normalized_explicit_job_ids,
-                runtime_visibility=RuntimeVisibility(
-                    scheduler_probe_state=SchedulerProbeState.SKIPPED,
-                    active_job_resolution_state=_active_job_resolution_state_for_job_ids(normalized_explicit_job_ids),
-                    degraded=False,
-                ),
-            )
+        manual_ids_reason = (
+            "; manual job ids do not prove complete queue visibility" if normalized_explicit_job_ids else ""
+        )
         return ActiveJobResolution(
-            explicit_job_ids=(),
+            explicit_job_ids=normalized_explicit_job_ids,
             discovered_job_ids=(),
-            effective_job_ids=(),
+            effective_job_ids=normalized_explicit_job_ids,
             runtime_visibility=RuntimeVisibility(
                 scheduler_probe_state=SchedulerProbeState.SKIPPED,
                 active_job_resolution_state=ActiveJobResolutionState.UNKNOWN,
                 degraded=True,
                 degraded_reasons=(
-                    f"active-job discovery skipped while mode_policy.on_active_job={runbook.mode_policy.on_active_job}",
+                    "active-job discovery skipped while "
+                    f"mode_policy.on_active_job={runbook.mode_policy.on_active_job}{manual_ids_reason}",
                 ),
             ),
         )

--- a/src/dnadesign/ops/status/registry_loader.py
+++ b/src/dnadesign/ops/status/registry_loader.py
@@ -16,6 +16,8 @@ from pathlib import Path
 
 import yaml
 
+from dnadesign.ops.discovery import discover_named_files
+
 from .models import InputFieldSpec, StatusKindSpec
 
 _STATUS_REGISTRY_FILENAME = "status.registry.yaml"
@@ -243,11 +245,11 @@ def _iter_status_registry_fragment_paths() -> tuple[Path, ...]:
 
 
 def _iter_status_registry_fragment_paths_for_root(*, dnadesign_root: Path) -> tuple[Path, ...]:
-    fragment_paths = [
+    fragment_paths = tuple(
         path
-        for path in dnadesign_root.rglob(_STATUS_REGISTRY_FILENAME)
-        if path.is_file() and _is_status_registry_fragment_path(path=path, dnadesign_root=dnadesign_root)
-    ]
+        for path in discover_named_files(roots=(dnadesign_root,), names=frozenset({_STATUS_REGISTRY_FILENAME}))
+        if _is_status_registry_fragment_path(path=path, dnadesign_root=dnadesign_root)
+    )
     return tuple(sorted(fragment_paths))
 
 

--- a/src/dnadesign/ops/tests/test_discovery_performance.py
+++ b/src/dnadesign/ops/tests/test_discovery_performance.py
@@ -1,0 +1,125 @@
+"""
+--------------------------------------------------------------------------------
+dnadesign
+src/dnadesign/ops/tests/test_discovery_performance.py
+
+Parity and traversal-boundary tests for OPS metadata discovery.
+
+Module Author(s): Eric J. South
+--------------------------------------------------------------------------------
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+import dnadesign.ops.catalog.loader as catalog_loader
+from dnadesign.ops.catalog.constants import REGISTRY_METADATA_SUFFIX, TOOL_SOURCE_METADATA_SUFFIX
+from dnadesign.ops.catalog.metadata import discover_catalog_metadata_paths
+from dnadesign.ops.catalog.paths import catalog_metadata_search_roots
+from dnadesign.ops.discovery import discover_named_files
+from dnadesign.ops.status.registry_loader import _iter_status_registry_fragment_paths_for_root
+
+
+def _repo_root() -> Path:
+    current = Path(__file__).resolve()
+    for parent in current.parents:
+        if (parent / "pyproject.toml").exists():
+            return parent
+    raise RuntimeError("repo root not found")
+
+
+def test_catalog_discovery_preserves_existing_file_parity() -> None:
+    repo_root = _repo_root()
+    search_roots = catalog_metadata_search_roots(repo_root)
+    expected_registry = tuple(
+        sorted(
+            path.resolve()
+            for search_root in search_roots
+            for path in search_root.rglob(f"*{REGISTRY_METADATA_SUFFIX}")
+            if not any(segment in {"archived", "prototypes", "__pycache__"} for segment in path.parts)
+        )
+    )
+    expected_tool_sources = tuple(
+        sorted(
+            path.resolve()
+            for search_root in search_roots
+            for path in search_root.rglob(f"*{TOOL_SOURCE_METADATA_SUFFIX}")
+            if not any(segment in {"archived", "prototypes", "__pycache__"} for segment in path.parts)
+        )
+    )
+
+    discovered = discover_catalog_metadata_paths(repo_root)
+
+    assert discovered.registry_paths == expected_registry
+    assert discovered.tool_source_paths == expected_tool_sources
+
+
+def test_catalog_loader_discovers_both_sidecar_kinds_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls = 0
+    original = catalog_loader.discover_catalog_metadata_paths
+
+    def _discover(repo_root: Path):
+        nonlocal calls
+        calls += 1
+        return original(repo_root)
+
+    monkeypatch.setattr(catalog_loader, "discover_catalog_metadata_paths", _discover)
+
+    catalog = catalog_loader.load_runbook_catalog(repo_root=_repo_root())
+
+    assert catalog.procedures
+    assert catalog.tool_sources
+    assert calls == 1
+
+
+def test_catalog_discovery_keeps_malformed_sidecars_visible_to_validation(tmp_path: Path) -> None:
+    catalog_path = tmp_path / "docs" / "runbooks" / "README.md"
+    doc_path = tmp_path / "docs" / "operations" / "demo.md"
+    metadata_path = doc_path.with_name("demo.registry.yaml")
+    catalog_path.parent.mkdir(parents=True)
+    doc_path.parent.mkdir(parents=True)
+    catalog_path.write_text("# Runbooks\n", encoding="utf-8")
+    doc_path.write_text("# Demo\n", encoding="utf-8")
+    metadata_path.write_text("schema_version: 1\nlegacy_alias: hidden-error\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match=r"registry metadata has unknown key\(s\): legacy_alias"):
+        catalog_loader.load_runbook_catalog(repo_root=tmp_path)
+
+
+def test_status_discovery_preserves_existing_file_parity() -> None:
+    dnadesign_root = _repo_root() / "src" / "dnadesign"
+    expected = tuple(
+        sorted(
+            path
+            for path in dnadesign_root.rglob("status.registry.yaml")
+            if path.is_file()
+            and (
+                path.parent.name == "ops"
+                or (
+                    len(path.resolve().relative_to(dnadesign_root).parts) == 4
+                    and path.resolve().relative_to(dnadesign_root).parts[0:2] == ("ops", "providers")
+                )
+            )
+        )
+    )
+
+    assert _iter_status_registry_fragment_paths_for_root(dnadesign_root=dnadesign_root) == expected
+
+
+def test_named_file_discovery_prunes_generated_and_archived_trees(tmp_path: Path) -> None:
+    visible = tmp_path / "tool" / "ops" / "status.registry.yaml"
+    generated = tmp_path / "tool" / "outputs" / "ops" / "status.registry.yaml"
+    archived = tmp_path / "tool" / "archived" / "ops" / "status.registry.yaml"
+    for path in (visible, generated, archived):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("version: 1\n", encoding="utf-8")
+
+    discovered = discover_named_files(
+        roots=(tmp_path,),
+        names=frozenset({"status.registry.yaml"}),
+    )
+
+    assert discovered == (visible.resolve(),)

--- a/src/dnadesign/ops/tests/test_runbook_orchestrator.py
+++ b/src/dnadesign/ops/tests/test_runbook_orchestrator.py
@@ -939,6 +939,51 @@ def test_mode_auto_with_active_jobs_normalizes_comma_delimited_ids(tmp_path: Pat
     assert decision.hold_jid == "81001,81002"
 
 
+def test_mode_auto_blocks_partial_active_job_matches_when_discovery_is_unknown(tmp_path: Path) -> None:
+    runbook_path = _write_runbook(tmp_path)
+    runbook = load_orchestration_runbook(runbook_path)
+    runtime_visibility = orchestrator_state.RuntimeVisibility(
+        scheduler_probe_state=orchestrator_state.SchedulerProbeState.BUDGET_EXHAUSTED,
+        active_job_resolution_state=orchestrator_state.ActiveJobResolutionState.UNKNOWN,
+        degraded=True,
+        degraded_reasons=("active-job discovery budget exhausted",),
+    )
+
+    decision = resolve_mode_decision(
+        runbook=runbook,
+        requested_mode=None,
+        active_job_ids=("81001",),
+        runtime_visibility=runtime_visibility,
+    )
+
+    assert decision.submit_behavior == "blocked"
+    assert decision.hold_jid is None
+    assert "submission_blocked_by_runtime_visibility" in decision.reason
+
+
+def test_mode_auto_chains_partial_active_job_matches_only_with_unknown_override(tmp_path: Path) -> None:
+    runbook_path = _write_runbook(tmp_path)
+    runbook = load_orchestration_runbook(runbook_path)
+    runtime_visibility = orchestrator_state.RuntimeVisibility(
+        scheduler_probe_state=orchestrator_state.SchedulerProbeState.BUDGET_EXHAUSTED,
+        active_job_resolution_state=orchestrator_state.ActiveJobResolutionState.UNKNOWN,
+        degraded=True,
+        degraded_reasons=("active-job discovery budget exhausted",),
+    )
+
+    decision = resolve_mode_decision(
+        runbook=runbook,
+        requested_mode=None,
+        active_job_ids=("81001",),
+        runtime_visibility=runtime_visibility,
+        allow_unknown_active_jobs=True,
+    )
+
+    assert decision.submit_behavior == "hold_jid"
+    assert decision.hold_jid == "81001"
+    assert "submission_override_allow_unknown_active_jobs=true" in decision.reason
+
+
 def test_mode_auto_blocks_submit_when_current_host_is_not_submit_host_even_with_override(tmp_path: Path) -> None:
     runbook_path = _write_runbook(tmp_path)
     runbook = load_orchestration_runbook(runbook_path)

--- a/src/dnadesign/ops/tests/test_runbook_orchestrator.py
+++ b/src/dnadesign/ops/tests/test_runbook_orchestrator.py
@@ -1515,6 +1515,40 @@ def test_probe_active_jobs_enforces_overall_time_budget(tmp_path: Path, monkeypa
     )
 
 
+def test_active_job_resolution_preserves_confirmed_matches_when_discovery_is_incomplete(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runbook_path = _write_runbook(tmp_path)
+    runbook = load_orchestration_runbook(runbook_path)
+    partial_resolution = orchestrator_state.ActiveJobResolution(
+        explicit_job_ids=(),
+        discovered_job_ids=("81001",),
+        effective_job_ids=("81001",),
+        runtime_visibility=orchestrator_state.RuntimeVisibility(
+            scheduler_probe_state=orchestrator_state.SchedulerProbeState.BUDGET_EXHAUSTED,
+            active_job_resolution_state=orchestrator_state.ActiveJobResolutionState.UNKNOWN,
+            degraded=True,
+            degraded_reasons=("active-job discovery budget exhausted",),
+        ),
+    )
+    monkeypatch.setattr(
+        orchestrator_state,
+        "probe_active_jobs_for_runbook",
+        lambda runbook, max_jobs: partial_resolution,
+    )
+
+    resolution = orchestrator_state.resolve_active_job_resolution(
+        runbook=runbook,
+        explicit_job_ids=(),
+        discover_active_jobs=True,
+        max_jobs=1,
+    )
+
+    assert resolution.discovered_job_ids == ("81001",)
+    assert resolution.effective_job_ids == ("81001",)
+    assert resolution.runtime_visibility == partial_resolution.runtime_visibility
+
+
 def test_batch_plan_submit_commands_include_explicit_job_identity_tags(tmp_path: Path) -> None:
     runbook_path = _write_runbook(tmp_path)
     runbook = load_orchestration_runbook(runbook_path)

--- a/src/dnadesign/ops/tests/test_runbook_orchestrator.py
+++ b/src/dnadesign/ops/tests/test_runbook_orchestrator.py
@@ -1549,6 +1549,41 @@ def test_active_job_resolution_preserves_confirmed_matches_when_discovery_is_inc
     assert resolution.runtime_visibility == partial_resolution.runtime_visibility
 
 
+def test_explicit_job_ids_do_not_mask_incomplete_active_job_discovery(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runbook_path = _write_runbook(tmp_path)
+    runbook = load_orchestration_runbook(runbook_path)
+    partial_resolution = orchestrator_state.ActiveJobResolution(
+        explicit_job_ids=(),
+        discovered_job_ids=("81001",),
+        effective_job_ids=("81001",),
+        runtime_visibility=orchestrator_state.RuntimeVisibility(
+            scheduler_probe_state=orchestrator_state.SchedulerProbeState.BUDGET_EXHAUSTED,
+            active_job_resolution_state=orchestrator_state.ActiveJobResolutionState.UNKNOWN,
+            degraded=True,
+            degraded_reasons=("active-job discovery budget exhausted",),
+        ),
+    )
+    monkeypatch.setattr(
+        orchestrator_state,
+        "probe_active_jobs_for_runbook",
+        lambda runbook, max_jobs: partial_resolution,
+    )
+
+    resolution = orchestrator_state.resolve_active_job_resolution(
+        runbook=runbook,
+        explicit_job_ids=("81002",),
+        discover_active_jobs=True,
+        max_jobs=1,
+    )
+
+    assert resolution.explicit_job_ids == ("81002",)
+    assert resolution.discovered_job_ids == ("81001",)
+    assert resolution.effective_job_ids == ("81002", "81001")
+    assert resolution.runtime_visibility == partial_resolution.runtime_visibility
+
+
 def test_batch_plan_submit_commands_include_explicit_job_identity_tags(tmp_path: Path) -> None:
     runbook_path = _write_runbook(tmp_path)
     runbook = load_orchestration_runbook(runbook_path)

--- a/src/dnadesign/ops/tests/test_runbook_orchestrator.py
+++ b/src/dnadesign/ops/tests/test_runbook_orchestrator.py
@@ -1410,7 +1410,8 @@ job-ID prior name user state submit/start at queue slots ja-task-ID
         ),
     }
 
-    def _probe(argv: tuple[str, ...]) -> tuple[int, str, str]:
+    def _probe(argv: tuple[str, ...], *, timeout_seconds: float | None = None) -> tuple[int, str, str]:
+        assert timeout_seconds is None or timeout_seconds > 0
         if argv[:2] == ("qstat", "-u"):
             return 0, qstat_table, ""
         if argv[:2] == ("qstat", "-j"):
@@ -1423,7 +1424,7 @@ job-ID prior name user state submit/start at queue slots ja-task-ID
     assert discovered == ("81001", "81002")
 
 
-def test_discover_active_job_ids_scans_full_qstat_listing_before_capping_matches(
+def test_probe_active_jobs_caps_inspected_jobs_and_reports_unknown_visibility(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     runbook_path = _write_runbook(tmp_path)
@@ -1448,7 +1449,8 @@ def test_discover_active_job_ids_scans_full_qstat_listing_before_capping_matches
     qstat_table = "\n".join(qstat_lines)
     seen_job_probes: list[str] = []
 
-    def _probe(argv: tuple[str, ...]) -> tuple[int, str, str]:
+    def _probe(argv: tuple[str, ...], *, timeout_seconds: float | None = None) -> tuple[int, str, str]:
+        assert timeout_seconds is None or timeout_seconds > 0
         if argv[:2] == ("qstat", "-u"):
             return 0, qstat_table, ""
         if argv[:2] == ("qstat", "-j"):
@@ -1458,11 +1460,59 @@ def test_discover_active_job_ids_scans_full_qstat_listing_before_capping_matches
 
     monkeypatch.setattr(orchestrator_state, "_run_probe", _probe)
 
-    discovered = discover_active_job_ids_for_runbook(runbook, max_jobs=1)
+    resolution = orchestrator_state.probe_active_jobs_for_runbook(runbook, max_jobs=1)
 
-    assert discovered == ("81025",)
-    assert seen_job_probes[-1] == "81025"
-    assert "81026" not in seen_job_probes
+    assert resolution.discovered_job_ids == ()
+    assert seen_job_probes == ["81001"]
+    assert resolution.runtime_visibility.scheduler_probe_state == (
+        orchestrator_state.SchedulerProbeState.BUDGET_EXHAUSTED
+    )
+    assert (
+        resolution.runtime_visibility.active_job_resolution_state == orchestrator_state.ActiveJobResolutionState.UNKNOWN
+    )
+    assert resolution.runtime_visibility.degraded is True
+    assert resolution.runtime_visibility.degraded_reasons == (
+        "active-job discovery inspected 1 of 26 queued jobs; --max-discovery-jobs=1 exhausted",
+    )
+
+
+def test_probe_active_jobs_enforces_overall_time_budget(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    runbook_path = _write_runbook(tmp_path)
+    runbook = load_orchestration_runbook(runbook_path)
+    qstat_table = "\n".join(
+        (
+            "job-ID prior name user state submit/start at queue slots ja-task-ID",
+            "--------------------------------------------------------------------------------",
+            "81001 0.555 a b qw 03/01/2026 queueA 1",
+            "81002 0.555 a b qw 03/01/2026 queueA 1",
+        )
+    )
+    clock = iter((100.0, 100.0, 100.4, 101.1, 101.1))
+    seen_job_probes: list[str] = []
+
+    def _probe(argv: tuple[str, ...], *, timeout_seconds: float | None = None) -> tuple[int, str, str]:
+        assert timeout_seconds is not None
+        if argv[:2] == ("qstat", "-u"):
+            return 0, qstat_table, ""
+        seen_job_probes.append(str(argv[2]))
+        return 0, "context: ops_run_group_id=foreign", ""
+
+    monkeypatch.setattr(orchestrator_state.time, "monotonic", lambda: next(clock))
+    monkeypatch.setattr(orchestrator_state, "_run_probe", _probe)
+
+    resolution = orchestrator_state.probe_active_jobs_for_runbook(runbook, max_jobs=10, budget_seconds=1.0)
+
+    assert seen_job_probes == ["81001"]
+    assert resolution.discovered_job_ids == ()
+    assert resolution.runtime_visibility.scheduler_probe_state == (
+        orchestrator_state.SchedulerProbeState.BUDGET_EXHAUSTED
+    )
+    assert (
+        resolution.runtime_visibility.active_job_resolution_state == orchestrator_state.ActiveJobResolutionState.UNKNOWN
+    )
+    assert resolution.runtime_visibility.degraded_reasons == (
+        "active-job discovery exceeded its 1 second overall probe budget after inspecting 1 of 2 queued jobs",
+    )
 
 
 def test_batch_plan_submit_commands_include_explicit_job_identity_tags(tmp_path: Path) -> None:
@@ -1491,7 +1541,11 @@ def test_discover_active_job_ids_raises_when_qstat_snapshot_fails(
     runbook_path = _write_runbook(tmp_path)
     runbook = load_orchestration_runbook(runbook_path)
 
-    monkeypatch.setattr(orchestrator_state, "_run_probe", lambda argv: (1, "", "qstat unavailable"))
+    monkeypatch.setattr(
+        orchestrator_state,
+        "_run_probe",
+        lambda argv, *, timeout_seconds=None: (1, "", "qstat unavailable"),
+    )
 
     with pytest.raises(RuntimeError, match="qstat unavailable"):
         discover_active_job_ids_for_runbook(runbook, max_jobs=12)
@@ -1536,7 +1590,11 @@ def test_probe_active_jobs_for_runbook_classifies_submit_host_denial(
     monkeypatch.setattr(
         orchestrator_state,
         "_run_probe",
-        lambda argv: (1, "", 'error: denied: host "scc1.bu.edu" is neither submit nor admin host'),
+        lambda argv, *, timeout_seconds=None: (
+            1,
+            "",
+            'error: denied: host "scc1.bu.edu" is neither submit nor admin host',
+        ),
     )
 
     resolution = orchestrator_state.probe_active_jobs_for_runbook(runbook, max_jobs=12)

--- a/src/dnadesign/ops/tests/test_runbook_orchestrator.py
+++ b/src/dnadesign/ops/tests/test_runbook_orchestrator.py
@@ -1629,6 +1629,30 @@ def test_explicit_job_ids_do_not_mask_incomplete_active_job_discovery(
     assert resolution.runtime_visibility == partial_resolution.runtime_visibility
 
 
+def test_explicit_job_ids_do_not_mask_disabled_active_job_discovery(tmp_path: Path) -> None:
+    runbook_path = _write_runbook(tmp_path)
+    runbook = load_orchestration_runbook(runbook_path)
+
+    resolution = orchestrator_state.resolve_active_job_resolution(
+        runbook=runbook,
+        explicit_job_ids=("81002", "81001"),
+        discover_active_jobs=False,
+    )
+
+    assert resolution.explicit_job_ids == ("81002", "81001")
+    assert resolution.discovered_job_ids == ()
+    assert resolution.effective_job_ids == ("81002", "81001")
+    assert resolution.runtime_visibility.scheduler_probe_state == orchestrator_state.SchedulerProbeState.SKIPPED
+    assert (
+        resolution.runtime_visibility.active_job_resolution_state == orchestrator_state.ActiveJobResolutionState.UNKNOWN
+    )
+    assert resolution.runtime_visibility.degraded is True
+    assert resolution.runtime_visibility.degraded_reasons == (
+        "active-job discovery skipped while mode_policy.on_active_job=hold_jid; "
+        "manual job ids do not prove complete queue visibility",
+    )
+
+
 def test_batch_plan_submit_commands_include_explicit_job_identity_tags(tmp_path: Path) -> None:
     runbook_path = _write_runbook(tmp_path)
     runbook = load_orchestration_runbook(runbook_path)
@@ -3857,6 +3881,42 @@ def test_cli_execute_blocks_submit_when_active_job_visibility_is_unknown(
     assert execute_called is False
 
 
+def test_cli_execute_blocks_manual_job_ids_when_discovery_is_disabled_without_override(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    runbook_path = _write_runbook(tmp_path)
+    audit_path = tmp_path / "workspace" / "outputs" / "logs" / "ops" / "audit" / "result.json"
+    execute_called = False
+
+    def _fake_execute_batch_plan(*, plan, audit_json_path, submit, command_timeout_seconds):
+        nonlocal execute_called
+        execute_called = True
+        raise AssertionError("execute_batch_plan should not be called when active-job visibility is unknown")
+
+    monkeypatch.setattr("dnadesign.ops.api.execute_batch_plan", _fake_execute_batch_plan)
+    runner = CliRunner()
+
+    result = runner.invoke(
+        app,
+        [
+            "runbook",
+            "execute",
+            "--runbook",
+            str(runbook_path),
+            "--audit-json",
+            str(audit_path),
+            "--submit",
+            "--no-discover-active-jobs",
+            "--active-job-id",
+            "81001",
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert "active-job visibility is unavailable" in result.output
+    assert execute_called is False
+
+
 def test_cli_execute_blocks_submit_when_current_host_is_not_submit_host(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -4500,7 +4560,7 @@ def test_cli_plan_chains_all_discovered_active_job_ids(tmp_path: Path, monkeypat
     assert payload["hold_jid"] == "93331,93332"
 
 
-def test_cli_plan_accepts_comma_delimited_active_job_ids(tmp_path: Path) -> None:
+def test_cli_plan_blocks_manual_job_ids_when_discovery_is_disabled_without_override(tmp_path: Path) -> None:
     runbook_path = _write_runbook(tmp_path)
     runner = CliRunner()
 
@@ -4521,8 +4581,38 @@ def test_cli_plan_accepts_comma_delimited_active_job_ids(tmp_path: Path) -> None
 
     assert result.exit_code == 0
     payload = json.loads(result.output)
+    assert payload["submit_behavior"] == "blocked"
+    assert payload["hold_jid"] is None
+    assert payload["runtime_visibility"]["active_job_resolution_state"] == "unknown"
+    assert payload["runtime_visibility"]["degraded"] is True
+
+
+def test_cli_plan_accepts_manual_job_ids_with_disabled_discovery_override(tmp_path: Path) -> None:
+    runbook_path = _write_runbook(tmp_path)
+    runner = CliRunner()
+
+    result = runner.invoke(
+        app,
+        [
+            "runbook",
+            "plan",
+            "--runbook",
+            str(runbook_path),
+            "--no-discover-active-jobs",
+            "--active-job-id",
+            "93332,93331",
+            "--active-job-id",
+            "93332",
+            "--allow-unknown-active-jobs",
+        ],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
     assert payload["submit_behavior"] == "hold_jid"
     assert payload["hold_jid"] == "93331,93332"
+    assert payload["runtime_visibility"]["active_job_resolution_state"] == "unknown"
+    assert payload["allow_unknown_active_jobs"] is True
 
 
 def test_cli_active_jobs_emits_discovered_ids(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -4550,7 +4640,10 @@ def test_cli_active_jobs_emits_discovered_ids(tmp_path: Path, monkeypatch: pytes
     assert payload["active_job_count"] == 2
     assert payload["active_job_ids_csv"] == "95001,95002"
     assert payload["active_job_id_args"] == "--active-job-id 95001 --active-job-id 95002"
-    assert "--no-discover-active-jobs --active-job-id 95001 --active-job-id 95002" in payload["plan_command_hint"]
+    assert (
+        "--no-discover-active-jobs --active-job-id 95001 --active-job-id 95002 --allow-unknown-active-jobs"
+        in payload["plan_command_hint"]
+    )
 
 
 def test_packaged_runbook_presets_exist_and_load() -> None:


### PR DESCRIPTION
## What changed

- replace repeated broad catalog and status registry scans with one shared, safely pruned discovery primitive
- keep catalog and status ownership rules separate while preserving exact discovered file and registry ID parity
- cap active-job discovery by inspected jobs rather than matching jobs
- enforce a combined scheduler probe time budget and report degraded unknown visibility when discovery is incomplete

## Why

Catalog/status commands repeatedly traversed large repository trees, including generated areas that cannot own checked-in registry metadata. Active-job discovery also interpreted the job cap as a match cap, so a queue with no early match could trigger an unbounded sequence of ten-second detail probes and incorrectly end as no match.

## Operator impact

Catalog and status output is unchanged. Scheduler discovery now fails closed when its count or time budget prevents a complete queue inspection; operators receive explicit budget-exhausted, degraded, unknown visibility instead of a false no-match result.

## Validation

- full repository pytest suite
- full Ops test suite, including exact path/ID parity and adversarial probe-count/time-budget tests
- Ruff check and format check
- architecture boundary checks
- documentation checks across 504 Markdown files
- git diff check and commit-time pre-commit hooks
- nine-run interleaved benchmark: catalog discovery 41.2 ms to 17.2 ms; status discovery 103.7 ms to 42.3 ms; exact parity true
