### PR TITLE
Fix PyMdown Extensions path traversal alert

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 **Type:** system-of-record
 **Owner:** dnadesign-maintainers
-**Last verified:** 2026-07-30
+**Last verified:** 2026-08-01
 
 ## At a glance
 This document records security expectations for code, data, secrets, and dependency handling in `dnadesign`.
@@ -33,8 +33,8 @@ It is a policy map with links to operator runbooks and implementation details.
 
 ### Bounded dependency exceptions
 
-Three upstream advisories across two constrained dependencies cannot yet be
-resolved without breaking an owning runtime constraint. They remain open,
+Two upstream advisories on one constrained dependency cannot yet be resolved
+without migrating and revalidating the owning GPU runtime. They remain open,
 visible, and time-bounded:
 
 - `torch` is constrained to the Evo2-compatible 2.10 series.
@@ -45,14 +45,11 @@ visible, and time-bounded:
   PYSEC-2026-139 affects PT2 loading through 2.10.0. PT2 artifacts and
   `torch.export.load` are not supported serialization surfaces.
   GHSA-rrmf-rvhw-rf47 affects `torch.jit.script` and is fixed in 2.13.
-  Repository-owned code does not call that function. Reassess when the
-  Evo2/CUDA stack supports PyTorch 2.13, and no later than 2026-10-29.
-- `pymdown-extensions` 10.21.3 is constrained by Marimo.
-  GHSA-9xwg-3r6f-jcx2 affects `pymdownx.b64`. Repository-owned code does not
-  enable that extension, and supported execution is native macOS or Linux.
-  Upstream Marimo can enable it under Pyodide/WASM, which is therefore outside
-  the supported deployment boundary while this exception is active. Reassess
-  when Marimo permits version 11, and no later than 2026-08-29.
+  Repository-owned code does not call that function. PyTorch 2.13 is
+  available, but adopting it requires a coupled migration from Torch 2.10,
+  torchvision 0.25, torchaudio 2.10, and the CUDA 12.8 wheel index, which does
+  not publish 2.13 wheels. Revalidate that GPU stack rather than changing
+  Torch alone, and reassess no later than 2026-10-29.
 
 The unresolved exception statements narrow supported reachability; they do not
 claim that affected installed versions are patched. Do not dismiss the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
   "certifi>=2025.11.12",
   "keyring>=25.6.0",
   "fastparquet>=2025.12.0",
-  "marimo>=0.23.9",
+  "marimo>=0.23.16",
   "openai>=2.14.0",
   "viennarna>=2.7.2",
   # 1.5.7.3 is yanked for a thread-safety regression.
@@ -230,7 +230,7 @@ constraint-dependencies = [
   "idna>=3.15",
   "onnx>=1.22.0",
   "pillow>=12.3.0",
-  "pymdown-extensions>=10.21.3",
+  "pymdown-extensions>=11.0.1",
   "starlette>=1.3.1",
 ]
 

--- a/src/dnadesign/devtools/tests/security/test_dependency_security_contract.py
+++ b/src/dnadesign/devtools/tests/security/test_dependency_security_contract.py
@@ -35,10 +35,13 @@ def test_security_floors_are_published_by_their_owning_dependency_sets() -> None
     dependencies = tuple(project["dependencies"])
     evo2_dependencies = tuple(project["optional-dependencies"]["infer-evo2"])
     build_dependencies = tuple(_pyproject()["build-system"]["requires"])
+    constraint_dependencies = tuple(_pyproject()["tool"]["uv"]["constraint-dependencies"])
 
     assert "click>=8.3.3" in dependencies
+    assert "marimo>=0.23.16" in dependencies
     assert "pillow>=12.3.0" in dependencies
     assert "zstd>=1.5.7.2,!=1.5.7.3" in dependencies
+    assert "pymdown-extensions>=11.0.1" in constraint_dependencies
     assert any(requirement.startswith("onnx>=1.22.0;") for requirement in evo2_dependencies)
     assert any(requirement.startswith("pip>=26.1.2;") for requirement in evo2_dependencies)
     assert any(requirement.startswith("setuptools>=83.0.0;") for requirement in evo2_dependencies)
@@ -46,9 +49,9 @@ def test_security_floors_are_published_by_their_owning_dependency_sets() -> None
     assert all("email" not in author for author in project["authors"])
 
 
-def test_bounded_dependency_exceptions_stay_inside_native_execution() -> None:
+def test_bounded_dependency_exception_does_not_enter_supported_code() -> None:
     repo_root = _repo_root()
-    forbidden = ("torch.jit." + "script", "pymdownx." + "b64")
+    forbidden = ("torch.jit." + "script",)
     violations: list[str] = []
 
     for root in (repo_root / ".github", repo_root / "src"):
@@ -60,11 +63,6 @@ def test_bounded_dependency_exceptions_stay_inside_native_execution() -> None:
                 if symbol in text:
                     violations.append(f"{path.relative_to(repo_root)}: {symbol}")
 
-    environments = tuple(_pyproject()["tool"]["uv"]["environments"])
-    assert environments == (
-        "sys_platform == 'darwin'",
-        "sys_platform == 'linux' and platform_machine == 'x86_64'",
-    )
     assert violations == []
 
 
@@ -75,7 +73,7 @@ def test_bounded_dependency_exception_review_dates_have_not_expired() -> None:
     )[0]
     entries = tuple(re.findall(r"(?ms)^- `.+?(?=^- `|\Z)", section))
 
-    assert len(entries) == 2
+    assert len(entries) == 1
     for entry in entries:
         deadlines = re.findall(r"no later than (\d{4}-\d{2}-\d{2})", entry)
         assert len(deadlines) == 1

--- a/uv.lock
+++ b/uv.lock
@@ -17,7 +17,7 @@ constraints = [
     { name = "idna", specifier = ">=3.15" },
     { name = "onnx", specifier = ">=1.22.0" },
     { name = "pillow", specifier = ">=12.3.0" },
-    { name = "pymdown-extensions", specifier = ">=10.21.3" },
+    { name = "pymdown-extensions", specifier = ">=11.0.1" },
     { name = "starlette", specifier = ">=1.3.1" },
 ]
 
@@ -504,7 +504,7 @@ requires-dist = [
     { name = "keyring", specifier = ">=25.6.0" },
     { name = "leidenalg" },
     { name = "logomaker" },
-    { name = "marimo", specifier = ">=0.23.9" },
+    { name = "marimo", specifier = ">=0.23.16" },
     { name = "matplotlib" },
     { name = "netcdf4", specifier = ">=1.7.3" },
     { name = "ninja", marker = "platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'infer-evo2'" },
@@ -1146,7 +1146,7 @@ wheels = [
 
 [[package]]
 name = "marimo"
-version = "0.23.11"
+version = "0.23.16"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
@@ -1169,9 +1169,9 @@ dependencies = [
     { name = "uvicorn", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
     { name = "websockets", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/56/e4b50516ae5ab7e6e14aae81e04cc49c36a97cdd01c2c213019dc84cd538/marimo-0.23.11.tar.gz", hash = "sha256:f32fc3095aa1e46d3b9cf9f67729b3e121eb91bffffb75f380e1449d83288878", size = 38616146, upload-time = "2026-06-25T20:04:37.585Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/83/c0/b6b7101dc9d3760c51d67714d4547047cb2c29c11f26691bed6a64d8a995/marimo-0.23.16.tar.gz", hash = "sha256:378c892f0e1bc3985bc0b5b61109078e09fc767438b95234bfec9faa45858c98", size = 38789959, upload-time = "2026-07-31T20:04:47.92Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/96/fd/e4468116b197585d800c57e0da16678b087f870d4746772acc4a3f7eb373/marimo-0.23.11-py3-none-any.whl", hash = "sha256:69dbf51993988fb854b513da768b1a64cbc36750610b93569b4c1d10fe7e5c2a", size = 39057161, upload-time = "2026-06-25T20:04:34.51Z" },
+    { url = "https://files.pythonhosted.org/packages/69/7a/db0583b21d1f03403fc26800cb4638f59e95a33efd333f7a4d45ac348b82/marimo-0.23.16-py3-none-any.whl", hash = "sha256:e0bba0a44b395d402072c65d686fb459bd8955c9ab8b0d6135a22f729c989373", size = 39241287, upload-time = "2026-07-31T20:04:43.678Z" },
 ]
 
 [[package]]
@@ -1913,15 +1913,15 @@ wheels = [
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.21.3"
+version = "11.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
     { name = "pyyaml", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux') or sys_platform == 'darwin'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9e/26/d1015444da4d952a1ca487a236b522eb979766f0295a0bd0c5fc089989a9/pymdown_extensions-10.21.3.tar.gz", hash = "sha256:72cfcf55f07aea0d4af2c4f11dd4e52466ddfb1bb819673146398e0bd3a77354", size = 854140, upload-time = "2026-05-13T12:57:32.267Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/a9/5f0c535ba3b08fe09270c16808e053a968868242ecbd5676d4e3a488bf28/pymdown_extensions-11.0.1.tar.gz", hash = "sha256:dd2905ae6fc5b75582fafb139a1266ffc754705efa902aa50067fa7ff4f94ec0", size = 857113, upload-time = "2026-07-02T17:59:22.955Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/85/545a951eecc270fcd688288c600017e2050a1aacb56c711d208586d3e470/pymdown_extensions-10.21.3-py3-none-any.whl", hash = "sha256:d7a5d08014fc571e80ca21dd6f854e31f94c489800350564d55d15b3c41e76b6", size = 269002, upload-time = "2026-05-13T12:57:30.296Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/54/da572c98c0b77626a91b5d3b89f0231d8bff5125c225420908632f8b342d/pymdown_extensions-11.0.1-py3-none-any.whl", hash = "sha256:db3943a62bab7e03af1364f0c4083e64b91fb097675a4b6cceccfbe9a77e5eb2", size = 269455, upload-time = "2026-07-02T17:59:21.271Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- raise Marimo to 0.23.16, the first compatible release permitting PyMdown Extensions 11
- constrain and lock PyMdown Extensions 11.0.1
- retire the resolved PyMdown exception and keep the Torch exception explicit
- enforce the new floors in the dependency security contract

## Why

PyMdown Extensions 10.21.3 is affected by GHSA-9xwg-3r6f-jcx2. Marimo 0.23.16 now permits the patched major release, so the prior bounded exception is no longer necessary.

PyTorch 2.13 is available, but it is not a one-package update for this repository: the validated optional GPU group remains coupled to Torch 2.10, torchvision 0.25, torchaudio 2.10, and the CUDA 12.8 wheel index. This PR does not hide or dismiss those alerts.

## Validation

- 237 notebook-generation and notebook-surface tests
- 17 security and package-layout tests
- docs checks across 504 Markdown files
- uv lock check
- architecture boundaries
- Ruff lint and format
- pre-commit full-tree checks
- git diff check