### PR TITLE
Harden dependency floors and Torch loading

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -150,6 +150,9 @@ jobs:
       - name: Format check
         run: uv run ruff format --check .
 
+      - name: Dependency security contracts
+        run: uv run pytest -q src/dnadesign/devtools/tests/security/test_dependency_security_contract.py
+
       - name: Install FFmpeg
         if: >
           needs.detect-ci-scope.outputs.run-full-core == 'true' ||

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 **Type:** system-of-record
 **Owner:** dnadesign-maintainers
-**Last verified:** 2026-06-02
+**Last verified:** 2026-07-30
 
 ## At a glance
 This document records security expectations for code, data, secrets, and dependency handling in `dnadesign`.
@@ -25,7 +25,38 @@ It is a policy map with links to operator runbooks and implementation details.
 ## Dependency and supply-chain controls
 - Python dependencies are pinned via `uv.lock` and installed with `uv sync --locked`.
 - Pixi-managed external tools are pinned with `pixi.lock` and installed with `pixi install --locked`.
-- CI and local workflows should avoid unpinned installs for operational paths.
+- Direct runtime imports have explicit published dependency floors; repository-only
+  constraints are not treated as package metadata.
+- GitHub Actions and remote pre-commit hooks are pinned to immutable commits.
+- Pull requests that change dependency manifests run GitHub dependency review.
+- CI and local workflows must avoid unpinned installs for operational paths.
+
+### Bounded dependency exceptions
+
+Three upstream advisories across two constrained dependencies cannot yet be
+resolved without breaking an owning runtime constraint. They remain open,
+visible, and time-bounded:
+
+- `torch` is constrained to the Evo2-compatible 2.10 series.
+  GHSA-53q9-r3pm-6pq6 affects restricted `torch.load` deserialization before
+  2.6 and is fixed in the supported series. Every repository-owned
+  `torch.load` call still sets `weights_only=True`; loaders reject unsupported
+  globals instead of falling back to unrestricted pickle.
+  PYSEC-2026-139 affects PT2 loading through 2.10.0. PT2 artifacts and
+  `torch.export.load` are not supported serialization surfaces.
+  GHSA-rrmf-rvhw-rf47 affects `torch.jit.script` and is fixed in 2.13.
+  Repository-owned code does not call that function. Reassess when the
+  Evo2/CUDA stack supports PyTorch 2.13, and no later than 2026-10-29.
+- `pymdown-extensions` 10.21.3 is constrained by Marimo.
+  GHSA-9xwg-3r6f-jcx2 affects `pymdownx.b64`. Repository-owned code does not
+  enable that extension, and supported execution is native macOS or Linux.
+  Upstream Marimo can enable it under Pyodide/WASM, which is therefore outside
+  the supported deployment boundary while this exception is active. Reassess
+  when Marimo permits version 11, and no later than 2026-08-29.
+
+The unresolved exception statements narrow supported reachability; they do not
+claim that affected installed versions are patched. Do not dismiss the
+corresponding alerts.
 
 ## Data handling expectations
 - Treat dataset and run artifacts as operational data, not source-of-truth code.
@@ -33,6 +64,8 @@ It is a policy map with links to operator runbooks and implementation details.
 - Validate external sync/remote operations explicitly; do not assume side effects succeeded.
 
 ## Incident/reporting workflow
+- Report suspected vulnerabilities privately through GitHub security
+  advisories rather than a public issue.
 - If a secret is discovered in repo history or working tree, stop and notify maintainers immediately.
 - Rotate compromised tokens/webhooks first, then remediate repository history and runtime configs.
 - Capture corrective actions in maintainer notes (`docs/dev/journal.md`) and relevant runbooks.
@@ -46,6 +79,10 @@ It is a policy map with links to operator runbooks and implementation details.
   - `pre-commit run detect-secrets --all-files` scans the full tracked tree against baseline policy.
 - Core CI lane runs pre-commit checks on PR diff or full tree (`.github/workflows/ci.yaml`).
 - CI validates workflow definitions using `check-github-workflows` via pre-commit configuration.
+- CI checks that bounded exceptions remain inside the documented native
+  deployment boundary and that their review dates have not expired.
+- GitHub secret scanning, push protection, Dependabot, and CodeQL complement
+  the checked-in controls and must remain enabled in repository settings.
 
 ## References
 - Root agent map and safety rules: `AGENTS.md`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,18 +1,19 @@
 [build-system]
-requires = ["setuptools>=69", "wheel>=0.46.2", "setuptools_scm"]
+requires = ["setuptools>=83.0.0", "wheel>=0.46.2", "setuptools_scm"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name            = "dnadesign"
 version         = "0.1.0"
 description     = "DNA sequence design pipelines and bioinformatics helpers."
-authors         = [{ name = "Eric South", email = "ericjohnsouth@gmail.com" }]
+authors         = [{ name = "Eric South" }]
 readme          = "README.md"
 requires-python = ">=3.12,<3.13"
 
 dependencies = [
   "arviz>=0.23.0",
   "biopython>=1.87",
+  "click>=8.3.3",
   "igraph",
   "leidenalg",
   "logomaker",
@@ -21,6 +22,7 @@ dependencies = [
   "openpyxl",
   "ortools>=9.9,<9.10",
   "pandas",
+  "pillow>=12.3.0",
   "pyarrow>=23.0.1",
   "pydantic",
   "pygments>=2.20.0",
@@ -36,7 +38,7 @@ dependencies = [
   "umap-learn>=0.5.11",
   "duckdb>=0.10.0",
   "xlrd",
-  # Torch 2.10 is the current patched floor for active PyTorch advisories with fixed releases.
+  # Compatibility-pinned for the Evo2/CUDA stack; the bounded security exception is documented in SECURITY.md.
   "torch>=2.10,<2.11; (sys_platform == 'darwin' and platform_machine == 'arm64') or (sys_platform == 'linux' and platform_machine == 'x86_64')",
   "dense-arrays",
   "polars>=1.36.1",
@@ -51,7 +53,8 @@ dependencies = [
   "marimo>=0.23.9",
   "openai>=2.14.0",
   "viennarna>=2.7.2",
-  "zstd>=1.5",
+  # 1.5.7.3 is yanked for a thread-safety regression.
+  "zstd>=1.5.7.2,!=1.5.7.3",
   "py3dmol==2.5.5",
   "plotly>=6.9.0",
 ]
@@ -80,8 +83,8 @@ infer-evo2 = [
   "torchvision>=0.25,<0.26; sys_platform == 'linux' and platform_machine == 'x86_64'",
   "torchaudio>=2.10,<2.11; sys_platform == 'linux' and platform_machine == 'x86_64'",
   # --- build helpers (required because we disable build isolation for flash-attn + TE-torch)
-  "pip>=26.1; sys_platform == 'linux' and platform_machine == 'x86_64'",
-  "setuptools; sys_platform == 'linux' and platform_machine == 'x86_64'",
+  "pip>=26.1.2; sys_platform == 'linux' and platform_machine == 'x86_64'",
+  "setuptools>=83.0.0; sys_platform == 'linux' and platform_machine == 'x86_64'",
   "wheel>=0.46.2; sys_platform == 'linux' and platform_machine == 'x86_64'",
   "packaging; sys_platform == 'linux' and platform_machine == 'x86_64'",
   "ninja; sys_platform == 'linux' and platform_machine == 'x86_64'",
@@ -93,6 +96,7 @@ infer-evo2 = [
   # (TE is a prereq for Evo2; Evo2 requires TE>=2.0.0)
   "transformer-engine[pytorch]>=2.0,<3; sys_platform == 'linux' and platform_machine == 'x86_64'",
   "evo2>=0.5.3; sys_platform == 'linux' and platform_machine == 'x86_64'",
+  "onnx>=1.22.0; sys_platform == 'linux' and platform_machine == 'x86_64'",
   "transformers; sys_platform == 'linux' and platform_machine == 'x86_64'",
 ]
 
@@ -222,9 +226,10 @@ environments = [
 ]
 constraint-dependencies = [
   "cryptography>=48.0.1",
+  "click>=8.3.3",
   "idna>=3.15",
-  "onnx>=1.21.0",
-  "pillow>=12.2.0",
+  "onnx>=1.22.0",
+  "pillow>=12.3.0",
   "pymdown-extensions>=10.21.3",
   "starlette>=1.3.1",
 ]

--- a/src/dnadesign/billboard/core.py
+++ b/src/dnadesign/billboard/core.py
@@ -38,7 +38,7 @@ def load_pt_files(paths):
     logger.info(f"Loading .pt files: {paths}")
     seqs = []
     for p in paths:
-        data = torch.load(p, map_location="cpu", weights_only=False)
+        data = torch.load(p, map_location="cpu", weights_only=True)
         if not isinstance(data, list):
             raise ValueError(f"Expected list in {p}, got {type(data)}")
         seqs.extend(data)

--- a/src/dnadesign/cruncher/tests/cli/test_cli_help.py
+++ b/src/dnadesign/cruncher/tests/cli/test_cli_help.py
@@ -293,8 +293,10 @@ def test_fetch_motifs_requires_tf_or_motif_id() -> None:
 
 def test_fetch_motifs_rejects_campaign_option() -> None:
     result = invoke_cli(["fetch", "motifs", "--campaign", "demo_pair", str(CONFIG_PATH)])
-    assert result.exit_code != 0
-    assert "No such option: --campaign" in combined_output(result)
+    output = combined_output(result)
+    assert result.exit_code == 2
+    assert "No such option" in output
+    assert "--campaign" in output
 
 
 def test_global_config_option_resolves_workspace() -> None:

--- a/src/dnadesign/devtools/tests/ci/test_workflow_contract.py
+++ b/src/dnadesign/devtools/tests/ci/test_workflow_contract.py
@@ -89,6 +89,16 @@ def test_core_precommit_defers_detect_secrets_to_dedicated_lane() -> None:
     assert set(precommit_step["env"]["SKIP"].split(",")) == {"ruff-check", "ruff-format", "detect-secrets"}
 
 
+def test_core_lane_always_runs_dependency_security_contract() -> None:
+    workflow = _workflow()
+    steps = workflow["jobs"]["core-lint-test-build"]["steps"]
+    security_step = next(step for step in steps if step.get("name") == "Dependency security contracts")
+
+    assert security_step["run"] == (
+        "uv run pytest -q src/dnadesign/devtools/tests/security/test_dependency_security_contract.py"
+    )
+
+
 def test_scope_outputs_expose_core_external_integration_keys() -> None:
     workflow = _workflow()
     outputs = workflow["jobs"]["detect-ci-scope"]["outputs"]

--- a/src/dnadesign/devtools/tests/security/test_dependency_security_contract.py
+++ b/src/dnadesign/devtools/tests/security/test_dependency_security_contract.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+import ast
+import pickle
+import re
+import tomllib
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[5]
+
+
+def _pyproject() -> dict[str, object]:
+    with (_repo_root() / "pyproject.toml").open("rb") as handle:
+        return tomllib.load(handle)
+
+
+def test_security_floors_are_published_by_their_owning_dependency_sets() -> None:
+    project = _pyproject()["project"]
+    dependencies = tuple(project["dependencies"])
+    evo2_dependencies = tuple(project["optional-dependencies"]["infer-evo2"])
+    build_dependencies = tuple(_pyproject()["build-system"]["requires"])
+
+    assert "click>=8.3.3" in dependencies
+    assert "pillow>=12.3.0" in dependencies
+    assert "zstd>=1.5.7.2,!=1.5.7.3" in dependencies
+    assert any(requirement.startswith("onnx>=1.22.0;") for requirement in evo2_dependencies)
+    assert any(requirement.startswith("pip>=26.1.2;") for requirement in evo2_dependencies)
+    assert any(requirement.startswith("setuptools>=83.0.0;") for requirement in evo2_dependencies)
+    assert "setuptools>=83.0.0" in build_dependencies
+    assert all("email" not in author for author in project["authors"])
+
+
+def test_bounded_dependency_exceptions_stay_inside_native_execution() -> None:
+    repo_root = _repo_root()
+    forbidden = ("torch.jit." + "script", "pymdownx." + "b64")
+    violations: list[str] = []
+
+    for root in (repo_root / ".github", repo_root / "src"):
+        for path in root.rglob("*"):
+            if not path.is_file() or path.suffix not in {".json", ".py", ".toml", ".yaml", ".yml"}:
+                continue
+            text = path.read_text(encoding="utf-8")
+            for symbol in forbidden:
+                if symbol in text:
+                    violations.append(f"{path.relative_to(repo_root)}: {symbol}")
+
+    environments = tuple(_pyproject()["tool"]["uv"]["environments"])
+    assert environments == (
+        "sys_platform == 'darwin'",
+        "sys_platform == 'linux' and platform_machine == 'x86_64'",
+    )
+    assert violations == []
+
+
+def test_bounded_dependency_exception_review_dates_have_not_expired() -> None:
+    policy = (_repo_root() / "SECURITY.md").read_text(encoding="utf-8")
+    section = policy.split("### Bounded dependency exceptions", maxsplit=1)[1].split(
+        "## Data handling expectations", maxsplit=1
+    )[0]
+    entries = tuple(re.findall(r"(?ms)^- `.+?(?=^- `|\Z)", section))
+
+    assert len(entries) == 2
+    for entry in entries:
+        deadlines = re.findall(r"no later than (\d{4}-\d{2}-\d{2})", entry)
+        assert len(deadlines) == 1
+        assert date.today() <= date.fromisoformat(deadlines[0])
+
+
+def _torch_aliases(tree: ast.Module) -> tuple[dict[str, str], dict[str, str]]:
+    module_aliases = {"torch": "torch"}
+    direct_aliases: dict[str, str] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for imported in node.names:
+                if imported.name == "torch" or imported.name.startswith("torch."):
+                    bound_name = imported.asname or imported.name.split(".", maxsplit=1)[0]
+                    module_aliases[bound_name] = imported.name if imported.asname else "torch"
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            if node.module == "torch":
+                for imported in node.names:
+                    direct_aliases[imported.asname or imported.name] = f"torch.{imported.name}"
+            elif node.module in {"torch.export", "torch.jit"}:
+                for imported in node.names:
+                    direct_aliases[imported.asname or imported.name] = f"{node.module}.{imported.name}"
+
+    changed = True
+    while changed:
+        changed = False
+        for node in ast.walk(tree):
+            target: ast.expr | None = None
+            value: ast.expr | None = None
+            if isinstance(node, ast.Assign) and len(node.targets) == 1:
+                target, value = node.targets[0], node.value
+            elif isinstance(node, ast.AnnAssign):
+                target, value = node.target, node.value
+            if not isinstance(target, ast.Name) or value is None:
+                continue
+            resolved = _torch_expr_name(value, module_aliases=module_aliases, direct_aliases=direct_aliases)
+            if resolved is not None and direct_aliases.get(target.id) != resolved:
+                direct_aliases[target.id] = resolved
+                changed = True
+    return module_aliases, direct_aliases
+
+
+def _torch_expr_name(
+    expression: ast.expr,
+    *,
+    module_aliases: dict[str, str],
+    direct_aliases: dict[str, str],
+) -> str | None:
+    if isinstance(expression, ast.Name):
+        return direct_aliases.get(expression.id) or module_aliases.get(expression.id)
+    if isinstance(expression, ast.Call):
+        if (
+            isinstance(expression.func, ast.Name)
+            and expression.func.id == "getattr"
+            and len(expression.args) >= 2
+            and isinstance(expression.args[1], ast.Constant)
+            and isinstance(expression.args[1].value, str)
+        ):
+            owner = _torch_expr_name(
+                expression.args[0],
+                module_aliases=module_aliases,
+                direct_aliases=direct_aliases,
+            )
+            if owner is not None:
+                return f"{owner}.{expression.args[1].value}"
+        return None
+    if not isinstance(expression, ast.Attribute):
+        return None
+
+    parts: list[str] = []
+    current: ast.expr = expression
+    while isinstance(current, ast.Attribute):
+        parts.append(current.attr)
+        current = current.value
+    if not isinstance(current, ast.Name):
+        return None
+    module_prefix = module_aliases.get(current.id)
+    if module_prefix:
+        return ".".join((module_prefix, *reversed(parts)))
+    prefix = direct_aliases.get(current.id)
+    if prefix:
+        return ".".join((prefix, *reversed(parts)))
+    return None
+
+
+def _torch_boundary_violations(source: str, *, filename: str) -> list[str]:
+    tree = ast.parse(source, filename=filename)
+    module_aliases, direct_aliases = _torch_aliases(tree)
+    violations: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Constant) and isinstance(node.value, str) and ".pt2" in node.value.casefold():
+            violations.append(f"{filename}:{node.lineno}: unsupported PT2 artifact")
+        if not isinstance(node, ast.Call):
+            continue
+        call_name = _torch_expr_name(node.func, module_aliases=module_aliases, direct_aliases=direct_aliases)
+        if call_name == "torch.load":
+            keyword = next((item for item in node.keywords if item.arg == "weights_only"), None)
+            if keyword is None or not (isinstance(keyword.value, ast.Constant) and keyword.value.value is True):
+                violations.append(f"{filename}:{node.lineno}: torch.load must set weights_only=True")
+        elif call_name in {"torch." + "export.load", "torch." + "jit.script"}:
+            violations.append(f"{filename}:{node.lineno}: forbidden {call_name}")
+    return violations
+
+
+def test_torch_deserialization_and_execution_boundaries_fail_closed() -> None:
+    repo_root = _repo_root()
+    violations: list[str] = []
+    for path in (repo_root / "src" / "dnadesign").rglob("*.py"):
+        if "tests" in path.parts:
+            continue
+        violations.extend(
+            _torch_boundary_violations(
+                path.read_text(encoding="utf-8"),
+                filename=path.relative_to(repo_root).as_posix(),
+            )
+        )
+
+    assert violations == []
+
+
+@pytest.mark.parametrize(
+    "source",
+    (
+        "import torch\nloader = torch.load\nloader('unsafe.pt')\n",
+        "import torch\nloader = getattr(torch, 'load')\nloader('unsafe.pt')\n",
+        "import torch\ngetattr(torch, 'load')('unsafe.pt')\n",
+        "from torch import load as loader\nloader('unsafe.pt')\n",
+        "import torch\npath = 'model.pt2'\n",
+    ),
+)
+def test_torch_boundary_guard_rejects_indirect_or_pt2_surfaces(source: str) -> None:
+    assert _torch_boundary_violations(source, filename="fixture.py")
+
+
+def test_torch_boundary_guard_accepts_restricted_alias_load() -> None:
+    source = "import torch\nloader = torch.load\nloader('safe.pt', weights_only=True)\n"
+
+    assert _torch_boundary_violations(source, filename="fixture.py") == []
+
+
+class _UnsupportedCheckpointValue:
+    pass
+
+
+def test_restricted_torch_load_rejects_unsupported_globals(tmp_path: Path) -> None:
+    import torch
+
+    path = tmp_path / "unsupported.pt"
+    torch.save([{"sequence": "ACGT", "value": _UnsupportedCheckpointValue()}], path)
+
+    with pytest.raises((pickle.UnpicklingError, ValueError), match="Weights only load failed"):
+        torch.load(path, map_location="cpu", weights_only=True)
+
+
+def test_restricted_torch_load_preserves_plain_tensor_and_dict_payloads(tmp_path: Path) -> None:
+    import torch
+
+    path = tmp_path / "plain.pt"
+    payload = [{"sequence": "ACGT", "embedding": torch.tensor([1.0, 2.0])}]
+    torch.save(payload, path)
+
+    loaded = torch.load(path, map_location="cpu", weights_only=True)
+
+    assert loaded[0]["sequence"] == "ACGT"
+    assert loaded[0]["embedding"].tolist() == [1.0, 2.0]

--- a/src/dnadesign/devtools/tests/security/test_dependency_security_contract.py
+++ b/src/dnadesign/devtools/tests/security/test_dependency_security_contract.py
@@ -1,3 +1,14 @@
+"""
+--------------------------------------------------------------------------------
+dnadesign
+src/dnadesign/devtools/tests/security/test_dependency_security_contract.py
+
+Security contract tests for dependency floors and safe artifact loading.
+
+Module Author(s): Eric J. South
+--------------------------------------------------------------------------------
+"""
+
 from __future__ import annotations
 
 import ast

--- a/src/dnadesign/infer/src/ingest/sources.py
+++ b/src/dnadesign/infer/src/ingest/sources.py
@@ -61,7 +61,7 @@ def load_records_jsonl_input(path: str, field: str) -> Tuple[List[str], List[Dic
 
 
 def load_pt_file_input(path: str, field: str) -> Tuple[List[str], List[Dict]]:
-    data = torch.load(path, map_location="cpu")
+    data = torch.load(path, map_location="cpu", weights_only=True)
     if not isinstance(data, list) or not all(isinstance(x, dict) for x in data):
         raise ValidationError(".pt file must contain list[dict]")
     seqs = []

--- a/src/dnadesign/nmf/parser.py
+++ b/src/dnadesign/nmf/parser.py
@@ -53,7 +53,7 @@ def load_pt_file(pt_path: str) -> List[Dict]:
     Load a .pt file that contains a list of sequence dictionaries.
     """
     try:
-        data = torch.load(pt_path, map_location="cpu")
+        data = torch.load(pt_path, map_location="cpu", weights_only=True)
     except Exception as e:
         raise ValueError(f"Failed to load .pt file {pt_path}: {str(e)}")
     if not isinstance(data, list):

--- a/src/dnadesign/opal/tests/cli/test_cli_workflows.py
+++ b/src/dnadesign/opal/tests/cli/test_cli_workflows.py
@@ -95,8 +95,10 @@ def test_round_commands_reject_retired_option_aliases(
 
     result = CliRunner().invoke(_build(), ["--no-color", *args, "-c", str(campaign)])
 
+    output = _plain_output(result.output)
     assert result.exit_code == 2
-    assert f"No such option: {retired_flag}" in _plain_output(result.output)
+    assert "No such option" in output
+    assert retired_flag in output
 
 
 def test_init_validate_explain_cli(tmp_path: Path) -> None:

--- a/src/dnadesign/usr/scripts/archived_pytorch_manager.py
+++ b/src/dnadesign/usr/scripts/archived_pytorch_manager.py
@@ -27,7 +27,7 @@ def validate_pt_file(file_path: str) -> bool:
     """
     pt_path = Path(file_path)
     assert pt_path.exists() and pt_path.is_file(), f"PT file {pt_path} does not exist."
-    checkpoint = torch.load(pt_path, map_location=torch.device("cpu"))
+    checkpoint = torch.load(pt_path, map_location=torch.device("cpu"), weights_only=True)
     assert isinstance(checkpoint, list) and len(checkpoint) > 0, f"{pt_path} must be a non-empty list."
     for i, entry in enumerate(checkpoint):
         assert isinstance(entry, dict), f"Entry {i} in {pt_path} is not a dictionary."
@@ -40,7 +40,7 @@ def inspect_entry(file_path: str, index: int) -> dict:
     Loads a .pt file and returns the entry (a dictionary) at the given index.
     """
     pt_path = Path(file_path)
-    checkpoint = torch.load(pt_path, map_location=torch.device("cpu"))
+    checkpoint = torch.load(pt_path, map_location=torch.device("cpu"), weights_only=True)
     if not (0 <= index < len(checkpoint)):
         raise IndexError(f"Index {index} is out of range for file {pt_path} (length {len(checkpoint)}).")
     return checkpoint[index]
@@ -74,7 +74,7 @@ def update_meta_part_type(file_path: str) -> None:
     The file is then saved in-place.
     """
     pt_path = Path(file_path)
-    checkpoint = torch.load(pt_path, map_location=torch.device("cpu"))
+    checkpoint = torch.load(pt_path, map_location=torch.device("cpu"), weights_only=True)
     if not (isinstance(checkpoint, list) and len(checkpoint) > 0):
         print(f"File {pt_path} is not a valid .pt file format for meta update.")
         return

--- a/src/dnadesign/usr/src/legacy/inputs.py
+++ b/src/dnadesign/usr/src/legacy/inputs.py
@@ -99,7 +99,7 @@ def _count_tf(parts: Sequence[str]) -> Dict[str, int]:
 
 def _ensure_pt_list_of_dicts(p: Path) -> List[dict]:
     torch = _require_torch()
-    checkpoint = torch.load(str(p), map_location=torch.device("cpu"))
+    checkpoint = torch.load(str(p), map_location=torch.device("cpu"), weights_only=True)
     if not isinstance(checkpoint, list) or not checkpoint:
         raise SchemaError(f"{p} must be a non-empty list.")
     for i, entry in enumerate(checkpoint):

--- a/uv.lock
+++ b/uv.lock
@@ -12,10 +12,11 @@ supported-markers = [
 
 [manifest]
 constraints = [
+    { name = "click", specifier = ">=8.3.3" },
     { name = "cryptography", specifier = ">=48.0.1" },
     { name = "idna", specifier = ">=3.15" },
-    { name = "onnx", specifier = ">=1.21.0" },
-    { name = "pillow", specifier = ">=12.2.0" },
+    { name = "onnx", specifier = ">=1.22.0" },
+    { name = "pillow", specifier = ">=12.3.0" },
     { name = "pymdown-extensions", specifier = ">=10.21.3" },
     { name = "starlette", specifier = ">=1.3.1" },
 ]
@@ -221,11 +222,11 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.3.1"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
 ]
 
 [[package]]
@@ -407,6 +408,7 @@ dependencies = [
     { name = "arviz", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
     { name = "biopython", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
     { name = "certifi", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "click", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
     { name = "dense-arrays", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
     { name = "duckdb", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
     { name = "fastparquet", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
@@ -422,6 +424,7 @@ dependencies = [
     { name = "openpyxl", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
     { name = "ortools", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
     { name = "pandas", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
+    { name = "pillow", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
     { name = "plotly", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
     { name = "polars", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
     { name = "py3dmol", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
@@ -454,6 +457,7 @@ infer-evo2 = [
     { name = "evo2", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "flash-attn", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "ninja", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "onnx", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "packaging", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "pip", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "setuptools", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
@@ -489,6 +493,7 @@ requires-dist = [
     { name = "arviz", specifier = ">=0.23.0" },
     { name = "biopython", specifier = ">=1.87" },
     { name = "certifi", specifier = ">=2025.11.12" },
+    { name = "click", specifier = ">=8.3.3" },
     { name = "cmake", marker = "platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'infer-evo2'", specifier = ">=3.18" },
     { name = "dense-arrays", git = "https://github.com/e-south/dense-arrays" },
     { name = "duckdb", specifier = ">=0.10.0" },
@@ -504,12 +509,14 @@ requires-dist = [
     { name = "netcdf4", specifier = ">=1.7.3" },
     { name = "ninja", marker = "platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'infer-evo2'" },
     { name = "numpy" },
+    { name = "onnx", marker = "platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'infer-evo2'", specifier = ">=1.22.0" },
     { name = "openai", specifier = ">=2.14.0" },
     { name = "openpyxl" },
     { name = "ortools", specifier = ">=9.9,<9.10" },
     { name = "packaging", marker = "platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'infer-evo2'" },
     { name = "pandas" },
-    { name = "pip", marker = "platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'infer-evo2'", specifier = ">=26.1" },
+    { name = "pillow", specifier = ">=12.3.0" },
+    { name = "pip", marker = "platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'infer-evo2'", specifier = ">=26.1.2" },
     { name = "plotly", specifier = ">=6.9.0" },
     { name = "polars", specifier = ">=1.36.1" },
     { name = "py3dmol", specifier = "==2.5.5" },
@@ -524,7 +531,7 @@ requires-dist = [
     { name = "scanpy", specifier = "==1.10.3" },
     { name = "scipy", specifier = ">=1.17.0" },
     { name = "seaborn" },
-    { name = "setuptools", marker = "platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'infer-evo2'" },
+    { name = "setuptools", marker = "platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'infer-evo2'", specifier = ">=83.0.0" },
     { name = "torch", marker = "(platform_machine == 'arm64' and sys_platform == 'darwin') or (platform_machine == 'x86_64' and sys_platform == 'linux')", specifier = ">=2.10,<2.11" },
     { name = "torch", marker = "platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'infer-evo2'", specifier = ">=2.10,<2.11", index = "https://download.pytorch.org/whl/cu128", conflict = { package = "dnadesign", extra = "infer-evo2" } },
     { name = "torchaudio", marker = "platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'infer-evo2'", specifier = ">=2.10,<2.11", index = "https://download.pytorch.org/whl/cu128", conflict = { package = "dnadesign", extra = "infer-evo2" } },
@@ -539,7 +546,7 @@ requires-dist = [
     { name = "vl-convert-python", specifier = ">=1.9.0" },
     { name = "wheel", marker = "platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'infer-evo2'", specifier = ">=0.46.2" },
     { name = "xlrd" },
-    { name = "zstd", specifier = ">=1.5" },
+    { name = "zstd", specifier = ">=1.5.7.2,!=1.5.7.3" },
 ]
 provides-extras = ["infer-evo2"]
 
@@ -1551,7 +1558,7 @@ wheels = [
 
 [[package]]
 name = "onnx"
-version = "1.21.0"
+version = "1.22.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ml-dtypes", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
@@ -1559,9 +1566,10 @@ dependencies = [
     { name = "protobuf", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "typing-extensions", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c5/93/942d2a0f6a70538eea042ce0445c8aefd46559ad153469986f29a743c01c/onnx-1.21.0.tar.gz", hash = "sha256:4d8b67d0aaec5864c87633188b91cc520877477ec0254eda122bef8be43cd764", size = 12074608, upload-time = "2026-03-27T21:33:36.118Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/19/8ea73a64b368b75fe339771a20a02bc61ea1f551484c9e3d9d0bfbd0450f/onnx-1.22.0.tar.gz", hash = "sha256:ef40c0aaf0b643857ea9306fc7eddce17eaf9fb0407e4801f1fc5758443a38e0", size = 12024721, upload-time = "2026-06-15T12:50:05.354Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a7/00/4823f06357892d1e60d6f34e7299d2ba4ed2108c487cc394f7ce85a3ff14/onnx-1.21.0-cp312-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a9261bd580fb8548c9c37b3c6750387eb8f21ea43c63880d37b2c622e1684285", size = 17613697, upload-time = "2026-03-27T21:32:54.222Z" },
+    { url = "https://files.pythonhosted.org/packages/09/a6/bd32357e6cc1ecb473afd78193d7231724f284435d2db25696ecfaaa1503/onnx-1.22.0-cp312-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:955e02e1f6d385b53d52f9cd7b9cdf5caf417c300bcfe3c64c6d542be763845b", size = 19106514, upload-time = "2026-06-15T12:49:37.424Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/9d/3af461ac6c714b8b369cb71499659932f4f12cfb066250b62f7567c3d530/onnx-1.22.0-cp312-abi3-pyemscripten_2025_0_wasm32.whl", hash = "sha256:82e9f27fc1223cb06d68a56bed6f9d3caf3d0dad1b61bce45006d529b15bd94c", size = 16966387, upload-time = "2026-06-15T12:49:40.918Z" },
 ]
 
 [[package]]
@@ -1692,24 +1700,23 @@ wheels = [
 
 [[package]]
 name = "pillow"
-version = "12.2.0"
+version = "12.3.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8c/21/c2bcdd5906101a30244eaffc1b6e6ce71a31bd0742a01eb89e660ebfac2d/pillow-12.2.0.tar.gz", hash = "sha256:a830b1a40919539d07806aa58e1b114df53ddd43213d9c8b75847eee6c0182b5", size = 46987819, upload-time = "2026-04-01T14:46:17.687Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1c/3d/bb7fca845737cf9d7dbde16ed1843984665ff2e0a518f5db43e77ec540b9/pillow-12.3.0.tar.gz", hash = "sha256:3b8182a766685eaa002637e28b4ec8d6b18819a0c71f579bf0dbaa5830297cce", size = 47025035, upload-time = "2026-07-01T11:56:38.965Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/58/be/7482c8a5ebebbc6470b3eb791812fff7d5e0216c2be3827b30b8bb6603ed/pillow-12.2.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2d192a155bbcec180f8564f693e6fd9bccff5a7af9b32e2e4bf8c9c69dbad6b5", size = 5308279, upload-time = "2026-04-01T14:43:13.246Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/95/0a351b9289c2b5cbde0bacd4a83ebc44023e835490a727b2a3bd60ddc0f4/pillow-12.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f3f40b3c5a968281fd507d519e444c35f0ff171237f4fdde090dd60699458421", size = 4695490, upload-time = "2026-04-01T14:43:15.584Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/9e/c05e19657fd57841e476be1ab46c4d501bffbadbafdc31a6d665f8b737b6/pillow-12.2.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b86024e52a1b269467a802258c25521e6d742349d760728092e1bc2d135b4d76", size = 8094744, upload-time = "2026-04-01T14:43:20.716Z" },
-    { url = "https://files.pythonhosted.org/packages/43/e3/fdc657359e919462369869f1c9f0e973f353f9a9ee295a39b1fea8ee1a77/pillow-12.2.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:62f5409336adb0663b7caa0da5c7d9e7bdbaae9ce761d34669420c2a801b2780", size = 7087215, upload-time = "2026-04-01T14:43:26.758Z" },
-    { url = "https://files.pythonhosted.org/packages/67/f9/029a27095ad20f854f9dba026b3ea6428548316e057e6fc3545409e86651/pillow-12.2.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fc3d34d4a8fbec3e88a79b92e5465e0f9b842b628675850d860b8bd300b159f5", size = 7212112, upload-time = "2026-04-01T14:43:32.091Z" },
+    { url = "https://files.pythonhosted.org/packages/37/bf/fb3ebff8ddcb76aac5a01389251bbbb9519922a9b520d8247c1ca864a25d/pillow-12.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ba09209fbe443b4acccebe845d8a138b89a8f4fbaeedd44953490b5315d5e965", size = 5345969, upload-time = "2026-07-01T11:54:06.397Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/66/9a386a92561f402389a4fc70c18838bf6d35eb5eb5c6850b4b2dc64f5048/pillow-12.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ffd0c5368496f41b0944be820fcb7a838aa6e623d250b01acf2643939c3f99d7", size = 4780323, upload-time = "2026-07-01T11:54:09.351Z" },
+    { url = "https://files.pythonhosted.org/packages/84/21/a35af28dcc61f37ed850a2d64c65c701321dfbf25085e469d5559360cbbf/pillow-12.3.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:78cb2c6865a35ab8ff8b75fd122f6033b92a62c82801110e48ddd6c936a45d91", size = 6940830, upload-time = "2026-07-01T11:54:13.732Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/72/cf78ac9780bb93c28328f408973845a309d4d145041665f734572ced1b52/pillow-12.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:0dd2064cbc55aaec028ef5fbb60fa47bb6c3e7918e07ff17935284b227a9d2df", size = 7052934, upload-time = "2026-07-01T11:54:17.721Z" },
 ]
 
 [[package]]
 name = "pip"
-version = "26.1"
+version = "26.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/73/7e/d2b04004e1068ad4fdfa2f227b839b5d03e602e47cdbbf49de71137c9546/pip-26.1.tar.gz", hash = "sha256:81e13ebcca3ffa8cc85e4deff5c27e1ee26dea0aa7fc2f294a073ac208806ff3", size = 1840316, upload-time = "2026-04-26T21:00:05.406Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/96/e6f8e9d9d7b9cc4457092712a7e919c3186aa2c2fa9ffed2c5d29cc947e8/pip-26.2.tar.gz", hash = "sha256:2d8542afcc84cdd8e846c2b36b2861fad1da376dd98f8e7113e9108a3c331690", size = 1848845, upload-time = "2026-07-29T21:57:56.407Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/70/7a/be4bd8bcbb24ea475856dd68159d78b03b2bb53dae369f69c9606b8888f5/pip-26.1-py3-none-any.whl", hash = "sha256:4e8486d821d814b77319acb7b9e8bf5a4ee7590a643e7cb21029f209be8573c1", size = 1812804, upload-time = "2026-04-26T21:00:03.194Z" },
+    { url = "https://files.pythonhosted.org/packages/62/36/a3aed958d60531cb442b7ab4596cda7b3621cfb916f8ae1d6769795c7dc1/pip-26.2-py3-none-any.whl", hash = "sha256:931c303696af6fa3417112103b1cad26890e5a07eccb5b99783700e33f2b8aad", size = 1816475, upload-time = "2026-07-29T21:57:54.763Z" },
 ]
 
 [[package]]
@@ -2278,11 +2285,11 @@ wheels = [
 
 [[package]]
 name = "setuptools"
-version = "80.10.1"
+version = "83.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/86/ff/f75651350db3cf2ef767371307eb163f3cc1ac03e16fdf3ac347607f7edb/setuptools-80.10.1.tar.gz", hash = "sha256:bf2e513eb8144c3298a3bd28ab1a5edb739131ec5c22e045ff93cd7f5319703a", size = 1229650, upload-time = "2026-01-21T09:42:03.061Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/26/f5d29e25ffdb535afef2d35cdb55b325298f96debd670da4c325e08d70f4/setuptools-83.0.0.tar.gz", hash = "sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef", size = 1154254, upload-time = "2026-07-04T15:31:22.699Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/76/f963c61683a39084aa575f98089253e1e852a4417cb8a3a8a422923a5246/setuptools-80.10.1-py3-none-any.whl", hash = "sha256:fc30c51cbcb8199a219c12cc9c281b5925a4978d212f84229c909636d9f6984e", size = 1099859, upload-time = "2026-01-21T09:42:00.688Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/40/e1e72872c6354b306daef1703549e8e83b4d43cfea356311bf722a043752/setuptools-83.0.0-py3-none-any.whl", hash = "sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3", size = 1008090, upload-time = "2026-07-04T15:31:20.885Z" },
 ]
 
 [[package]]
@@ -2812,13 +2819,11 @@ wheels = [
 
 [[package]]
 name = "zstd"
-version = "1.5.7.3"
+version = "1.5.7.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/49/62/b9c075ad664e7c4cbb3d8d2be7c246506abe1bc7f778eb58d260ef9538c8/zstd-1.5.7.3.tar.gz", hash = "sha256:403e5205f4ac04b92e6b0cda654be2f51de268228a0db0067bc087faacf2f495", size = 672559, upload-time = "2026-01-08T16:24:43.361Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/78/9a476e09c825304df47b98be80d1ffe223733b03550af71325415028f615/zstd-1.5.7.2.tar.gz", hash = "sha256:6d8684c69009be49e1b18ec251a5eb0d7e24f93624990a8a124a1da66a92fc8a", size = 670481, upload-time = "2025-06-23T12:36:08.131Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/aa/ed/5a3bf2e29dc56d4cc7619929bb51f0c758de6d02967cc73c5d8755a862c0/zstd-1.5.7.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:01a39efb0eeab7cc45cb308618233b624b0840d5e16dcf85456b6cca0592f203", size = 268124, upload-time = "2026-01-08T16:29:57.091Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/1d/efc2074ac90af938e78f2ed4004639fe24f294d9086c5280f8d9a02b9897/zstd-1.5.7.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7a8e8838cf35fa3987bfe1958584cc22e1797efce8e155a63544b4144fc671f8", size = 230988, upload-time = "2026-01-08T16:29:55.604Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/7a/8dcd86a2efb2ed3f9dae39545a05d3c7ed26c7678330786ce4a44cd8b099/zstd-1.5.7.3-cp312-cp312-manylinux_2_14_x86_64.whl", hash = "sha256:143f9062953fb5590cbd47c1040d357336742c79696bf90b6d5b835279a68304", size = 304154, upload-time = "2026-01-10T11:17:40.91Z" },
-    { url = "https://files.pythonhosted.org/packages/11/c4/db4807d6a68b4628c74fd379de7e3c67ec34f19a2a80ac246b3837cde6cb/zstd-1.5.7.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f1538db419afa62773cf534fc7f3009ff59ecf55ecee4e889587ac2ef0010ed8", size = 2201732, upload-time = "2026-01-08T18:02:20.835Z" },
-    { url = "https://files.pythonhosted.org/packages/23/fd/02eac30419475dbe50212c119043a2d0698a0cbc756da85fd3fd9abddf42/zstd-1.5.7.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:39b3438e64637d80a5b1860526903b92020acb9bae9ceb5adffd9838c1441328", size = 2125442, upload-time = "2026-01-08T18:02:17.715Z" },
+    { url = "https://files.pythonhosted.org/packages/45/14/096bb77f3e5ef525b452cd6294da33de7f8a8c9647ba78293378fbb0a7ce/zstd-1.5.7.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d2ebe3e60dbace52525fa7aa604479e231dc3e4fcc76d0b4c54d8abce5e58734", size = 269408, upload-time = "2025-06-23T13:11:46.492Z" },
+    { url = "https://files.pythonhosted.org/packages/08/b8/2bc2590a34c733ea0570f366e6ad7d889d05c7825bd3ccab01f36ece71c6/zstd-1.5.7.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ef201b6f7d3a6751d85cc52f9e6198d4d870e83d490172016b64a6dd654a9583", size = 228188, upload-time = "2025-06-23T13:11:47.539Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/80/6252de3a70cfd7767718ad476893f1c7dc129f942cc7ed0322e3137c03d9/zstd-1.5.7.2-cp312-cp312-manylinux_2_14_x86_64.whl", hash = "sha256:ac7bdfedda51b1fcdcf0ab69267d01256fc97ddf666ce894fde0fae9f3630eac", size = 302720, upload-time = "2025-06-23T12:40:11.522Z" },
 ]


### PR DESCRIPTION
## Outcome

This raises vulnerable direct dependency floors, makes package metadata portable, and closes repository-owned unrestricted PyTorch deserialization paths.

## Changes

- publish direct floors for Click, Pillow, ONNX, pip, and setuptools
- exclude the yanked zstd 1.5.7.3 release without permanently pinning future fixed releases
- remove the personal author email from package metadata while preserving attribution
- require `weights_only=True` at every repository-owned `torch.load` call
- reject unsupported globals, PT2/`torch.export.load`, and `torch.jit.script` surfaces
- run the dependency security contract on every core CI invocation, including tool-scoped PRs
- document the three remaining, bounded upstream advisories and their review deadlines

## Evidence

- 30 security and workflow contract tests passed
- architecture boundaries passed
- documentation checks passed across 504 Markdown files
- Ruff, formatting, lock, workflow validation, and diff checks passed
- wheel and sdist built; Twine checks passed
- exported-lock audit now reports exactly the three documented upstream issues:
  - PyTorch PT2 loading (`PYSEC-2026-139`)
  - PyTorch `torch.jit.script` (`PYSEC-2025-194` / `GHSA-rrmf-rvhw-rf47`)
  - PyMdown `b64` (`GHSA-9xwg-3r6f-jcx2`)

The supported runtime does not expose those affected surfaces. The policy does not dismiss or claim to patch the upstream advisories.
