### PR TITLE
Unify documentation banners and simplify the tool map

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,43 +24,43 @@ Use the docs index to choose a workflow, inspect existing work, or jump to a too
 Pick the tool that matches the work you need to do. Each link opens the tool
 README for commands, inputs, and outputs.
 
-### Workspace and analysis tools
+### Design, modeling, and analysis
 
-| Tool | Description | Coverage |
-| --- | --- | --- |
-| [**usr**](src/dnadesign/usr/README.md) | Store, inspect, validate, and sync tabular sequence records. | [![usr coverage](https://codecov.io/gh/e-south/dnadesign/graph/badge.svg?component=usr)](https://codecov.io/gh/e-south/dnadesign?component=usr) |
-| [**densegen**](src/dnadesign/densegen/README.md) | Generate DNA sequence libraries from declared design workspaces. | [![densegen coverage](https://codecov.io/gh/e-south/dnadesign/graph/badge.svg?component=densegen)](https://codecov.io/gh/e-south/dnadesign?component=densegen) |
-| [**infer**](src/dnadesign/infer/README.md) | Run sequence-model inference and write features back to datasets. | [![infer coverage](https://codecov.io/gh/e-south/dnadesign/graph/badge.svg?component=infer)](https://codecov.io/gh/e-south/dnadesign?component=infer) |
-| [**construct**](src/dnadesign/construct/README.md) | Build template-based constructs and declared sequence products. | [![construct coverage](https://codecov.io/gh/e-south/dnadesign/graph/badge.svg?component=construct)](https://codecov.io/gh/e-south/dnadesign?component=construct) |
-| [**opal**](src/dnadesign/opal/README.md) | Choose the next DNA designs from measured sequence results. | [![opal coverage](https://codecov.io/gh/e-south/dnadesign/graph/badge.svg?component=opal)](https://codecov.io/gh/e-south/dnadesign?component=opal) |
-| [**cluster**](src/dnadesign/cluster/README.md) | Group and visualize rows in numerical feature tables. | [![cluster coverage](https://codecov.io/gh/e-south/dnadesign/graph/badge.svg?component=cluster)](https://codecov.io/gh/e-south/dnadesign?component=cluster) |
-| [**latentdna**](src/dnadesign/latentdna/README.md) | Compare numerical sequence representations and publish review artifacts. | [![latentdna coverage](https://codecov.io/gh/e-south/dnadesign/graph/badge.svg?component=latentdna)](https://codecov.io/gh/e-south/dnadesign?component=latentdna) |
-| [**cruncher**](src/dnadesign/cruncher/README.md) | Solve constrained DNA sequence and assembly design tasks. | [![cruncher coverage](https://codecov.io/gh/e-south/dnadesign/graph/badge.svg?component=cruncher)](https://codecov.io/gh/e-south/dnadesign?component=cruncher) |
-| [**billboard**](src/dnadesign/billboard/README.md) | Measure how varied sequence motifs are within a library. | [![billboard coverage](https://codecov.io/gh/e-south/dnadesign/graph/badge.svg?component=billboard)](https://codecov.io/gh/e-south/dnadesign?component=billboard) |
-| [**libshuffle**](src/dnadesign/libshuffle/README.md) | Select representative subsets from large sequence libraries. | [![libshuffle coverage](https://codecov.io/gh/e-south/dnadesign/graph/badge.svg?component=libshuffle)](https://codecov.io/gh/e-south/dnadesign?component=libshuffle) |
-| [**nmf**](src/dnadesign/nmf/README.md) | Find recurring motif combinations with non-negative matrix factorization. | [![nmf coverage](https://codecov.io/gh/e-south/dnadesign/graph/badge.svg?component=nmf)](https://codecov.io/gh/e-south/dnadesign?component=nmf) |
-| [**permuter**](src/dnadesign/permuter/README.md) | Generate sequence variants and evaluate them with declared scoring tools. | [![permuter coverage](https://codecov.io/gh/e-south/dnadesign/graph/badge.svg?component=permuter)](https://codecov.io/gh/e-south/dnadesign?component=permuter) |
-| [**tfkdanalysis**](src/dnadesign/tfkdanalysis/README.md) | Summarize measured responses after transcription-factor knockdown. | [![tfkdanalysis coverage](https://codecov.io/gh/e-south/dnadesign/graph/badge.svg?component=tfkdanalysis)](https://codecov.io/gh/e-south/dnadesign?component=tfkdanalysis) |
-| [**aligner**](src/dnadesign/aligner/README.md) | Score pairwise sequence alignments with Biopython. | [![aligner coverage](https://codecov.io/gh/e-south/dnadesign/graph/badge.svg?component=aligner)](https://codecov.io/gh/e-south/dnadesign?component=aligner) |
-| [**thread**](src/dnadesign/thread/README.md) | Prepare protein-design requests and check predicted structures. | [![thread coverage](https://codecov.io/gh/e-south/dnadesign/graph/badge.svg?component=thread)](https://codecov.io/gh/e-south/dnadesign?component=thread) |
+| Tool | Description |
+| --- | --- |
+| [**usr**](src/dnadesign/usr/README.md) | Store, check, and sync tables of sequence records. |
+| [**densegen**](src/dnadesign/densegen/README.md) | Generate DNA sequence libraries from saved design inputs. |
+| [**infer**](src/dnadesign/infer/README.md) | Run sequence models and add their results to datasets. |
+| [**construct**](src/dnadesign/construct/README.md) | Build DNA constructs from reusable templates. |
+| [**opal**](src/dnadesign/opal/README.md) | Choose the next DNA designs from measured results. |
+| [**cluster**](src/dnadesign/cluster/README.md) | Group and visualize rows in numerical data tables. |
+| [**latentdna**](src/dnadesign/latentdna/README.md) | Compare numerical sequence features and save review-ready results. |
+| [**cruncher**](src/dnadesign/cruncher/README.md) | Find DNA sequences and assembly plans that satisfy stated constraints. |
+| [**billboard**](src/dnadesign/billboard/README.md) | Measure how varied sequence motifs are within a library. |
+| [**libshuffle**](src/dnadesign/libshuffle/README.md) | Select representative subsets from large sequence libraries. |
+| [**nmf**](src/dnadesign/nmf/README.md) | Find recurring groups of sequence motifs in data tables. |
+| [**permuter**](src/dnadesign/permuter/README.md) | Generate sequence variants and score them with chosen tools. |
+| [**tfkdanalysis**](src/dnadesign/tfkdanalysis/README.md) | Summarize measured responses after transcription-factor knockdown. |
+| [**aligner**](src/dnadesign/aligner/README.md) | Compare pairs or sets of DNA and protein sequences. |
+| [**thread**](src/dnadesign/thread/README.md) | Prepare requests for protein-design models and check predicted structures. |
 
-### Artifact services
+### Draw and inspect results
 
-| Tool | Description | Coverage |
-| --- | --- | --- |
-| [**folding**](src/dnadesign/folding/README.md) | Predict and draw RNA secondary structures from sequence records. | [![folding coverage](https://codecov.io/gh/e-south/dnadesign/graph/badge.svg?component=folding)](https://codecov.io/gh/e-south/dnadesign?component=folding) |
-| [**baserender**](src/dnadesign/baserender/README.md) | Render sequence visuals from job files and visual contracts. | [![baserender coverage](https://codecov.io/gh/e-south/dnadesign/graph/badge.svg?component=baserender)](https://codecov.io/gh/e-south/dnadesign?component=baserender) |
+| Tool | Description |
+| --- | --- |
+| [**folding**](src/dnadesign/folding/README.md) | Predict and draw RNA secondary structures from sequence records. |
+| [**baserender**](src/dnadesign/baserender/README.md) | Draw annotated sequence diagrams from saved job files. |
 
-### Operator surfaces
+### Run and monitor jobs
 
-| Tool | Description | Coverage |
-| --- | --- | --- |
-| [**ops**](src/dnadesign/ops/README.md) | Discover, run, and inspect jobs owned by repository tools. | [![ops coverage](https://codecov.io/gh/e-south/dnadesign/graph/badge.svg?component=ops)](https://codecov.io/gh/e-south/dnadesign?component=ops) |
-| [**notify**](src/dnadesign/notify/README.md) | Send webhook notifications for local runs and scheduler-backed jobs. | [![notify coverage](https://codecov.io/gh/e-south/dnadesign/graph/badge.svg?component=notify)](https://codecov.io/gh/e-south/dnadesign?component=notify) |
+| Tool | Description |
+| --- | --- |
+| [**ops**](src/dnadesign/ops/README.md) | Find, run, and inspect jobs owned by repository tools. |
+| [**notify**](src/dnadesign/notify/README.md) | Send webhook notifications for local and scheduled jobs. |
 
-### Shared contracts
+### Data shared between tools
 
-| Tool | Description | Coverage |
-| --- | --- | --- |
-| [**contracts**](src/dnadesign/contracts/README.md) | Versioned schemas shared between tools. | [![contracts coverage](https://codecov.io/gh/e-south/dnadesign/graph/badge.svg?component=contracts)](https://codecov.io/gh/e-south/dnadesign?component=contracts) |
+| Tool | Description |
+| --- | --- |
+| [**contracts**](src/dnadesign/contracts/README.md) | Define versioned data formats shared between tools. |
 ---

--- a/README.md
+++ b/README.md
@@ -1,12 +1,8 @@
-[![CI](https://github.com/e-south/dnadesign/actions/workflows/ci.yaml/badge.svg)](https://github.com/e-south/dnadesign/actions/workflows/ci.yaml)
-[![Codecov](https://codecov.io/gh/e-south/dnadesign/graph/badge.svg)](https://codecov.io/gh/e-south/dnadesign)
-[![Python 3.12](https://img.shields.io/badge/python-3.12-blue.svg)](https://www.python.org/downloads/release/python-3120/)
-[![uv](https://img.shields.io/badge/package_manager-uv-6f42c1.svg)](https://docs.astral.sh/uv/)
-[![Ruff](https://img.shields.io/badge/linting-ruff-46a2f1.svg)](https://docs.astral.sh/ruff/)
-[![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen.svg)](https://pre-commit.com/)
-[![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
+# ![dnadesign sequence toolkit](assets/dnadesign-banner.svg)
 
-![dnadesign banner](assets/dnadesign-banner.svg)
+[![CI](https://github.com/e-south/dnadesign/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/e-south/dnadesign/actions/workflows/ci.yaml)
+[![Codecov](https://codecov.io/gh/e-south/dnadesign/graph/badge.svg)](https://codecov.io/gh/e-south/dnadesign)
+[![MIT license](https://img.shields.io/badge/license-MIT-3D8068.svg)](LICENSE)
 
 `dnadesign` is a modular bioinformatics toolkit for designing sequence libraries, assembling DNA constructs, running sequence models, and analyzing the resulting datasets.
 
@@ -32,34 +28,34 @@ README for commands, inputs, and outputs.
 
 | Tool | Description | Coverage |
 | --- | --- | --- |
-| [**usr**](src/dnadesign/usr/README.md) | Store, inspect, validate, and sync Parquet-backed USR datasets. | [![usr coverage](https://codecov.io/gh/e-south/dnadesign/graph/badge.svg?component=usr)](https://codecov.io/gh/e-south/dnadesign?component=usr) |
+| [**usr**](src/dnadesign/usr/README.md) | Store, inspect, validate, and sync tabular sequence records. | [![usr coverage](https://codecov.io/gh/e-south/dnadesign/graph/badge.svg?component=usr)](https://codecov.io/gh/e-south/dnadesign?component=usr) |
 | [**densegen**](src/dnadesign/densegen/README.md) | Generate DNA sequence libraries from declared design workspaces. | [![densegen coverage](https://codecov.io/gh/e-south/dnadesign/graph/badge.svg?component=densegen)](https://codecov.io/gh/e-south/dnadesign?component=densegen) |
 | [**infer**](src/dnadesign/infer/README.md) | Run sequence-model inference and write features back to datasets. | [![infer coverage](https://codecov.io/gh/e-south/dnadesign/graph/badge.svg?component=infer)](https://codecov.io/gh/e-south/dnadesign?component=infer) |
 | [**construct**](src/dnadesign/construct/README.md) | Build template-based constructs and declared sequence products. | [![construct coverage](https://codecov.io/gh/e-south/dnadesign/graph/badge.svg?component=construct)](https://codecov.io/gh/e-south/dnadesign?component=construct) |
-| [**opal**](src/dnadesign/opal/README.md) | Run active-learning campaigns over labeled sequence datasets. | [![opal coverage](https://codecov.io/gh/e-south/dnadesign/graph/badge.svg?component=opal)](https://codecov.io/gh/e-south/dnadesign?component=opal) |
-| [**cluster**](src/dnadesign/cluster/README.md) | Cluster feature tables and render UMAP analysis outputs. | [![cluster coverage](https://codecov.io/gh/e-south/dnadesign/graph/badge.svg?component=cluster)](https://codecov.io/gh/e-south/dnadesign?component=cluster) |
-| [**latentdna**](src/dnadesign/latentdna/README.md) | Compare sequence embeddings and publish tables, plots, snapshots, and notebooks. | [![latentdna coverage](https://codecov.io/gh/e-south/dnadesign/graph/badge.svg?component=latentdna)](https://codecov.io/gh/e-south/dnadesign?component=latentdna) |
-| [**cruncher**](src/dnadesign/cruncher/README.md) | Run DNA design workflows for optimization, cassettes, Snapback, scar-nick, and related panels. | [![cruncher coverage](https://codecov.io/gh/e-south/dnadesign/graph/badge.svg?component=cruncher)](https://codecov.io/gh/e-south/dnadesign?component=cruncher) |
-| [**billboard**](src/dnadesign/billboard/README.md) | Measure motif and regulator diversity in generated libraries. | [![billboard coverage](https://codecov.io/gh/e-south/dnadesign/graph/badge.svg?component=billboard)](https://codecov.io/gh/e-south/dnadesign?component=billboard) |
-| [**libshuffle**](src/dnadesign/libshuffle/README.md) | Subsample libraries across rounds and summarize diversity with Billboard. | [![libshuffle coverage](https://codecov.io/gh/e-south/dnadesign/graph/badge.svg?component=libshuffle)](https://codecov.io/gh/e-south/dnadesign?component=libshuffle) |
+| [**opal**](src/dnadesign/opal/README.md) | Choose the next DNA designs from measured sequence results. | [![opal coverage](https://codecov.io/gh/e-south/dnadesign/graph/badge.svg?component=opal)](https://codecov.io/gh/e-south/dnadesign?component=opal) |
+| [**cluster**](src/dnadesign/cluster/README.md) | Group and visualize rows in numerical feature tables. | [![cluster coverage](https://codecov.io/gh/e-south/dnadesign/graph/badge.svg?component=cluster)](https://codecov.io/gh/e-south/dnadesign?component=cluster) |
+| [**latentdna**](src/dnadesign/latentdna/README.md) | Compare numerical sequence representations and publish review artifacts. | [![latentdna coverage](https://codecov.io/gh/e-south/dnadesign/graph/badge.svg?component=latentdna)](https://codecov.io/gh/e-south/dnadesign?component=latentdna) |
+| [**cruncher**](src/dnadesign/cruncher/README.md) | Solve constrained DNA sequence and assembly design tasks. | [![cruncher coverage](https://codecov.io/gh/e-south/dnadesign/graph/badge.svg?component=cruncher)](https://codecov.io/gh/e-south/dnadesign?component=cruncher) |
+| [**billboard**](src/dnadesign/billboard/README.md) | Measure how varied sequence motifs are within a library. | [![billboard coverage](https://codecov.io/gh/e-south/dnadesign/graph/badge.svg?component=billboard)](https://codecov.io/gh/e-south/dnadesign?component=billboard) |
+| [**libshuffle**](src/dnadesign/libshuffle/README.md) | Select representative subsets from large sequence libraries. | [![libshuffle coverage](https://codecov.io/gh/e-south/dnadesign/graph/badge.svg?component=libshuffle)](https://codecov.io/gh/e-south/dnadesign?component=libshuffle) |
 | [**nmf**](src/dnadesign/nmf/README.md) | Find recurring motif combinations with non-negative matrix factorization. | [![nmf coverage](https://codecov.io/gh/e-south/dnadesign/graph/badge.svg?component=nmf)](https://codecov.io/gh/e-south/dnadesign?component=nmf) |
-| [**permuter**](src/dnadesign/permuter/README.md) | Generate sequence permutations and evaluate downstream outputs. | [![permuter coverage](https://codecov.io/gh/e-south/dnadesign/graph/badge.svg?component=permuter)](https://codecov.io/gh/e-south/dnadesign?component=permuter) |
-| [**tfkdanalysis**](src/dnadesign/tfkdanalysis/README.md) | Analyze TFKD libraries in PPTP-seq context. | [![tfkdanalysis coverage](https://codecov.io/gh/e-south/dnadesign/graph/badge.svg?component=tfkdanalysis)](https://codecov.io/gh/e-south/dnadesign?component=tfkdanalysis) |
+| [**permuter**](src/dnadesign/permuter/README.md) | Generate sequence variants and evaluate them with declared scoring tools. | [![permuter coverage](https://codecov.io/gh/e-south/dnadesign/graph/badge.svg?component=permuter)](https://codecov.io/gh/e-south/dnadesign?component=permuter) |
+| [**tfkdanalysis**](src/dnadesign/tfkdanalysis/README.md) | Summarize measured responses after transcription-factor knockdown. | [![tfkdanalysis coverage](https://codecov.io/gh/e-south/dnadesign/graph/badge.svg?component=tfkdanalysis)](https://codecov.io/gh/e-south/dnadesign?component=tfkdanalysis) |
 | [**aligner**](src/dnadesign/aligner/README.md) | Score pairwise sequence alignments with Biopython. | [![aligner coverage](https://codecov.io/gh/e-south/dnadesign/graph/badge.svg?component=aligner)](https://codecov.io/gh/e-south/dnadesign?component=aligner) |
-| [**thread**](src/dnadesign/thread/README.md) | Build fixed-backbone design request artifacts for declared backend adapters. | [![thread coverage](https://codecov.io/gh/e-south/dnadesign/graph/badge.svg?component=thread)](https://codecov.io/gh/e-south/dnadesign?component=thread) |
+| [**thread**](src/dnadesign/thread/README.md) | Prepare protein-design requests and check predicted structures. | [![thread coverage](https://codecov.io/gh/e-south/dnadesign/graph/badge.svg?component=thread)](https://codecov.io/gh/e-south/dnadesign?component=thread) |
 
 ### Artifact services
 
 | Tool | Description | Coverage |
 | --- | --- | --- |
-| [**folding**](src/dnadesign/folding/README.md) | Predict secondary structure and render ViennaRNA plots from bundle artifacts. | [![folding coverage](https://codecov.io/gh/e-south/dnadesign/graph/badge.svg?component=folding)](https://codecov.io/gh/e-south/dnadesign?component=folding) |
+| [**folding**](src/dnadesign/folding/README.md) | Predict and draw RNA secondary structures from sequence records. | [![folding coverage](https://codecov.io/gh/e-south/dnadesign/graph/badge.svg?component=folding)](https://codecov.io/gh/e-south/dnadesign?component=folding) |
 | [**baserender**](src/dnadesign/baserender/README.md) | Render sequence visuals from job files and visual contracts. | [![baserender coverage](https://codecov.io/gh/e-south/dnadesign/graph/badge.svg?component=baserender)](https://codecov.io/gh/e-south/dnadesign?component=baserender) |
 
 ### Operator surfaces
 
 | Tool | Description | Coverage |
 | --- | --- | --- |
-| [**ops**](src/dnadesign/ops/README.md) | Plan, submit, and inspect batch runbooks across tools. | [![ops coverage](https://codecov.io/gh/e-south/dnadesign/graph/badge.svg?component=ops)](https://codecov.io/gh/e-south/dnadesign?component=ops) |
+| [**ops**](src/dnadesign/ops/README.md) | Discover, run, and inspect jobs owned by repository tools. | [![ops coverage](https://codecov.io/gh/e-south/dnadesign/graph/badge.svg?component=ops)](https://codecov.io/gh/e-south/dnadesign?component=ops) |
 | [**notify**](src/dnadesign/notify/README.md) | Send webhook notifications for local runs and scheduler-backed jobs. | [![notify coverage](https://codecov.io/gh/e-south/dnadesign/graph/badge.svg?component=notify)](https://codecov.io/gh/e-south/dnadesign?component=notify) |
 
 ### Shared contracts

--- a/assets/dnadesign-banner.svg
+++ b/assets/dnadesign-banner.svg
@@ -1,22 +1,37 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1600" height="420" viewBox="0 0 1600 420" role="img" aria-labelledby="title desc">
-  <title id="title">dnadesign banner</title>
-  <desc id="desc">dnadesign repository banner with subtitle and sequence-design iconography.</desc>
-  <rect width="1600" height="420" fill="#000000"/>
-  <circle cx="1328" cy="78" r="170" fill="#a5f3fc" opacity="0.1"/>
-  <circle cx="1466" cy="322" r="128" fill="#67e8f9" opacity="0.12"/>
-  <g fill="#f8fafc" font-family="'Helvetica Neue', Arial, sans-serif">
-    <text x="84" y="150" font-size="66" font-weight="700">dnadesign</text>
-    <text x="84" y="214" font-size="30" opacity="0.95">Modular pipelines for biological sequence design</text>
+<svg width="1280" height="260" viewBox="0 0 1280 260" fill="none"
+  xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc"
+  shape-rendering="crispEdges">
+  <title id="title">dnadesign sequence-design toolkit</title>
+  <desc id="desc">A dark, quiet path through sequence design, construction, modeling, and analysis.</desc>
+  <rect width="1280" height="260" fill="#1E1D1A"/>
+  <g font-family="Menlo, Monaco, Consolas, monospace">
+    <text x="52" y="58" fill="#969087" font-size="12" letter-spacing="1.4">MODULAR SEQUENCE TOOLKIT</text>
+    <text x="48" y="151" fill="#F3EFE7" font-size="72" font-weight="700" letter-spacing="-2">dnadesign</text>
+    <rect x="52" y="177" width="40" height="6" fill="#D97757"/>
   </g>
-  <g transform="translate(1036 78)">
-    <g fill="none" stroke="#a5f3fc" stroke-width="6" stroke-linecap="round" opacity="0.9">
-      <path d="M24 88 H316"/>
-      <path d="M24 132 H316"/>
-      <path d="M24 176 H316"/>
+  <path d="M432 46V214" stroke="#3F3C37" stroke-width="2"/>
+  <path d="M520 132H1192" stroke="#5A5650" stroke-width="2"/>
+  <g font-family="Menlo, Monaco, Consolas, monospace" font-size="12" font-weight="700" letter-spacing="0.6">
+    <g transform="translate(520 0)">
+      <path d="M0 82H56M0 98H40M0 114H48" stroke="#F3EFE7" stroke-width="6"/>
+      <text x="0" y="174" fill="#F3EFE7">DESIGN</text>
     </g>
-    <g fill="#67e8f9">
-      <circle cx="358" cy="132" r="14" opacity="0.95"/>
-      <circle cx="334" cy="88" r="6" opacity="0.8"/>
+    <g transform="translate(696 0)">
+      <rect x="0" y="88" width="22" height="22" fill="#F3EFE7"/>
+      <rect x="30" y="88" width="38" height="22" fill="#D97757"/>
+      <rect x="76" y="88" width="20" height="22" fill="#F3EFE7"/>
+      <text x="0" y="174" fill="#F3EFE7">ASSEMBLE</text>
+    </g>
+    <g transform="translate(892 0)">
+      <path d="M0 110L22 84L44 104L68 72" stroke="#F3EFE7" stroke-width="5" fill="none"/>
+      <rect x="64" y="68" width="8" height="8" fill="#D97757"/>
+      <text x="0" y="174" fill="#F3EFE7">MODEL</text>
+    </g>
+    <g transform="translate(1064 0)">
+      <rect x="0" y="104" width="12" height="12" fill="#969087"/>
+      <rect x="22" y="90" width="12" height="26" fill="#F3EFE7"/>
+      <rect x="44" y="76" width="12" height="40" fill="#D97757"/>
+      <text x="0" y="174" fill="#F3EFE7">ANALYZE</text>
     </g>
   </g>
 </svg>

--- a/src/dnadesign/aligner/assets/aligner-banner.svg
+++ b/src/dnadesign/aligner/assets/aligner-banner.svg
@@ -1,10 +1,17 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="180" viewBox="0 0 1200 180" role="img" aria-labelledby="title desc">
-  <title id="title">aligner</title>
-  <desc id="desc">pairwise sequence alignment.</desc>
-  <rect width="1200" height="180" fill="#111827" />
-  <path d="M72 48H1128" stroke="#94a3b8" stroke-opacity="0.28" stroke-width="2" />
-  <g font-family="Helvetica, Arial, sans-serif">
-    <text x="72" y="106" fill="#f8fafc" font-size="54" font-weight="700">aligner</text>
-    <text x="74" y="140" fill="#cbd5e1" font-size="22">pairwise sequence alignment</text>
+<svg width="1200" height="180" viewBox="0 0 1200 180" fill="none"
+  xmlns="http://www.w3.org/2000/svg" role="img"
+  aria-labelledby="aligner-banner-title aligner-banner-description" shape-rendering="crispEdges">
+  <title id="aligner-banner-title">aligner: align sequences</title>
+  <desc id="aligner-banner-description">Align nucleotide pairs and protein sequence sets.</desc>
+  <rect width="1200" height="180" fill="#1E1D1A"/>
+  <g font-family="Menlo, Monaco, Consolas, monospace">
+    <text x="48" y="78" fill="#F3EFE7" font-size="42" font-weight="700" letter-spacing="-1">aligner</text>
+    <text x="50" y="114" fill="#969087" font-size="12" font-weight="700" letter-spacing="1.2">ALIGN SEQUENCES</text>
+    <rect x="50" y="132" width="32" height="5" fill="#D97757"/>
+  </g>
+  <path d="M510 34V146" stroke="#3F3C37" stroke-width="2"/>
+  <path d="M584 124H1144" stroke="#5A5650" stroke-width="2"/>
+  <g transform="translate(720 48)">
+    <path d="M0 18H72M0 42H72" stroke="#969087" stroke-width="3" fill="none"/><rect x="12" y="13" width="20" height="10" fill="#F3EFE7"/><rect x="38" y="37" width="20" height="10" fill="#D97757"/>
   </g>
 </svg>

--- a/src/dnadesign/baserender/assets/baserender-banner.svg
+++ b/src/dnadesign/baserender/assets/baserender-banner.svg
@@ -1,12 +1,12 @@
 <svg width="1200" height="180" viewBox="0 0 1200 180" fill="none"
   xmlns="http://www.w3.org/2000/svg" role="img"
   aria-labelledby="baserender-banner-title baserender-banner-description" shape-rendering="crispEdges">
-  <title id="baserender-banner-title">baserender: render sequences</title>
-  <desc id="baserender-banner-description">Render sequence records from explicit visual contracts.</desc>
+  <title id="baserender-banner-title">baserender: draw sequence maps</title>
+  <desc id="baserender-banner-description">Draw annotated sequence diagrams from saved job files.</desc>
   <rect width="1200" height="180" fill="#1E1D1A"/>
   <g font-family="Menlo, Monaco, Consolas, monospace">
     <text x="48" y="78" fill="#F3EFE7" font-size="42" font-weight="700" letter-spacing="-1">baserender</text>
-    <text x="50" y="114" fill="#969087" font-size="12" font-weight="700" letter-spacing="1.2">RENDER SEQUENCES</text>
+    <text x="50" y="114" fill="#969087" font-size="12" font-weight="700" letter-spacing="1.2">DRAW SEQUENCE MAPS</text>
     <rect x="50" y="132" width="32" height="5" fill="#D97757"/>
   </g>
   <path d="M510 34V146" stroke="#3F3C37" stroke-width="2"/>

--- a/src/dnadesign/baserender/assets/baserender-banner.svg
+++ b/src/dnadesign/baserender/assets/baserender-banner.svg
@@ -1,10 +1,17 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="180" viewBox="0 0 1200 180" role="img" aria-labelledby="title desc">
-  <title id="title">baserender</title>
-  <desc id="desc">sequence visuals from explicit contracts.</desc>
-  <rect width="1200" height="180" fill="#111827" />
-  <path d="M72 48H1128" stroke="#94a3b8" stroke-opacity="0.28" stroke-width="2" />
-  <g font-family="Helvetica, Arial, sans-serif">
-    <text x="72" y="106" fill="#f8fafc" font-size="54" font-weight="700">baserender</text>
-    <text x="74" y="140" fill="#cbd5e1" font-size="22">sequence visuals from explicit contracts</text>
+<svg width="1200" height="180" viewBox="0 0 1200 180" fill="none"
+  xmlns="http://www.w3.org/2000/svg" role="img"
+  aria-labelledby="baserender-banner-title baserender-banner-description" shape-rendering="crispEdges">
+  <title id="baserender-banner-title">baserender: render sequences</title>
+  <desc id="baserender-banner-description">Render sequence records from explicit visual contracts.</desc>
+  <rect width="1200" height="180" fill="#1E1D1A"/>
+  <g font-family="Menlo, Monaco, Consolas, monospace">
+    <text x="48" y="78" fill="#F3EFE7" font-size="42" font-weight="700" letter-spacing="-1">baserender</text>
+    <text x="50" y="114" fill="#969087" font-size="12" font-weight="700" letter-spacing="1.2">RENDER SEQUENCES</text>
+    <rect x="50" y="132" width="32" height="5" fill="#D97757"/>
+  </g>
+  <path d="M510 34V146" stroke="#3F3C37" stroke-width="2"/>
+  <path d="M584 124H1144" stroke="#5A5650" stroke-width="2"/>
+  <g transform="translate(720 48)">
+    <path d="M0 8H66V52H0Z" stroke="#969087" stroke-width="3" fill="none"/><path d="M12 20H54M12 30H42M12 40H48" stroke="#F3EFE7" stroke-width="4" fill="none"/>
   </g>
 </svg>

--- a/src/dnadesign/billboard/assets/billboard-banner.svg
+++ b/src/dnadesign/billboard/assets/billboard-banner.svg
@@ -1,10 +1,17 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="180" viewBox="0 0 1200 180" role="img" aria-labelledby="title desc">
-  <title id="title">billboard</title>
-  <desc id="desc">regulatory diversity metrics for libraries.</desc>
-  <rect width="1200" height="180" fill="#111827" />
-  <path d="M72 48H1128" stroke="#94a3b8" stroke-opacity="0.28" stroke-width="2" />
-  <g font-family="Helvetica, Arial, sans-serif">
-    <text x="72" y="106" fill="#f8fafc" font-size="54" font-weight="700">billboard</text>
-    <text x="74" y="140" fill="#cbd5e1" font-size="22">regulatory diversity metrics for libraries</text>
+<svg width="1200" height="180" viewBox="0 0 1200 180" fill="none"
+  xmlns="http://www.w3.org/2000/svg" role="img"
+  aria-labelledby="billboard-banner-title billboard-banner-description" shape-rendering="crispEdges">
+  <title id="billboard-banner-title">billboard: measure diversity</title>
+  <desc id="billboard-banner-description">Measure binding-site diversity in generated libraries.</desc>
+  <rect width="1200" height="180" fill="#1E1D1A"/>
+  <g font-family="Menlo, Monaco, Consolas, monospace">
+    <text x="48" y="78" fill="#F3EFE7" font-size="42" font-weight="700" letter-spacing="-1">billboard</text>
+    <text x="50" y="114" fill="#969087" font-size="12" font-weight="700" letter-spacing="1.2">MEASURE DIVERSITY</text>
+    <rect x="50" y="132" width="32" height="5" fill="#D97757"/>
+  </g>
+  <path d="M510 34V146" stroke="#3F3C37" stroke-width="2"/>
+  <path d="M584 124H1144" stroke="#5A5650" stroke-width="2"/>
+  <g transform="translate(720 48)">
+    <rect x="0" y="32" width="10" height="14" fill="#969087"/><rect x="18" y="16" width="10" height="30" fill="#F3EFE7"/><rect x="36" y="26" width="10" height="20" fill="#5A5650"/><rect x="54" y="4" width="10" height="42" fill="#D97757"/><rect x="72" y="21" width="10" height="25" fill="#F3EFE7"/>
   </g>
 </svg>

--- a/src/dnadesign/cluster/assets/cluster-banner.svg
+++ b/src/dnadesign/cluster/assets/cluster-banner.svg
@@ -1,10 +1,17 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="180" viewBox="0 0 1200 180" role="img" aria-labelledby="title desc">
-  <title id="title">cluster</title>
-  <desc id="desc">clustering and UMAP views for feature tables.</desc>
-  <rect width="1200" height="180" fill="#111827" />
-  <path d="M72 48H1128" stroke="#94a3b8" stroke-opacity="0.28" stroke-width="2" />
-  <g font-family="Helvetica, Arial, sans-serif">
-    <text x="72" y="106" fill="#f8fafc" font-size="54" font-weight="700">cluster</text>
-    <text x="74" y="140" fill="#cbd5e1" font-size="22">clustering and UMAP views for feature tables</text>
+<svg width="1200" height="180" viewBox="0 0 1200 180" fill="none"
+  xmlns="http://www.w3.org/2000/svg" role="img"
+  aria-labelledby="cluster-banner-title cluster-banner-description" shape-rendering="crispEdges">
+  <title id="cluster-banner-title">cluster: explore features</title>
+  <desc id="cluster-banner-description">Explore feature tables through clusters and projections.</desc>
+  <rect width="1200" height="180" fill="#1E1D1A"/>
+  <g font-family="Menlo, Monaco, Consolas, monospace">
+    <text x="48" y="78" fill="#F3EFE7" font-size="42" font-weight="700" letter-spacing="-1">cluster</text>
+    <text x="50" y="114" fill="#969087" font-size="12" font-weight="700" letter-spacing="1.2">EXPLORE FEATURES</text>
+    <rect x="50" y="132" width="32" height="5" fill="#D97757"/>
+  </g>
+  <path d="M510 34V146" stroke="#3F3C37" stroke-width="2"/>
+  <path d="M584 124H1144" stroke="#5A5650" stroke-width="2"/>
+  <g transform="translate(720 48)">
+    <circle cx="15" cy="18" r="7" fill="#F3EFE7"/><circle cx="34" cy="12" r="5" fill="#969087"/><circle cx="26" cy="34" r="6" fill="#D97757"/><circle cx="68" cy="38" r="7" fill="#F3EFE7"/><circle cx="84" cy="27" r="5" fill="#5A5650"/>
   </g>
 </svg>

--- a/src/dnadesign/cluster/assets/cluster-banner.svg
+++ b/src/dnadesign/cluster/assets/cluster-banner.svg
@@ -1,12 +1,12 @@
 <svg width="1200" height="180" viewBox="0 0 1200 180" fill="none"
   xmlns="http://www.w3.org/2000/svg" role="img"
   aria-labelledby="cluster-banner-title cluster-banner-description" shape-rendering="crispEdges">
-  <title id="cluster-banner-title">cluster: explore features</title>
-  <desc id="cluster-banner-description">Explore feature tables through clusters and projections.</desc>
+  <title id="cluster-banner-title">cluster: group features</title>
+  <desc id="cluster-banner-description">Group and visualize rows in numerical feature tables.</desc>
   <rect width="1200" height="180" fill="#1E1D1A"/>
   <g font-family="Menlo, Monaco, Consolas, monospace">
     <text x="48" y="78" fill="#F3EFE7" font-size="42" font-weight="700" letter-spacing="-1">cluster</text>
-    <text x="50" y="114" fill="#969087" font-size="12" font-weight="700" letter-spacing="1.2">EXPLORE FEATURES</text>
+    <text x="50" y="114" fill="#969087" font-size="12" font-weight="700" letter-spacing="1.2">GROUP FEATURES</text>
     <rect x="50" y="132" width="32" height="5" fill="#D97757"/>
   </g>
   <path d="M510 34V146" stroke="#3F3C37" stroke-width="2"/>

--- a/src/dnadesign/construct/docs/assets/construct-banner.svg
+++ b/src/dnadesign/construct/docs/assets/construct-banner.svg
@@ -1,10 +1,17 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="180" viewBox="0 0 1200 180" role="img" aria-labelledby="title desc">
-  <title id="title">construct</title>
-  <desc id="desc">template-based DNA construct assembly.</desc>
-  <rect width="1200" height="180" fill="#111827" />
-  <path d="M72 48H1128" stroke="#94a3b8" stroke-opacity="0.28" stroke-width="2" />
-  <g font-family="Helvetica, Arial, sans-serif">
-    <text x="72" y="106" fill="#f8fafc" font-size="54" font-weight="700">construct</text>
-    <text x="74" y="140" fill="#cbd5e1" font-size="22">template-based DNA construct assembly</text>
+<svg width="1200" height="180" viewBox="0 0 1200 180" fill="none"
+  xmlns="http://www.w3.org/2000/svg" role="img"
+  aria-labelledby="construct-banner-title construct-banner-description" shape-rendering="crispEdges">
+  <title id="construct-banner-title">construct: assemble constructs</title>
+  <desc id="construct-banner-description">Place named DNA parts into declared sequence contexts.</desc>
+  <rect width="1200" height="180" fill="#1E1D1A"/>
+  <g font-family="Menlo, Monaco, Consolas, monospace">
+    <text x="48" y="78" fill="#F3EFE7" font-size="42" font-weight="700" letter-spacing="-1">construct</text>
+    <text x="50" y="114" fill="#969087" font-size="12" font-weight="700" letter-spacing="1.2">ASSEMBLE CONSTRUCTS</text>
+    <rect x="50" y="132" width="32" height="5" fill="#D97757"/>
+  </g>
+  <path d="M510 34V146" stroke="#3F3C37" stroke-width="2"/>
+  <path d="M584 124H1144" stroke="#5A5650" stroke-width="2"/>
+  <g transform="translate(720 48)">
+    <rect x="0" y="21" width="26" height="16" fill="#969087"/><rect x="32" y="21" width="42" height="16" fill="#D97757"/><rect x="80" y="21" width="24" height="16" fill="#F3EFE7"/><path d="M26 29H32M74 29H80" stroke="#5A5650" stroke-width="3" fill="none"/>
   </g>
 </svg>

--- a/src/dnadesign/contracts/assets/contracts-banner.svg
+++ b/src/dnadesign/contracts/assets/contracts-banner.svg
@@ -1,12 +1,12 @@
 <svg width="1200" height="180" viewBox="0 0 1200 180" fill="none"
   xmlns="http://www.w3.org/2000/svg" role="img"
   aria-labelledby="contracts-banner-title contracts-banner-description" shape-rendering="crispEdges">
-  <title id="contracts-banner-title">contracts: define data shapes</title>
-  <desc id="contracts-banner-description">Define versioned data shapes shared between tools.</desc>
+  <title id="contracts-banner-title">contracts: share data formats</title>
+  <desc id="contracts-banner-description">Define versioned data formats shared between tools.</desc>
   <rect width="1200" height="180" fill="#1E1D1A"/>
   <g font-family="Menlo, Monaco, Consolas, monospace">
     <text x="48" y="78" fill="#F3EFE7" font-size="42" font-weight="700" letter-spacing="-1">contracts</text>
-    <text x="50" y="114" fill="#969087" font-size="12" font-weight="700" letter-spacing="1.2">DEFINE DATA SHAPES</text>
+    <text x="50" y="114" fill="#969087" font-size="12" font-weight="700" letter-spacing="1.2">SHARE DATA FORMATS</text>
     <rect x="50" y="132" width="32" height="5" fill="#D97757"/>
   </g>
   <path d="M510 34V146" stroke="#3F3C37" stroke-width="2"/>

--- a/src/dnadesign/contracts/assets/contracts-banner.svg
+++ b/src/dnadesign/contracts/assets/contracts-banner.svg
@@ -1,10 +1,17 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="180" viewBox="0 0 1200 180" role="img" aria-labelledby="title desc">
-  <title id="title">contracts</title>
-  <desc id="desc">shared artifact schemas between tools.</desc>
-  <rect width="1200" height="180" fill="#111827" />
-  <path d="M72 48H1128" stroke="#94a3b8" stroke-opacity="0.28" stroke-width="2" />
-  <g font-family="Helvetica, Arial, sans-serif">
-    <text x="72" y="106" fill="#f8fafc" font-size="54" font-weight="700">contracts</text>
-    <text x="74" y="140" fill="#cbd5e1" font-size="22">shared artifact schemas between tools</text>
+<svg width="1200" height="180" viewBox="0 0 1200 180" fill="none"
+  xmlns="http://www.w3.org/2000/svg" role="img"
+  aria-labelledby="contracts-banner-title contracts-banner-description" shape-rendering="crispEdges">
+  <title id="contracts-banner-title">contracts: define handoffs</title>
+  <desc id="contracts-banner-description">Define neutral, versioned artifacts shared between tools.</desc>
+  <rect width="1200" height="180" fill="#1E1D1A"/>
+  <g font-family="Menlo, Monaco, Consolas, monospace">
+    <text x="48" y="78" fill="#F3EFE7" font-size="42" font-weight="700" letter-spacing="-1">contracts</text>
+    <text x="50" y="114" fill="#969087" font-size="12" font-weight="700" letter-spacing="1.2">DEFINE HANDOFFS</text>
+    <rect x="50" y="132" width="32" height="5" fill="#D97757"/>
+  </g>
+  <path d="M510 34V146" stroke="#3F3C37" stroke-width="2"/>
+  <path d="M584 124H1144" stroke="#5A5650" stroke-width="2"/>
+  <g transform="translate(720 48)">
+    <path d="M0 12H40V46H0ZM62 12H102V46H62Z" stroke="#969087" stroke-width="3" fill="none"/><path d="M34 29H68" stroke="#D97757" stroke-width="5" fill="none"/>
   </g>
 </svg>

--- a/src/dnadesign/contracts/assets/contracts-banner.svg
+++ b/src/dnadesign/contracts/assets/contracts-banner.svg
@@ -1,12 +1,12 @@
 <svg width="1200" height="180" viewBox="0 0 1200 180" fill="none"
   xmlns="http://www.w3.org/2000/svg" role="img"
   aria-labelledby="contracts-banner-title contracts-banner-description" shape-rendering="crispEdges">
-  <title id="contracts-banner-title">contracts: define handoffs</title>
-  <desc id="contracts-banner-description">Define neutral, versioned artifacts shared between tools.</desc>
+  <title id="contracts-banner-title">contracts: define data shapes</title>
+  <desc id="contracts-banner-description">Define versioned data shapes shared between tools.</desc>
   <rect width="1200" height="180" fill="#1E1D1A"/>
   <g font-family="Menlo, Monaco, Consolas, monospace">
     <text x="48" y="78" fill="#F3EFE7" font-size="42" font-weight="700" letter-spacing="-1">contracts</text>
-    <text x="50" y="114" fill="#969087" font-size="12" font-weight="700" letter-spacing="1.2">DEFINE HANDOFFS</text>
+    <text x="50" y="114" fill="#969087" font-size="12" font-weight="700" letter-spacing="1.2">DEFINE DATA SHAPES</text>
     <rect x="50" y="132" width="32" height="5" fill="#D97757"/>
   </g>
   <path d="M510 34V146" stroke="#3F3C37" stroke-width="2"/>

--- a/src/dnadesign/cruncher/assets/cruncher-banner.svg
+++ b/src/dnadesign/cruncher/assets/cruncher-banner.svg
@@ -1,12 +1,12 @@
 <svg width="1200" height="180" viewBox="0 0 1200 180" fill="none"
   xmlns="http://www.w3.org/2000/svg" role="img"
   aria-labelledby="cruncher-banner-title cruncher-banner-description" shape-rendering="crispEdges">
-  <title id="cruncher-banner-title">cruncher: optimize sequences</title>
-  <desc id="cruncher-banner-description">Solve explicit sequence-design and assembly workflows.</desc>
+  <title id="cruncher-banner-title">cruncher: design to constraints</title>
+  <desc id="cruncher-banner-description">Find sequences and assembly plans that satisfy stated constraints.</desc>
   <rect width="1200" height="180" fill="#1E1D1A"/>
   <g font-family="Menlo, Monaco, Consolas, monospace">
     <text x="48" y="78" fill="#F3EFE7" font-size="42" font-weight="700" letter-spacing="-1">cruncher</text>
-    <text x="50" y="114" fill="#969087" font-size="12" font-weight="700" letter-spacing="1.2">OPTIMIZE SEQUENCES</text>
+    <text x="50" y="114" fill="#969087" font-size="12" font-weight="700" letter-spacing="1.2">DESIGN TO CONSTRAINTS</text>
     <rect x="50" y="132" width="32" height="5" fill="#D97757"/>
   </g>
   <path d="M510 34V146" stroke="#3F3C37" stroke-width="2"/>

--- a/src/dnadesign/cruncher/assets/cruncher-banner.svg
+++ b/src/dnadesign/cruncher/assets/cruncher-banner.svg
@@ -1,10 +1,17 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="180" viewBox="0 0 1200 180" role="img" aria-labelledby="title desc">
-  <title id="title">cruncher</title>
-  <desc id="desc">bounded DNA design workflows.</desc>
-  <rect width="1200" height="180" fill="#111827" />
-  <path d="M72 48H1128" stroke="#94a3b8" stroke-opacity="0.28" stroke-width="2" />
-  <g font-family="Helvetica, Arial, sans-serif">
-    <text x="72" y="106" fill="#f8fafc" font-size="54" font-weight="700">cruncher</text>
-    <text x="74" y="140" fill="#cbd5e1" font-size="22">bounded DNA design workflows</text>
+<svg width="1200" height="180" viewBox="0 0 1200 180" fill="none"
+  xmlns="http://www.w3.org/2000/svg" role="img"
+  aria-labelledby="cruncher-banner-title cruncher-banner-description" shape-rendering="crispEdges">
+  <title id="cruncher-banner-title">cruncher: optimize sequences</title>
+  <desc id="cruncher-banner-description">Solve explicit sequence-design and assembly workflows.</desc>
+  <rect width="1200" height="180" fill="#1E1D1A"/>
+  <g font-family="Menlo, Monaco, Consolas, monospace">
+    <text x="48" y="78" fill="#F3EFE7" font-size="42" font-weight="700" letter-spacing="-1">cruncher</text>
+    <text x="50" y="114" fill="#969087" font-size="12" font-weight="700" letter-spacing="1.2">OPTIMIZE SEQUENCES</text>
+    <rect x="50" y="132" width="32" height="5" fill="#D97757"/>
+  </g>
+  <path d="M510 34V146" stroke="#3F3C37" stroke-width="2"/>
+  <path d="M584 124H1144" stroke="#5A5650" stroke-width="2"/>
+  <g transform="translate(720 48)">
+    <path d="M0 8H102L72 30V50H30V30Z" stroke="#969087" stroke-width="3" fill="none"/><rect x="45" y="39" width="12" height="12" fill="#D97757"/>
   </g>
 </svg>

--- a/src/dnadesign/densegen/assets/densegen-banner.svg
+++ b/src/dnadesign/densegen/assets/densegen-banner.svg
@@ -1,10 +1,17 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="180" viewBox="0 0 1200 180" role="img" aria-labelledby="title desc">
-  <title id="title">densegen</title>
-  <desc id="desc">design-generation workspaces for DNA libraries.</desc>
-  <rect width="1200" height="180" fill="#111827" />
-  <path d="M72 48H1128" stroke="#94a3b8" stroke-opacity="0.28" stroke-width="2" />
-  <g font-family="Helvetica, Arial, sans-serif">
-    <text x="72" y="106" fill="#f8fafc" font-size="54" font-weight="700">densegen</text>
-    <text x="74" y="140" fill="#cbd5e1" font-size="22">design-generation workspaces for DNA libraries</text>
+<svg width="1200" height="180" viewBox="0 0 1200 180" fill="none"
+  xmlns="http://www.w3.org/2000/svg" role="img"
+  aria-labelledby="densegen-banner-title densegen-banner-description" shape-rendering="crispEdges">
+  <title id="densegen-banner-title">densegen: generate libraries</title>
+  <desc id="densegen-banner-description">Generate reproducible DNA libraries from workspace inputs.</desc>
+  <rect width="1200" height="180" fill="#1E1D1A"/>
+  <g font-family="Menlo, Monaco, Consolas, monospace">
+    <text x="48" y="78" fill="#F3EFE7" font-size="42" font-weight="700" letter-spacing="-1">densegen</text>
+    <text x="50" y="114" fill="#969087" font-size="12" font-weight="700" letter-spacing="1.2">GENERATE LIBRARIES</text>
+    <rect x="50" y="132" width="32" height="5" fill="#D97757"/>
+  </g>
+  <path d="M510 34V146" stroke="#3F3C37" stroke-width="2"/>
+  <path d="M584 124H1144" stroke="#5A5650" stroke-width="2"/>
+  <g transform="translate(720 48)">
+    <path d="M0 29H24M24 29L48 10M24 29L48 29M24 29L48 48" stroke="#969087" stroke-width="3" fill="none"/><path d="M48 10H92M48 29H102M48 48H82" stroke="#F3EFE7" stroke-width="4" fill="none"/>
   </g>
 </svg>

--- a/src/dnadesign/devtools/docs/banners/__init__.py
+++ b/src/dnadesign/devtools/docs/banners/__init__.py
@@ -1,0 +1,14 @@
+"""
+--------------------------------------------------------------------------------
+dnadesign
+src/dnadesign/devtools/docs/banners/__init__.py
+
+Exports the deterministic documentation-banner generator.
+
+Module Author(s): Eric J. South
+--------------------------------------------------------------------------------
+"""
+
+from .render import check_banners, render_banners
+
+__all__ = ["check_banners", "render_banners"]

--- a/src/dnadesign/devtools/docs/banners/__main__.py
+++ b/src/dnadesign/devtools/docs/banners/__main__.py
@@ -1,0 +1,39 @@
+"""
+--------------------------------------------------------------------------------
+dnadesign
+src/dnadesign/devtools/docs/banners/__main__.py
+
+Provides the command-line entry point for banner generation and drift checks.
+
+Module Author(s): Eric J. South
+--------------------------------------------------------------------------------
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from .render import check_banners, render_banners
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Generate dnadesign documentation banners.")
+    parser.add_argument("--check", action="store_true", help="Fail when a banner differs from its source.")
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    args = parser.parse_args()
+
+    if args.check:
+        stale = check_banners(args.repo_root)
+        if stale:
+            for path in stale:
+                print(path)
+            return 1
+        return 0
+
+    for path in render_banners(args.repo_root):
+        print(path)
+    return 0
+
+
+raise SystemExit(main())

--- a/src/dnadesign/devtools/docs/banners/catalog.py
+++ b/src/dnadesign/devtools/docs/banners/catalog.py
@@ -1,0 +1,184 @@
+"""
+--------------------------------------------------------------------------------
+dnadesign
+src/dnadesign/devtools/docs/banners/catalog.py
+
+Defines the README banner inventory and plain capability labels.
+
+Module Author(s): Eric J. South
+--------------------------------------------------------------------------------
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class BannerSpec:
+    path: str
+    name: str
+    capability: str
+    description: str
+    glyph: str
+
+
+REPOSITORY_BANNER_PATH = "assets/dnadesign-banner.svg"
+
+
+BANNERS = (
+    BannerSpec(
+        "src/dnadesign/aligner/assets/aligner-banner.svg",
+        "aligner",
+        "ALIGN SEQUENCES",
+        "Align nucleotide pairs and protein sequence sets.",
+        "align",
+    ),
+    BannerSpec(
+        "src/dnadesign/baserender/assets/baserender-banner.svg",
+        "baserender",
+        "RENDER SEQUENCES",
+        "Render sequence records from explicit visual contracts.",
+        "render",
+    ),
+    BannerSpec(
+        "src/dnadesign/billboard/assets/billboard-banner.svg",
+        "billboard",
+        "MEASURE DIVERSITY",
+        "Measure binding-site diversity in generated libraries.",
+        "diversity",
+    ),
+    BannerSpec(
+        "src/dnadesign/cluster/assets/cluster-banner.svg",
+        "cluster",
+        "EXPLORE FEATURES",
+        "Explore feature tables through clusters and projections.",
+        "cluster",
+    ),
+    BannerSpec(
+        "src/dnadesign/construct/docs/assets/construct-banner.svg",
+        "construct",
+        "ASSEMBLE CONSTRUCTS",
+        "Place named DNA parts into declared sequence contexts.",
+        "construct",
+    ),
+    BannerSpec(
+        "src/dnadesign/contracts/assets/contracts-banner.svg",
+        "contracts",
+        "DEFINE HANDOFFS",
+        "Define neutral, versioned artifacts shared between tools.",
+        "contracts",
+    ),
+    BannerSpec(
+        "src/dnadesign/cruncher/assets/cruncher-banner.svg",
+        "cruncher",
+        "OPTIMIZE SEQUENCES",
+        "Solve explicit sequence-design and assembly workflows.",
+        "optimize",
+    ),
+    BannerSpec(
+        "src/dnadesign/densegen/assets/densegen-banner.svg",
+        "densegen",
+        "GENERATE LIBRARIES",
+        "Generate reproducible DNA libraries from workspace inputs.",
+        "generate",
+    ),
+    BannerSpec(
+        "src/dnadesign/devtools/tests/support/assets/testsupport-banner.svg",
+        "testsupport",
+        "SHARE TEST FIXTURES",
+        "Share test-only fixtures across repository tools.",
+        "test",
+    ),
+    BannerSpec(
+        "src/dnadesign/folding/assets/folding-banner.svg",
+        "folding",
+        "PREDICT STRUCTURE",
+        "Predict and render secondary structure for sequence artifacts.",
+        "fold",
+    ),
+    BannerSpec(
+        "src/dnadesign/infer/assets/infer-banner.svg",
+        "infer",
+        "RUN SEQUENCE MODELS",
+        "Run sequence models and publish namespaced results.",
+        "infer",
+    ),
+    BannerSpec(
+        "src/dnadesign/latentdna/docs/assets/latentdna-banner.svg",
+        "latentdna",
+        "COMPARE REPRESENTATIONS",
+        "Compare learned sequence representations in workspaces.",
+        "latent",
+    ),
+    BannerSpec(
+        "src/dnadesign/libshuffle/assets/libshuffle-banner.svg",
+        "libshuffle",
+        "SELECT DIVERSE SETS",
+        "Select representative subsets from dense sequence libraries.",
+        "shuffle",
+    ),
+    BannerSpec(
+        "src/dnadesign/nmf/assets/nmf-banner.svg",
+        "nmf",
+        "FIND MOTIF PROGRAMS",
+        "Factor motif tables into recurring programs.",
+        "factor",
+    ),
+    BannerSpec(
+        "src/dnadesign/notify/assets/notify-banner.svg",
+        "notify",
+        "WATCH DATA EVENTS",
+        "Watch sequence-record events and send notifications.",
+        "notify",
+    ),
+    BannerSpec(
+        "src/dnadesign/opal/assets/opal-banner.svg",
+        "opal",
+        "SELECT NEXT DESIGNS",
+        "Run contract-driven active-learning campaigns.",
+        "select",
+    ),
+    BannerSpec(
+        "src/dnadesign/ops/assets/ops-banner.svg",
+        "ops",
+        "RUN SHARED WORKFLOWS",
+        "Discover, inspect, and run tool-owned workflows.",
+        "route",
+    ),
+    BannerSpec(
+        "src/dnadesign/permuter/assets/permuter-banner.svg",
+        "permuter",
+        "GENERATE VARIANTS",
+        "Generate and score sequence variants through explicit evaluators.",
+        "permute",
+    ),
+    BannerSpec(
+        "src/dnadesign/studies/assets/studies-banner.svg",
+        "studies",
+        "OWN STUDY LOGIC",
+        "Keep study-specific code with its checked-in records.",
+        "study",
+    ),
+    BannerSpec(
+        "src/dnadesign/tfkdanalysis/assets/tfkdanalysis-banner.svg",
+        "tfkdanalysis",
+        "SUMMARIZE KNOCKDOWNS",
+        "Summarize transcription-factor knockdown responses.",
+        "knockdown",
+    ),
+    BannerSpec(
+        "src/dnadesign/thread/assets/thread-banner.svg",
+        "thread",
+        "PREPARE PROTEIN DESIGNS",
+        "Prepare fixed-backbone design requests and fold checks.",
+        "thread",
+    ),
+    BannerSpec(
+        "src/dnadesign/usr/assets/usr-banner.svg",
+        "usr",
+        "STORE SEQUENCE RECORDS",
+        "Store sequence records, overlays, and mutation events.",
+        "records",
+    ),
+)

--- a/src/dnadesign/devtools/docs/banners/catalog.py
+++ b/src/dnadesign/devtools/docs/banners/catalog.py
@@ -37,8 +37,8 @@ BANNERS = (
     BannerSpec(
         "src/dnadesign/baserender/assets/baserender-banner.svg",
         "baserender",
-        "RENDER SEQUENCES",
-        "Render sequence records from explicit visual contracts.",
+        "DRAW SEQUENCE MAPS",
+        "Draw annotated sequence diagrams from saved job files.",
         "render",
     ),
     BannerSpec(
@@ -65,15 +65,15 @@ BANNERS = (
     BannerSpec(
         "src/dnadesign/contracts/assets/contracts-banner.svg",
         "contracts",
-        "DEFINE DATA SHAPES",
-        "Define versioned data shapes shared between tools.",
+        "SHARE DATA FORMATS",
+        "Define versioned data formats shared between tools.",
         "contracts",
     ),
     BannerSpec(
         "src/dnadesign/cruncher/assets/cruncher-banner.svg",
         "cruncher",
-        "OPTIMIZE SEQUENCES",
-        "Solve explicit sequence-design and assembly workflows.",
+        "DESIGN TO CONSTRAINTS",
+        "Find sequences and assembly plans that satisfy stated constraints.",
         "optimize",
     ),
     BannerSpec(
@@ -93,22 +93,22 @@ BANNERS = (
     BannerSpec(
         "src/dnadesign/folding/assets/folding-banner.svg",
         "folding",
-        "PREDICT STRUCTURE",
-        "Predict and render secondary structure for sequence artifacts.",
+        "DRAW RNA STRUCTURES",
+        "Predict and draw RNA secondary structures from sequence records.",
         "fold",
     ),
     BannerSpec(
         "src/dnadesign/infer/assets/infer-banner.svg",
         "infer",
-        "RUN SEQUENCE MODELS",
-        "Run sequence models and publish namespaced results.",
+        "ADD MODEL RESULTS",
+        "Run sequence models and add their results to datasets.",
         "infer",
     ),
     BannerSpec(
         "src/dnadesign/latentdna/docs/assets/latentdna-banner.svg",
         "latentdna",
-        "COMPARE SEQUENCE FEATURES",
-        "Compare numerical sequence features in declared workspaces.",
+        "COMPARE SEQUENCE DATA",
+        "Compare numerical sequence features and save review-ready results.",
         "latent",
     ),
     BannerSpec(
@@ -128,8 +128,8 @@ BANNERS = (
     BannerSpec(
         "src/dnadesign/notify/assets/notify-banner.svg",
         "notify",
-        "WATCH DATA EVENTS",
-        "Watch sequence-record events and send notifications.",
+        "SEND RUN UPDATES",
+        "Send notifications for local and scheduled jobs.",
         "notify",
     ),
     BannerSpec(
@@ -142,15 +142,15 @@ BANNERS = (
     BannerSpec(
         "src/dnadesign/ops/assets/ops-banner.svg",
         "ops",
-        "RUN SHARED WORKFLOWS",
-        "Discover, inspect, and run tool-owned workflows.",
+        "FIND AND RUN JOBS",
+        "Find, run, and inspect jobs owned by repository tools.",
         "route",
     ),
     BannerSpec(
         "src/dnadesign/permuter/assets/permuter-banner.svg",
         "permuter",
-        "GENERATE VARIANTS",
-        "Generate and score sequence variants through explicit evaluators.",
+        "MAKE AND SCORE VARIANTS",
+        "Generate sequence variants and score them with chosen tools.",
         "permute",
     ),
     BannerSpec(
@@ -177,8 +177,8 @@ BANNERS = (
     BannerSpec(
         "src/dnadesign/usr/assets/usr-banner.svg",
         "usr",
-        "STORE SEQUENCE RECORDS",
-        "Store sequence records, overlays, and mutation events.",
+        "MANAGE SEQUENCE TABLES",
+        "Store, check, and sync tables of sequence records.",
         "records",
     ),
 )

--- a/src/dnadesign/devtools/docs/banners/catalog.py
+++ b/src/dnadesign/devtools/docs/banners/catalog.py
@@ -51,8 +51,8 @@ BANNERS = (
     BannerSpec(
         "src/dnadesign/cluster/assets/cluster-banner.svg",
         "cluster",
-        "EXPLORE FEATURES",
-        "Explore feature tables through clusters and projections.",
+        "GROUP FEATURES",
+        "Group and visualize rows in numerical feature tables.",
         "cluster",
     ),
     BannerSpec(
@@ -65,8 +65,8 @@ BANNERS = (
     BannerSpec(
         "src/dnadesign/contracts/assets/contracts-banner.svg",
         "contracts",
-        "DEFINE HANDOFFS",
-        "Define neutral, versioned artifacts shared between tools.",
+        "DEFINE DATA SHAPES",
+        "Define versioned data shapes shared between tools.",
         "contracts",
     ),
     BannerSpec(
@@ -107,8 +107,8 @@ BANNERS = (
     BannerSpec(
         "src/dnadesign/latentdna/docs/assets/latentdna-banner.svg",
         "latentdna",
-        "COMPARE REPRESENTATIONS",
-        "Compare learned sequence representations in workspaces.",
+        "COMPARE SEQUENCE FEATURES",
+        "Compare numerical sequence features in declared workspaces.",
         "latent",
     ),
     BannerSpec(
@@ -121,8 +121,8 @@ BANNERS = (
     BannerSpec(
         "src/dnadesign/nmf/assets/nmf-banner.svg",
         "nmf",
-        "FIND MOTIF PROGRAMS",
-        "Factor motif tables into recurring programs.",
+        "FIND MOTIF PATTERNS",
+        "Find recurring combinations in motif tables.",
         "factor",
     ),
     BannerSpec(
@@ -136,7 +136,7 @@ BANNERS = (
         "src/dnadesign/opal/assets/opal-banner.svg",
         "opal",
         "SELECT NEXT DESIGNS",
-        "Run contract-driven active-learning campaigns.",
+        "Choose the next designs from measured sequence results.",
         "select",
     ),
     BannerSpec(
@@ -156,8 +156,8 @@ BANNERS = (
     BannerSpec(
         "src/dnadesign/studies/assets/studies-banner.svg",
         "studies",
-        "OWN STUDY LOGIC",
-        "Keep study-specific code with its checked-in records.",
+        "ORGANIZE STUDIES",
+        "Keep study methods, records, and decisions together.",
         "study",
     ),
     BannerSpec(

--- a/src/dnadesign/devtools/docs/banners/glyphs.py
+++ b/src/dnadesign/devtools/docs/banners/glyphs.py
@@ -1,0 +1,100 @@
+"""
+--------------------------------------------------------------------------------
+dnadesign
+src/dnadesign/devtools/docs/banners/glyphs.py
+
+Builds the restrained SVG glyphs used by documentation banners.
+
+Module Author(s): Eric J. South
+--------------------------------------------------------------------------------
+"""
+
+from __future__ import annotations
+
+INK = "#F3EFE7"
+MUTED = "#969087"
+DIM = "#5A5650"
+ACCENT = "#D97757"
+
+
+def _rect(x: int, y: int, width: int, height: int, fill: str = INK) -> str:
+    return f'<rect x="{x}" y="{y}" width="{width}" height="{height}" fill="{fill}"/>'
+
+
+def _line(path: str, stroke: str = INK, width: int = 4, dash: str | None = None) -> str:
+    dashed = f' stroke-dasharray="{dash}"' if dash else ""
+    return f'<path d="{path}" stroke="{stroke}" stroke-width="{width}" fill="none"{dashed}/>'
+
+
+def glyph(name: str) -> str:
+    """Return one deliberately small, crisp capability mark."""
+    marks = {
+        "align": _line("M0 18H72M0 42H72", MUTED, 3) + _rect(12, 13, 20, 10) + _rect(38, 37, 20, 10, ACCENT),
+        "render": _line("M0 8H66V52H0Z", MUTED, 3) + _line("M12 20H54M12 30H42M12 40H48", INK, 4),
+        "diversity": "".join(
+            _rect(index * 18, 46 - height, 10, height, color)
+            for index, (height, color) in enumerate(((14, MUTED), (30, INK), (20, DIM), (42, ACCENT), (25, INK)))
+        ),
+        "cluster": (
+            '<circle cx="15" cy="18" r="7" fill="#F3EFE7"/>'
+            '<circle cx="34" cy="12" r="5" fill="#969087"/>'
+            '<circle cx="26" cy="34" r="6" fill="#D97757"/>'
+            '<circle cx="68" cy="38" r="7" fill="#F3EFE7"/>'
+            '<circle cx="84" cy="27" r="5" fill="#5A5650"/>'
+        ),
+        "construct": _rect(0, 21, 26, 16, MUTED)
+        + _rect(32, 21, 42, 16, ACCENT)
+        + _rect(80, 21, 24, 16)
+        + _line("M26 29H32M74 29H80", DIM, 3),
+        "contracts": _line("M0 12H40V46H0ZM62 12H102V46H62Z", MUTED, 3) + _line("M34 29H68", ACCENT, 5),
+        "optimize": _line("M0 8H102L72 30V50H30V30Z", MUTED, 3) + _rect(45, 39, 12, 12, ACCENT),
+        "generate": _line("M0 29H24M24 29L48 10M24 29L48 29M24 29L48 48", MUTED, 3)
+        + _line("M48 10H92M48 29H102M48 48H82", INK, 4),
+        "test": _line("M0 12H42V50H0ZM60 12H102V50H60Z", MUTED, 3)
+        + _line("M9 31L18 40L34 20M69 31L78 40L94 20", ACCENT, 4),
+        "fold": _line("M0 45C14 45 14 10 32 10C50 10 50 45 66 45C82 45 82 20 98 20", INK, 4)
+        + _rect(29, 7, 6, 6, ACCENT),
+        "infer": _line("M0 28H30M30 28L48 10M30 28H54M30 28L48 46", MUTED, 3)
+        + _rect(62, 9, 34, 8)
+        + _rect(62, 24, 48, 8, ACCENT)
+        + _rect(62, 39, 26, 8, MUTED),
+        "latent": _line("M0 49L28 9L55 49", DIM, 3)
+        + '<circle cx="13" cy="34" r="5" fill="#F3EFE7"/>'
+        + '<circle cx="33" cy="27" r="5" fill="#D97757"/>'
+        + '<circle cx="47" cy="41" r="4" fill="#969087"/>'
+        + _line("M70 49L98 9L125 49", DIM, 3),
+        "shuffle": _line("M0 12H24C48 12 48 46 72 46H104", MUTED, 3)
+        + _line("M0 46H24C48 46 48 12 72 12H104", ACCENT, 3),
+        "factor": _rect(0, 8, 44, 44, MUTED)
+        + _rect(8, 16, 10, 10, INK)
+        + _rect(26, 34, 10, 10, ACCENT)
+        + _line("M56 30H72", DIM, 3)
+        + _rect(82, 8, 10, 44, INK)
+        + _rect(102, 8, 10, 44, ACCENT),
+        "notify": _line("M0 33H18L28 12L42 48L54 24L68 33H106", INK, 4) + _rect(102, 29, 8, 8, ACCENT),
+        "select": _line("M0 45L25 34L48 38L74 17L100 8", MUTED, 3)
+        + '<circle cx="74" cy="17" r="7" fill="#D97757"/>'
+        + _line("M92 8H108V24", INK, 3),
+        "route": _line("M0 28H26M26 28L50 10M26 28L50 46M50 10H102M50 46H84", INK, 3) + _rect(96, 6, 10, 8, ACCENT),
+        "permute": _line("M0 14H104M0 30H104M0 46H104", DIM, 3)
+        + _rect(22, 9, 18, 10)
+        + _rect(48, 25, 18, 10, ACCENT)
+        + _rect(74, 41, 18, 10, MUTED),
+        "study": _line("M0 10H42V48H0ZM58 10H100V48H58Z", MUTED, 3)
+        + _rect(8, 19, 26, 5)
+        + _rect(66, 19, 26, 5, ACCENT)
+        + _rect(8, 31, 18, 5, DIM)
+        + _rect(66, 31, 22, 5),
+        "knockdown": _rect(0, 8, 10, 42)
+        + _rect(22, 19, 10, 31, MUTED)
+        + _rect(44, 30, 10, 20, ACCENT)
+        + _line("M70 8V50M62 42L70 50L78 42", INK, 4),
+        "thread": _line("M0 16C20 16 20 44 40 44S60 16 80 16S100 44 120 44", INK, 4)
+        + _rect(37, 39, 7, 10, ACCENT)
+        + _rect(77, 11, 7, 10, MUTED),
+        "records": _line("M0 8H88V22H0ZM0 27H104V41H0ZM0 46H76V60H0Z", MUTED, 3) + _rect(92, 10, 8, 8, ACCENT),
+    }
+    try:
+        return marks[name]
+    except KeyError as error:
+        raise ValueError(f"Unknown banner glyph: {name}") from error

--- a/src/dnadesign/devtools/docs/banners/render.py
+++ b/src/dnadesign/devtools/docs/banners/render.py
@@ -41,10 +41,17 @@ def _resolve_output_path(root: Path, relative_path: str) -> Path:
     if declared_path.is_absolute():
         raise ValueError(f"Banner output path escapes repository root: {relative_path}")
     candidate = root
-    for component in declared_path.parts:
+    components = declared_path.parts
+    for index, component in enumerate(components):
         candidate /= component
         if candidate.is_symlink():
             raise ValueError(f"Banner output path contains a symlink component: {relative_path}")
+        if not candidate.exists():
+            continue
+        if index < len(components) - 1 and not candidate.is_dir():
+            raise ValueError(f"Banner output parent component is not a directory: {relative_path}")
+        if index == len(components) - 1 and not candidate.is_file():
+            raise ValueError(f"Banner output is not a regular file: {relative_path}")
     output_path = (root / declared_path).resolve()
     try:
         output_path.relative_to(root)

--- a/src/dnadesign/devtools/docs/banners/render.py
+++ b/src/dnadesign/devtools/docs/banners/render.py
@@ -40,6 +40,11 @@ def _resolve_output_path(root: Path, relative_path: str) -> Path:
     declared_path = Path(relative_path)
     if declared_path.is_absolute():
         raise ValueError(f"Banner output path escapes repository root: {relative_path}")
+    candidate = root
+    for component in declared_path.parts:
+        candidate /= component
+        if candidate.is_symlink():
+            raise ValueError(f"Banner output path contains a symlink component: {relative_path}")
     output_path = (root / declared_path).resolve()
     try:
         output_path.relative_to(root)

--- a/src/dnadesign/devtools/docs/banners/render.py
+++ b/src/dnadesign/devtools/docs/banners/render.py
@@ -11,6 +11,7 @@ Module Author(s): Eric J. South
 
 from __future__ import annotations
 
+import tomllib
 from pathlib import Path
 
 from .catalog import BANNERS, REPOSITORY_BANNER_PATH, BannerSpec
@@ -18,6 +19,33 @@ from .glyphs import ACCENT, DIM, INK, MUTED, glyph
 
 BACKGROUND = "#1E1D1A"
 FONT_STACK = "Menlo, Monaco, Consolas, monospace"
+
+
+def _resolve_repo_root(repo_root: Path) -> Path:
+    root = repo_root.expanduser().resolve()
+    pyproject_path = root / "pyproject.toml"
+    package_marker = root / "src" / "dnadesign" / "__init__.py"
+    if not pyproject_path.is_file() or not package_marker.is_file():
+        raise ValueError(f"Not a dnadesign repository root: {root}")
+    try:
+        project_name = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))["project"]["name"]
+    except (KeyError, OSError, tomllib.TOMLDecodeError) as error:
+        raise ValueError(f"Not a dnadesign repository root: {root}") from error
+    if project_name != "dnadesign":
+        raise ValueError(f"Not a dnadesign repository root: {root}")
+    return root
+
+
+def _resolve_output_path(root: Path, relative_path: str) -> Path:
+    declared_path = Path(relative_path)
+    if declared_path.is_absolute():
+        raise ValueError(f"Banner output path escapes repository root: {relative_path}")
+    output_path = (root / declared_path).resolve()
+    try:
+        output_path.relative_to(root)
+    except ValueError as error:
+        raise ValueError(f"Banner output path escapes repository root: {relative_path}") from error
+    return output_path
 
 
 def repository_svg() -> str:
@@ -85,9 +113,16 @@ def tool_svg(spec: BannerSpec) -> str:
 
 
 def expected_banners(repo_root: Path) -> dict[Path, str]:
-    root = repo_root.resolve()
-    expected = {root / REPOSITORY_BANNER_PATH: repository_svg()}
-    expected.update({root / spec.path: tool_svg(spec) for spec in BANNERS})
+    root = _resolve_repo_root(repo_root)
+    declarations = ((REPOSITORY_BANNER_PATH, repository_svg()),) + tuple(
+        (spec.path, tool_svg(spec)) for spec in BANNERS
+    )
+    expected: dict[Path, str] = {}
+    for relative_path, content in declarations:
+        output_path = _resolve_output_path(root, relative_path)
+        if output_path in expected:
+            raise ValueError(f"Duplicate banner output path: {relative_path}")
+        expected[output_path] = content
     return expected
 
 
@@ -101,8 +136,9 @@ def render_banners(repo_root: Path) -> tuple[Path, ...]:
 
 
 def check_banners(repo_root: Path) -> tuple[Path, ...]:
+    root = _resolve_repo_root(repo_root)
     return tuple(
-        path.relative_to(repo_root.resolve())
-        for path, content in expected_banners(repo_root).items()
+        path.relative_to(root)
+        for path, content in expected_banners(root).items()
         if not path.exists() or path.read_text(encoding="utf-8") != content
     )

--- a/src/dnadesign/devtools/docs/banners/render.py
+++ b/src/dnadesign/devtools/docs/banners/render.py
@@ -1,0 +1,108 @@
+"""
+--------------------------------------------------------------------------------
+dnadesign
+src/dnadesign/devtools/docs/banners/render.py
+
+Renders repository and tool banners from their checked source catalog.
+
+Module Author(s): Eric J. South
+--------------------------------------------------------------------------------
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .catalog import BANNERS, REPOSITORY_BANNER_PATH, BannerSpec
+from .glyphs import ACCENT, DIM, INK, MUTED, glyph
+
+BACKGROUND = "#1E1D1A"
+FONT_STACK = "Menlo, Monaco, Consolas, monospace"
+
+
+def repository_svg() -> str:
+    return f'''<svg width="1280" height="260" viewBox="0 0 1280 260" fill="none"
+  xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc"
+  shape-rendering="crispEdges">
+  <title id="title">dnadesign sequence-design toolkit</title>
+  <desc id="desc">A dark, quiet path through sequence design, construction, modeling, and analysis.</desc>
+  <rect width="1280" height="260" fill="{BACKGROUND}"/>
+  <g font-family="{FONT_STACK}">
+    <text x="52" y="58" fill="{MUTED}" font-size="12" letter-spacing="1.4">MODULAR SEQUENCE TOOLKIT</text>
+    <text x="48" y="151" fill="{INK}" font-size="72" font-weight="700" letter-spacing="-2">dnadesign</text>
+    <rect x="52" y="177" width="40" height="6" fill="{ACCENT}"/>
+  </g>
+  <path d="M432 46V214" stroke="#3F3C37" stroke-width="2"/>
+  <path d="M520 132H1192" stroke="{DIM}" stroke-width="2"/>
+  <g font-family="{FONT_STACK}" font-size="12" font-weight="700" letter-spacing="0.6">
+    <g transform="translate(520 0)">
+      <path d="M0 82H56M0 98H40M0 114H48" stroke="{INK}" stroke-width="6"/>
+      <text x="0" y="174" fill="{INK}">DESIGN</text>
+    </g>
+    <g transform="translate(696 0)">
+      <rect x="0" y="88" width="22" height="22" fill="{INK}"/>
+      <rect x="30" y="88" width="38" height="22" fill="{ACCENT}"/>
+      <rect x="76" y="88" width="20" height="22" fill="{INK}"/>
+      <text x="0" y="174" fill="{INK}">ASSEMBLE</text>
+    </g>
+    <g transform="translate(892 0)">
+      <path d="M0 110L22 84L44 104L68 72" stroke="{INK}" stroke-width="5" fill="none"/>
+      <rect x="64" y="68" width="8" height="8" fill="{ACCENT}"/>
+      <text x="0" y="174" fill="{INK}">MODEL</text>
+    </g>
+    <g transform="translate(1064 0)">
+      <rect x="0" y="104" width="12" height="12" fill="{MUTED}"/>
+      <rect x="22" y="90" width="12" height="26" fill="{INK}"/>
+      <rect x="44" y="76" width="12" height="40" fill="{ACCENT}"/>
+      <text x="0" y="174" fill="{INK}">ANALYZE</text>
+    </g>
+  </g>
+</svg>
+'''
+
+
+def tool_svg(spec: BannerSpec) -> str:
+    title_id = f"{spec.name}-banner-title"
+    description_id = f"{spec.name}-banner-description"
+    return f'''<svg width="1200" height="180" viewBox="0 0 1200 180" fill="none"
+  xmlns="http://www.w3.org/2000/svg" role="img"
+  aria-labelledby="{title_id} {description_id}" shape-rendering="crispEdges">
+  <title id="{title_id}">{spec.name}: {spec.capability.lower()}</title>
+  <desc id="{description_id}">{spec.description}</desc>
+  <rect width="1200" height="180" fill="{BACKGROUND}"/>
+  <g font-family="{FONT_STACK}">
+    <text x="48" y="78" fill="{INK}" font-size="42" font-weight="700" letter-spacing="-1">{spec.name}</text>
+    <text x="50" y="114" fill="{MUTED}" font-size="12" font-weight="700" letter-spacing="1.2">{spec.capability}</text>
+    <rect x="50" y="132" width="32" height="5" fill="{ACCENT}"/>
+  </g>
+  <path d="M510 34V146" stroke="#3F3C37" stroke-width="2"/>
+  <path d="M584 124H1144" stroke="{DIM}" stroke-width="2"/>
+  <g transform="translate(720 48)">
+    {glyph(spec.glyph)}
+  </g>
+</svg>
+'''
+
+
+def expected_banners(repo_root: Path) -> dict[Path, str]:
+    root = repo_root.resolve()
+    expected = {root / REPOSITORY_BANNER_PATH: repository_svg()}
+    expected.update({root / spec.path: tool_svg(spec) for spec in BANNERS})
+    return expected
+
+
+def render_banners(repo_root: Path) -> tuple[Path, ...]:
+    rendered: list[Path] = []
+    for path, content in expected_banners(repo_root).items():
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+        rendered.append(path)
+    return tuple(rendered)
+
+
+def check_banners(repo_root: Path) -> tuple[Path, ...]:
+    return tuple(
+        path.relative_to(repo_root.resolve())
+        for path, content in expected_banners(repo_root).items()
+        if not path.exists() or path.read_text(encoding="utf-8") != content
+    )

--- a/src/dnadesign/devtools/docs/checks.py
+++ b/src/dnadesign/devtools/docs/checks.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import argparse
 import datetime as dt
+import os
 import re
 import subprocess
 from collections.abc import Mapping
@@ -22,6 +23,7 @@ from urllib.parse import urlparse
 import yaml
 
 from dnadesign.devtools.ci.changes import discover_repo_tools
+from dnadesign.devtools.docs.banners.catalog import BANNERS
 from dnadesign.devtools.docs.banners.render import check_banners
 from dnadesign.devtools.docs.freshness import collect_changed_doc_dates, verification_change_issue
 from dnadesign.devtools.docs.metadata import LAST_VERIFIED_PATTERN, OWNER_PATTERN, SOR_MARKDOWN_FILES
@@ -2072,6 +2074,61 @@ def _find_public_interface_doc_contract_issues(repo_root: Path) -> list[str]:
     return issues
 
 
+def _resolve_readme_banner_reference(*, repo_root: Path, readme_path: Path, target_rel: str) -> tuple[Path, Path]:
+    resolved_repo_root = repo_root.resolve()
+    readme_relative = readme_path.relative_to(repo_root)
+    declared_relative = Path(os.path.normpath(str(readme_relative.parent / target_rel)))
+    if declared_relative.is_absolute() or declared_relative.parts[:1] == ("..",):
+        raise ValueError(target_rel)
+
+    target_path = (resolved_repo_root / declared_relative).resolve()
+    try:
+        target_path.relative_to(resolved_repo_root)
+    except ValueError as error:
+        raise ValueError(target_rel) from error
+    return declared_relative, target_path
+
+
+def _find_banner_catalog_inventory_issues(repo_root: Path) -> list[str]:
+    banner_source = repo_root / "src" / "dnadesign" / "devtools" / "docs" / "banners"
+    if not banner_source.is_dir():
+        return []
+
+    referenced_paths: set[str] = set()
+    for readme_path in sorted((repo_root / "src" / "dnadesign").rglob("README.md")):
+        top_block = "\n".join(readme_path.read_text(encoding="utf-8").splitlines()[:25])
+        banner_match = TOOL_README_BANNER_PATTERN.search(top_block)
+        if banner_match is None:
+            continue
+        link = banner_match.group("link").strip().split()[0]
+        parsed = urlparse(link)
+        if parsed.scheme or link.startswith("mailto:") or not link.lower().endswith(".svg"):
+            continue
+        target_rel = link.split("#", 1)[0].strip()
+        if not target_rel:
+            continue
+        try:
+            declared_relative, _target_path = _resolve_readme_banner_reference(
+                repo_root=repo_root,
+                readme_path=readme_path,
+                target_rel=target_rel,
+            )
+        except ValueError:
+            continue
+        referenced_paths.add(declared_relative.as_posix())
+
+    catalog_paths = {Path(spec.path).as_posix() for spec in BANNERS}
+    issues = [
+        f"{path}: tool README banner path is not declared in the banner catalog."
+        for path in sorted(referenced_paths - catalog_paths)
+    ]
+    issues.extend(
+        f"{path}: banner catalog path is not referenced by a tool README."
+        for path in sorted(catalog_paths - referenced_paths)
+    )
+    return issues
+
+
 def _find_tool_readme_banner_issues(repo_root: Path) -> list[str]:
     src_root = repo_root / "src" / "dnadesign"
     if not src_root.exists():
@@ -2101,7 +2158,15 @@ def _find_tool_readme_banner_issues(repo_root: Path) -> list[str]:
             issues.append(f"{readme_path}: banner link must include a relative asset path.")
             continue
 
-        target_path = (readme_path.parent / target_rel).resolve()
+        try:
+            _declared_relative, target_path = _resolve_readme_banner_reference(
+                repo_root=repo_root,
+                readme_path=readme_path,
+                target_rel=target_rel,
+            )
+        except ValueError:
+            issues.append(f"{readme_path}: banner asset target escapes the repository: {target_rel}.")
+            continue
         if not target_path.exists():
             issues.append(f"{readme_path}: banner asset target does not exist: {target_rel}.")
             continue
@@ -2116,6 +2181,7 @@ def _find_tool_readme_banner_issues(repo_root: Path) -> list[str]:
         if "placeholder" in top_block.lower():
             issues.append(f"{readme_path}: banner copy must not use placeholder wording.")
 
+    issues.extend(_find_banner_catalog_inventory_issues(repo_root))
     return issues
 
 

--- a/src/dnadesign/devtools/docs/checks.py
+++ b/src/dnadesign/devtools/docs/checks.py
@@ -22,6 +22,7 @@ from urllib.parse import urlparse
 import yaml
 
 from dnadesign.devtools.ci.changes import discover_repo_tools
+from dnadesign.devtools.docs.banners.render import check_banners
 from dnadesign.devtools.docs.freshness import collect_changed_doc_dates, verification_change_issue
 from dnadesign.devtools.docs.metadata import LAST_VERIFIED_PATTERN, OWNER_PATTERN, SOR_MARKDOWN_FILES
 from dnadesign.ops.catalog import (
@@ -2118,6 +2119,21 @@ def _find_tool_readme_banner_issues(repo_root: Path) -> list[str]:
     return issues
 
 
+def _find_banner_source_drift_issues(repo_root: Path) -> list[str]:
+    banner_source = repo_root / "src" / "dnadesign" / "devtools" / "docs" / "banners"
+    if not banner_source.is_dir():
+        return []
+    try:
+        stale_paths = check_banners(repo_root)
+    except ValueError as error:
+        return [str(error)]
+    return [
+        f"{relative_path}: checked-in banner differs from its deterministic source; "
+        "run 'uv run python -m dnadesign.devtools.docs.banners --repo-root .'."
+        for relative_path in stale_paths
+    ]
+
+
 def _find_tool_readme_structure_issues(repo_root: Path) -> list[str]:
     src_root = repo_root / "src" / "dnadesign"
     if not src_root.exists():
@@ -2793,6 +2809,13 @@ def main(argv: list[str] | None = None) -> int:
     if study_execution_source_drift_issues:
         print("Study execution-source docs check failed:")
         for issue in study_execution_source_drift_issues:
+            print(f" - {issue}")
+        return 1
+
+    banner_source_drift_issues = _find_banner_source_drift_issues(repo_root)
+    if banner_source_drift_issues:
+        print("Banner source drift check failed:")
+        for issue in banner_source_drift_issues:
             print(f" - {issue}")
         return 1
 

--- a/src/dnadesign/devtools/docs/checks.py
+++ b/src/dnadesign/devtools/docs/checks.py
@@ -17,7 +17,7 @@ import re
 import subprocess
 from collections.abc import Mapping
 from pathlib import Path
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import urlparse
 
 import yaml
 
@@ -40,7 +40,7 @@ from dnadesign.ops.status import list_status_kind_specs_for_repo
 
 LINK_PATTERN = re.compile(r"\[[^\]]+\]\(([^)]+)\)")
 README_TOOL_LINK_PATTERN = re.compile(r"\[\*\*(?P<tool>[a-z0-9_-]+)\*\*\]\((?P<link>[^)]+)\)")
-README_COVERAGE_LINK_PATTERN = re.compile(r"\[[^\]]+\]\((?P<link>[^)]+)\)")
+README_TOOL_COMPONENT_COVERAGE_PATTERN = re.compile(r"codecov\.io/[^\s)]+[?&]component=", flags=re.IGNORECASE)
 TOOL_README_BANNER_PATTERN = re.compile(r"!\[[^\]]*banner[^\]]*\]\((?P<link>[^)]+)\)", flags=re.IGNORECASE)
 TOOL_README_BANNER_DIMENSION_PATTERN = re.compile(
     r"<svg[^>]*\bwidth=\"1200\"[^>]*\bheight=\"180\"[^>]*\bviewBox=\"0 0 1200 180\"",
@@ -649,20 +649,6 @@ def _normalize_relative_markdown_path(value: str) -> str:
     return str(Path(value).as_posix().lstrip("./"))
 
 
-def _is_valid_codecov_component_link(*, tool_name: str, link: str) -> bool:
-    parsed = urlparse(link)
-    if parsed.scheme != "https":
-        return False
-    if parsed.netloc not in {"codecov.io", "www.codecov.io", "app.codecov.io"}:
-        return False
-    if not parsed.path.startswith("/gh/"):
-        return False
-    component_values = parse_qs(parsed.query).get("component")
-    if component_values is None:
-        return False
-    return any(value.strip() == tool_name for value in component_values)
-
-
 def _find_readme_tool_catalog_issues(repo_root: Path) -> list[str]:
     readme_path = repo_root / "README.md"
     src_root = repo_root / "src" / "dnadesign"
@@ -679,14 +665,16 @@ def _find_readme_tool_catalog_issues(repo_root: Path) -> list[str]:
         return [f"{readme_path}: section '## Available tools' must include a markdown tool table."]
 
     issues: list[str] = []
+    available_tools_text = "\n".join(_extract_level2_section_lines(readme_text, "Available tools"))
+    if README_TOOL_COMPONENT_COVERAGE_PATTERN.search(available_tools_text):
+        issues.append(f"{readme_path}: tool catalog must not repeat per-tool Codecov badges or component links.")
     declared_tools: set[str] = set()
     for row in rows:
-        if len(row) < 3:
-            issues.append(f"{readme_path}: tool table rows must include Tool, Description, and Coverage columns.")
+        if len(row) != 2:
+            issues.append(f"{readme_path}: tool table rows must include exactly Tool and Description columns.")
             continue
 
         tool_cell = row[0]
-        coverage_cell = row[2]
         match = README_TOOL_LINK_PATTERN.search(tool_cell)
         if match is None:
             issues.append(f"{readme_path}: tool cell must use [**tool**](src/dnadesign/tool) format ({tool_cell}).")
@@ -709,20 +697,6 @@ def _find_readme_tool_catalog_issues(repo_root: Path) -> list[str]:
         if not tool_readme.exists() or not tool_readme.is_file():
             issues.append(
                 f"{readme_path}: tool '{tool_name}' link target does not exist as a markdown file: {tool_link}."
-            )
-
-        coverage_match = README_COVERAGE_LINK_PATTERN.search(coverage_cell)
-        if coverage_match is None:
-            issues.append(
-                f"{readme_path}: coverage cell for '{tool_name}' must include a markdown link "
-                "to a Codecov component URL."
-            )
-            continue
-        coverage_link = coverage_match.group("link")
-        if not _is_valid_codecov_component_link(tool_name=tool_name, link=coverage_link):
-            issues.append(
-                f"{readme_path}: coverage link for '{tool_name}' must target Codecov with query "
-                f"'component={tool_name}' (found '{coverage_link}')."
             )
 
     missing_tools = sorted(repo_tools - declared_tools)

--- a/src/dnadesign/devtools/tests/docs/test_banner_assets.py
+++ b/src/dnadesign/devtools/tests/docs/test_banner_assets.py
@@ -1,0 +1,55 @@
+"""
+--------------------------------------------------------------------------------
+dnadesign
+src/dnadesign/devtools/tests/docs/test_banner_assets.py
+
+Tests banner inventory, accessibility, SVG validity, and generation drift.
+
+Module Author(s): Eric J. South
+--------------------------------------------------------------------------------
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from xml.etree import ElementTree
+
+from dnadesign.devtools.docs.banners.catalog import BANNERS, REPOSITORY_BANNER_PATH
+from dnadesign.devtools.docs.banners.render import check_banners, expected_banners
+
+
+def test_checked_in_banners_match_their_source() -> None:
+    repo_root = Path(__file__).resolve().parents[5]
+
+    assert check_banners(repo_root) == ()
+
+
+def test_banner_catalog_matches_readme_references() -> None:
+    repo_root = Path(__file__).resolve().parents[5]
+    referenced: set[str] = set()
+    for readme in (repo_root / "src" / "dnadesign").rglob("README.md"):
+        for line in readme.read_text(encoding="utf-8").splitlines()[:5]:
+            if "banner" not in line.lower() or not line.rstrip().endswith(".svg)"):
+                continue
+            link = line.rsplit("(", 1)[1][:-1]
+            referenced.add(str((readme.parent / link).relative_to(repo_root)))
+
+    assert referenced == {spec.path for spec in BANNERS}
+
+
+def test_banners_are_accessible_valid_svg_without_transient_copy() -> None:
+    repo_root = Path(__file__).resolve().parents[5]
+    expected = expected_banners(repo_root)
+
+    assert REPOSITORY_BANNER_PATH in {str(path.relative_to(repo_root)) for path in expected}
+    for path, content in expected.items():
+        root = ElementTree.fromstring(content)
+        namespace = "{http://www.w3.org/2000/svg}"
+        assert root.tag == f"{namespace}svg"
+        assert root.find(f"{namespace}title") is not None
+        assert root.find(f"{namespace}desc") is not None
+        lowered = content.lower()
+        assert "schema v" not in lowered
+        assert "generated on" not in lowered
+        assert "agent" not in lowered
+        assert path.suffix == ".svg"

--- a/src/dnadesign/devtools/tests/docs/test_banner_assets.py
+++ b/src/dnadesign/devtools/tests/docs/test_banner_assets.py
@@ -162,7 +162,36 @@ def test_render_rejects_symlinked_output_parent_without_mutation(tmp_path: Path)
     outside.mkdir()
     (repo_root / "assets").symlink_to(outside, target_is_directory=True)
 
-    with pytest.raises(ValueError, match="escapes repository root"):
+    with pytest.raises(ValueError, match="symlink component"):
         render_banners(repo_root)
 
     assert list(outside.iterdir()) == []
+
+
+def test_render_rejects_in_repo_symlinked_output_parent_without_mutation(tmp_path: Path) -> None:
+    repo_root = tmp_path / "dnadesign"
+    _write_repo_markers(repo_root)
+    alternate_assets = repo_root / "alternate-assets"
+    alternate_assets.mkdir()
+    (repo_root / "assets").symlink_to(alternate_assets, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="symlink component"):
+        render_banners(repo_root)
+
+    assert list(alternate_assets.iterdir()) == []
+
+
+def test_render_rejects_symlinked_output_file_without_mutation(tmp_path: Path) -> None:
+    repo_root = tmp_path / "dnadesign"
+    _write_repo_markers(repo_root)
+    unrelated = repo_root / "unrelated.svg"
+    unrelated.write_text("preserve me", encoding="utf-8")
+    output = repo_root / REPOSITORY_BANNER_PATH
+    output.parent.mkdir(parents=True)
+    output.symlink_to(unrelated)
+
+    with pytest.raises(ValueError, match="symlink component"):
+        render_banners(repo_root)
+
+    assert output.is_symlink()
+    assert unrelated.read_text(encoding="utf-8") == "preserve me"

--- a/src/dnadesign/devtools/tests/docs/test_banner_assets.py
+++ b/src/dnadesign/devtools/tests/docs/test_banner_assets.py
@@ -11,11 +11,21 @@ Module Author(s): Eric J. South
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from xml.etree import ElementTree
 
+import pytest
+
+from dnadesign.devtools.docs.banners import render as banner_render
 from dnadesign.devtools.docs.banners.catalog import BANNERS, REPOSITORY_BANNER_PATH
-from dnadesign.devtools.docs.banners.render import check_banners, expected_banners
+from dnadesign.devtools.docs.banners.render import check_banners, expected_banners, render_banners
+
+
+def _write_repo_markers(repo_root: Path) -> None:
+    (repo_root / "src" / "dnadesign").mkdir(parents=True)
+    (repo_root / "src" / "dnadesign" / "__init__.py").write_text("", encoding="utf-8")
+    (repo_root / "pyproject.toml").write_text('[project]\nname = "dnadesign"\n', encoding="utf-8")
 
 
 def test_checked_in_banners_match_their_source() -> None:
@@ -52,4 +62,107 @@ def test_banners_are_accessible_valid_svg_without_transient_copy() -> None:
         assert "schema v" not in lowered
         assert "generated on" not in lowered
         assert "agent" not in lowered
+        assert re.search(r"(?<!/)\b(?:19|20)\d{2}\b", content) is None
+        assert (
+            re.search(
+                r"\b(?:january|february|march|april|may|june|july|august|september|october|november|december)\b",
+                lowered,
+            )
+            is None
+        )
+        assert re.search(r"\b(?:version|release|schema)\b", lowered) is None
+        assert re.search(r"\b(?:version|release|schema)\s*(?:v\s*)?\d+", lowered) is None
+        assert re.search(r"\bv\d+(?:\.\d+)*\b", lowered) is None
+        assert re.search(r"\b(?:stage|step|phase|node)\s*0?\d+\b", lowered) is None
+        assert re.search(r">\s*0[1-9]\s*<", content) is None
         assert path.suffix == ".svg"
+
+
+def test_banners_do_not_place_ornaments_on_horizontal_rails() -> None:
+    repo_root = Path(__file__).resolve().parents[5]
+
+    for content in expected_banners(repo_root).values():
+        rails: list[tuple[float, float, float]] = []
+        ornaments: list[tuple[float, float]] = []
+
+        def collect_geometry(element: ElementTree.Element, offset_x: float = 0, offset_y: float = 0) -> None:
+            transform = element.attrib.get("transform", "")
+            translated = re.fullmatch(r"translate\(([-\d.]+)(?:[ ,]+)([-\d.]+)\)", transform)
+            if translated is not None:
+                offset_x += float(translated.group(1))
+                offset_y += float(translated.group(2))
+
+            tag = element.tag.rsplit("}", 1)[-1]
+            if tag == "path":
+                rail = re.fullmatch(r"M([-\d.]+) ([-\d.]+)H([-\d.]+)", element.attrib.get("d", ""))
+                if rail is not None:
+                    rails.append(
+                        (
+                            offset_x + float(rail.group(1)),
+                            offset_x + float(rail.group(3)),
+                            offset_y + float(rail.group(2)),
+                        )
+                    )
+            elif tag == "rect":
+                ornaments.append(
+                    (
+                        offset_x + float(element.attrib.get("x", 0)) + float(element.attrib["width"]) / 2,
+                        offset_y + float(element.attrib.get("y", 0)) + float(element.attrib["height"]) / 2,
+                    )
+                )
+            elif tag == "circle":
+                ornaments.append(
+                    (
+                        offset_x + float(element.attrib["cx"]),
+                        offset_y + float(element.attrib["cy"]),
+                    )
+                )
+
+            for child in element:
+                collect_geometry(child, offset_x, offset_y)
+
+        collect_geometry(ElementTree.fromstring(content))
+
+        assert all(not (start <= x <= end and y == rail_y) for start, end, rail_y in rails for x, y in ornaments)
+
+
+def test_render_rejects_wrong_repo_root_without_mutation(tmp_path: Path) -> None:
+    wrong_root = tmp_path / "not-dnadesign"
+
+    with pytest.raises(ValueError, match="dnadesign repository root"):
+        render_banners(wrong_root)
+
+    assert not wrong_root.exists()
+
+
+def test_render_preflights_every_output_before_mutation(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    repo_root = tmp_path / "dnadesign"
+    _write_repo_markers(repo_root)
+    outside = tmp_path / "escaped.svg"
+    malicious = banner_render.BannerSpec(
+        path="../escaped.svg",
+        name="escaped",
+        capability="ESCAPE",
+        description="Must not be written.",
+        glyph="align",
+    )
+    monkeypatch.setattr(banner_render, "BANNERS", (*BANNERS, malicious))
+
+    with pytest.raises(ValueError, match="escapes repository root"):
+        render_banners(repo_root)
+
+    assert not outside.exists()
+    assert not (repo_root / REPOSITORY_BANNER_PATH).exists()
+
+
+def test_render_rejects_symlinked_output_parent_without_mutation(tmp_path: Path) -> None:
+    repo_root = tmp_path / "dnadesign"
+    _write_repo_markers(repo_root)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (repo_root / "assets").symlink_to(outside, target_is_directory=True)
+
+    with pytest.raises(ValueError, match="escapes repository root"):
+        render_banners(repo_root)
+
+    assert list(outside.iterdir()) == []

--- a/src/dnadesign/devtools/tests/docs/test_banner_assets.py
+++ b/src/dnadesign/devtools/tests/docs/test_banner_assets.py
@@ -155,6 +155,39 @@ def test_render_preflights_every_output_before_mutation(tmp_path: Path, monkeypa
     assert not (repo_root / REPOSITORY_BANNER_PATH).exists()
 
 
+def test_render_rejects_non_directory_output_parent_without_partial_mutation(tmp_path: Path) -> None:
+    repo_root = tmp_path / "dnadesign"
+    _write_repo_markers(repo_root)
+    repository_banner = repo_root / REPOSITORY_BANNER_PATH
+    repository_banner.parent.mkdir(parents=True)
+    repository_banner.write_text("preserve me", encoding="utf-8")
+    blocking_parent = repo_root / "src" / "dnadesign" / "aligner" / "assets"
+    blocking_parent.parent.mkdir(parents=True)
+    blocking_parent.write_text("blocking file", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="parent component is not a directory"):
+        render_banners(repo_root)
+
+    assert repository_banner.read_text(encoding="utf-8") == "preserve me"
+    assert blocking_parent.read_text(encoding="utf-8") == "blocking file"
+
+
+def test_render_rejects_non_file_output_without_partial_mutation(tmp_path: Path) -> None:
+    repo_root = tmp_path / "dnadesign"
+    _write_repo_markers(repo_root)
+    repository_banner = repo_root / REPOSITORY_BANNER_PATH
+    repository_banner.parent.mkdir(parents=True)
+    repository_banner.write_text("preserve me", encoding="utf-8")
+    blocking_output = repo_root / "src" / "dnadesign" / "aligner" / "assets" / "aligner-banner.svg"
+    blocking_output.mkdir(parents=True)
+
+    with pytest.raises(ValueError, match="output is not a regular file"):
+        render_banners(repo_root)
+
+    assert repository_banner.read_text(encoding="utf-8") == "preserve me"
+    assert blocking_output.is_dir()
+
+
 def test_render_rejects_symlinked_output_parent_without_mutation(tmp_path: Path) -> None:
     repo_root = tmp_path / "dnadesign"
     _write_repo_markers(repo_root)

--- a/src/dnadesign/devtools/tests/docs/test_checks.py
+++ b/src/dnadesign/devtools/tests/docs/test_checks.py
@@ -19,6 +19,7 @@ import pytest
 import yaml
 
 from dnadesign.devtools.docs import checks as docs_checks
+from dnadesign.devtools.docs.banners.catalog import BannerSpec
 from dnadesign.devtools.docs.checks import (
     _find_active_shared_usr_dataset_id_issues,
     _find_agents_path_reference_issues,
@@ -850,6 +851,40 @@ def test_tool_readme_banner_check_accepts_existing_local_svg_banner(tmp_path: Pa
     issues = _find_tool_readme_banner_issues(tmp_path)
 
     assert issues == []
+
+
+def test_tool_readme_banner_check_rejects_uncatalogued_and_orphaned_paths(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write(
+        tmp_path / "src" / "dnadesign" / "alpha" / "README.md",
+        "![Alpha banner](assets/alternate-banner.svg)\n\nCompact subtitle.\n",
+    )
+    _write(
+        tmp_path / "src" / "dnadesign" / "alpha" / "assets" / "alternate-banner.svg",
+        VALID_TOOL_BANNER_SVG,
+    )
+    (tmp_path / "src" / "dnadesign" / "devtools" / "docs" / "banners").mkdir(parents=True)
+    catalog_path = "src/dnadesign/alpha/assets/alpha-banner.svg"
+    monkeypatch.setattr(
+        docs_checks,
+        "BANNERS",
+        (
+            BannerSpec(
+                path=catalog_path,
+                name="alpha",
+                capability="TEST ALPHA",
+                description="Test alpha banners.",
+                glyph="align",
+            ),
+        ),
+        raising=False,
+    )
+
+    issues = _find_tool_readme_banner_issues(tmp_path)
+
+    assert any("alternate-banner.svg" in issue and "not declared in the banner catalog" in issue for issue in issues)
+    assert any(catalog_path in issue and "not referenced by a tool README" in issue for issue in issues)
 
 
 def test_tool_readme_banner_check_rejects_nonstandard_banner_dimensions(tmp_path: Path) -> None:

--- a/src/dnadesign/devtools/tests/docs/test_checks.py
+++ b/src/dnadesign/devtools/tests/docs/test_checks.py
@@ -2159,10 +2159,9 @@ def test_main_fails_when_readme_tool_catalog_missing_repo_tool(tmp_path: Path) -
                 "",
                 "## Available tools",
                 "",
-                "| Tool | Description | Coverage |",
-                "| --- | --- | --- |",
-                "| [**aligner**](src/dnadesign/aligner/README.md) | alignment | "
-                "[Codecov](https://codecov.io/gh/example/repo?component=aligner) |",
+                "| Tool | Description |",
+                "| --- | --- |",
+                "| [**aligner**](src/dnadesign/aligner/README.md) | alignment |",
                 "",
             ]
         ),
@@ -2187,10 +2186,9 @@ def test_readme_tool_catalog_does_not_require_studies_row(tmp_path: Path) -> Non
                 "",
                 "## Available tools",
                 "",
-                "| Tool | Description | Coverage |",
-                "| --- | --- | --- |",
-                "| [**aligner**](src/dnadesign/aligner/README.md) | alignment | "
-                "[Codecov](https://codecov.io/gh/example/repo?component=aligner) |",
+                "| Tool | Description |",
+                "| --- | --- |",
+                "| [**aligner**](src/dnadesign/aligner/README.md) | alignment |",
                 "",
             ]
         ),
@@ -2217,8 +2215,8 @@ def test_main_fails_when_readme_tool_catalog_row_has_too_few_columns(tmp_path: P
                 "",
                 "## Available tools",
                 "",
-                "| Tool | Description | Coverage |",
-                "| --- | --- | --- |",
+                "| Tool | Description |",
+                "| --- | --- |",
                 "| [**aligner**](src/dnadesign/aligner/README.md) |",
                 "",
             ]
@@ -2229,7 +2227,7 @@ def test_main_fails_when_readme_tool_catalog_row_has_too_few_columns(tmp_path: P
     assert rc == 1
 
 
-def test_main_fails_when_readme_tool_catalog_missing_coverage_column(tmp_path: Path) -> None:
+def test_main_fails_when_readme_tool_catalog_has_an_extra_column(tmp_path: Path) -> None:
     today = dt.date.today().isoformat()
     _write(tmp_path / "docs" / "index.md", "## Index\n")
     _write(
@@ -2247,9 +2245,9 @@ def test_main_fails_when_readme_tool_catalog_missing_coverage_column(tmp_path: P
                 "",
                 "## Available tools",
                 "",
-                "| Tool | Description |",
-                "| --- | --- |",
-                "| [**aligner**](src/dnadesign/aligner/README.md) | alignment |",
+                "| Tool | Description | Internal status |",
+                "| --- | --- | --- |",
+                "| [**aligner**](src/dnadesign/aligner/README.md) | alignment | covered |",
                 "",
             ]
         ),
@@ -2257,6 +2255,30 @@ def test_main_fails_when_readme_tool_catalog_missing_coverage_column(tmp_path: P
 
     rc = main(["--repo-root", str(tmp_path)])
     assert rc == 1
+
+
+def test_readme_tool_catalog_rejects_component_coverage_badges(tmp_path: Path) -> None:
+    _write(tmp_path / "src" / "dnadesign" / "aligner" / "__init__.py", "")
+    _write(tmp_path / "src" / "dnadesign" / "aligner" / "README.md", "# aligner\n")
+    _write(
+        tmp_path / "README.md",
+        "\n".join(
+            [
+                "## Available tools",
+                "",
+                "| Tool | Description |",
+                "| --- | --- |",
+                "| [**aligner**](src/dnadesign/aligner/README.md) | "
+                "[![coverage](https://codecov.io/gh/example/repo/graph/badge.svg?component=aligner)]"
+                "(https://codecov.io/gh/example/repo?component=aligner) |",
+                "",
+            ]
+        ),
+    )
+
+    assert _find_readme_tool_catalog_issues(tmp_path) == [
+        f"{tmp_path / 'README.md'}: tool catalog must not repeat per-tool Codecov badges or component links."
+    ]
 
 
 def test_main_passes_when_readme_tool_catalog_matches_repo_tools(tmp_path: Path) -> None:
@@ -2300,12 +2322,10 @@ def test_main_passes_when_readme_tool_catalog_matches_repo_tools(tmp_path: Path)
                 "",
                 "## Available tools",
                 "",
-                "| Tool | Description | Coverage |",
-                "| --- | --- | --- |",
-                "| [**aligner**](src/dnadesign/aligner/README.md) | alignment | "
-                "[Codecov](https://codecov.io/gh/example/repo?component=aligner) |",
-                "| [**notify**](src/dnadesign/notify/README.md) | notifications | "
-                "[Codecov](https://codecov.io/gh/example/repo?component=notify) |",
+                "| Tool | Description |",
+                "| --- | --- |",
+                "| [**aligner**](src/dnadesign/aligner/README.md) | alignment |",
+                "| [**notify**](src/dnadesign/notify/README.md) | notifications |",
                 "",
             ]
         ),
@@ -2356,10 +2376,9 @@ def test_main_fails_when_readme_tool_link_does_not_match_expected_path(tmp_path:
                 "",
                 "## Available tools",
                 "",
-                "| Tool | Description | Coverage |",
-                "| --- | --- | --- |",
-                "| [**aligner**](src/dnadesign/aligner/docs) | alignment | "
-                "[Codecov](https://codecov.io/gh/example/repo?component=aligner) |",
+                "| Tool | Description |",
+                "| --- | --- |",
+                "| [**aligner**](src/dnadesign/aligner/docs) | alignment |",
                 "",
             ]
         ),
@@ -2384,39 +2403,9 @@ def test_main_fails_when_readme_tool_link_target_directory_is_missing(tmp_path: 
                 "",
                 "## Available tools",
                 "",
-                "| Tool | Description | Coverage |",
-                "| --- | --- | --- |",
-                "| [**aligner**](src/dnadesign/aligner/README.md) | alignment | "
-                "[Codecov](https://codecov.io/gh/example/repo?component=aligner) |",
-                "",
-            ]
-        ),
-    )
-
-    rc = main(["--repo-root", str(tmp_path)])
-    assert rc == 1
-
-
-def test_main_fails_when_readme_tool_coverage_link_component_mismatches_tool(tmp_path: Path) -> None:
-    today = dt.date.today().isoformat()
-    _write(tmp_path / "docs" / "index.md", "## Index\n")
-    _write(
-        tmp_path / "ARCHITECTURE.md",
-        f"# ARCHITECTURE\n\n**Type:** system-of-record\n**Owner:** maintainers\n**Last verified:** {today}\n",
-    )
-    _write(tmp_path / "src" / "dnadesign" / "aligner" / "__init__.py", "")
-    _write(
-        tmp_path / "README.md",
-        "\n".join(
-            [
-                "# dnadesign",
-                "",
-                "## Available tools",
-                "",
-                "| Tool | Description | Coverage |",
-                "| --- | --- | --- |",
-                "| [**aligner**](src/dnadesign/aligner/README.md) | alignment | "
-                "[Codecov](https://codecov.io/gh/example/repo?component=notify) |",
+                "| Tool | Description |",
+                "| --- | --- |",
+                "| [**aligner**](src/dnadesign/aligner/README.md) | alignment |",
                 "",
             ]
         ),
@@ -2465,12 +2454,10 @@ def test_main_fails_when_codecov_components_do_not_cover_repo_tools(tmp_path: Pa
                 "",
                 "## Available tools",
                 "",
-                "| Tool | Description | Coverage |",
-                "| --- | --- | --- |",
-                "| [**aligner**](src/dnadesign/aligner/README.md) | alignment | "
-                "[Codecov](https://codecov.io/gh/example/repo?component=aligner) |",
-                "| [**notify**](src/dnadesign/notify/README.md) | notifications | "
-                "[Codecov](https://codecov.io/gh/example/repo?component=notify) |",
+                "| Tool | Description |",
+                "| --- | --- |",
+                "| [**aligner**](src/dnadesign/aligner/README.md) | alignment |",
+                "| [**notify**](src/dnadesign/notify/README.md) | notifications |",
                 "",
             ]
         ),
@@ -2517,10 +2504,9 @@ def test_main_fails_when_codecov_component_default_rules_are_missing(tmp_path: P
                 "",
                 "## Available tools",
                 "",
-                "| Tool | Description | Coverage |",
-                "| --- | --- | --- |",
-                "| [**aligner**](src/dnadesign/aligner/README.md) | alignment | "
-                "[Codecov](https://codecov.io/gh/example/repo?component=aligner) |",
+                "| Tool | Description |",
+                "| --- | --- |",
+                "| [**aligner**](src/dnadesign/aligner/README.md) | alignment |",
                 "",
             ]
         ),
@@ -2564,10 +2550,9 @@ def test_main_fails_when_public_interface_docs_use_absolute_paths(tmp_path: Path
                 "",
                 "## Available tools",
                 "",
-                "| Tool | Description | Coverage |",
-                "| --- | --- | --- |",
-                "| [**densegen**](src/dnadesign/densegen/README.md) | densegen tool | "
-                "[Codecov](https://codecov.io/gh/example/repo?component=densegen) |",
+                "| Tool | Description |",
+                "| --- | --- |",
+                "| [**densegen**](src/dnadesign/densegen/README.md) | densegen tool |",
                 "",
             ]
         ),
@@ -2618,10 +2603,9 @@ def test_main_fails_when_public_interface_docs_use_internal_source_inreach(tmp_p
                 "",
                 "## Available tools",
                 "",
-                "| Tool | Description | Coverage |",
-                "| --- | --- | --- |",
-                "| [**densegen**](src/dnadesign/densegen/README.md) | densegen tool | "
-                "[Codecov](https://codecov.io/gh/example/repo?component=densegen) |",
+                "| Tool | Description |",
+                "| --- | --- |",
+                "| [**densegen**](src/dnadesign/densegen/README.md) | densegen tool |",
                 "",
             ]
         ),
@@ -2700,10 +2684,9 @@ def test_broken_link_check_includes_top_level_tool_readmes(tmp_path: Path) -> No
                 "",
                 "## Available tools",
                 "",
-                "| Tool | Description | Coverage |",
-                "| --- | --- | --- |",
-                "| [**opal**](src/dnadesign/opal/README.md) | opal tool | "
-                "[Codecov](https://codecov.io/gh/example/repo?component=opal) |",
+                "| Tool | Description |",
+                "| --- | --- |",
+                "| [**opal**](src/dnadesign/opal/README.md) | opal tool |",
                 "",
             ]
         ),
@@ -2776,12 +2759,10 @@ def test_main_passes_when_codecov_components_match_repo_tools(tmp_path: Path) ->
                 "",
                 "## Available tools",
                 "",
-                "| Tool | Description | Coverage |",
-                "| --- | --- | --- |",
-                "| [**aligner**](src/dnadesign/aligner/README.md) | alignment | "
-                "[Codecov](https://codecov.io/gh/example/repo?component=aligner) |",
-                "| [**notify**](src/dnadesign/notify/README.md) | notifications | "
-                "[Codecov](https://codecov.io/gh/example/repo?component=notify) |",
+                "| Tool | Description |",
+                "| --- | --- |",
+                "| [**aligner**](src/dnadesign/aligner/README.md) | alignment |",
+                "| [**notify**](src/dnadesign/notify/README.md) | notifications |",
                 "",
             ]
         ),

--- a/src/dnadesign/devtools/tests/docs/test_checks.py
+++ b/src/dnadesign/devtools/tests/docs/test_checks.py
@@ -18,6 +18,7 @@ from pathlib import Path
 import pytest
 import yaml
 
+from dnadesign.devtools.docs import checks as docs_checks
 from dnadesign.devtools.docs.checks import (
     _find_active_shared_usr_dataset_id_issues,
     _find_agents_path_reference_issues,
@@ -1390,6 +1391,30 @@ def test_main_passes_when_docs_index_has_required_metadata(tmp_path: Path) -> No
 
     rc = main(["--repo-root", str(tmp_path)])
     assert rc == 0
+
+
+def test_main_fails_when_generated_banner_is_stale(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    today = dt.date.today().isoformat()
+    _write(
+        tmp_path / "docs" / "README.md",
+        f"## Documentation Index\n\n**Owner:** maintainers\n**Last verified:** {today}\n",
+    )
+    _write(
+        tmp_path / "ARCHITECTURE.md",
+        f"# ARCHITECTURE\n\n**Type:** system-of-record\n**Owner:** maintainers\n**Last verified:** {today}\n",
+    )
+    (tmp_path / "src" / "dnadesign" / "devtools" / "docs" / "banners").mkdir(parents=True)
+    stale_path = Path("assets/dnadesign-banner.svg")
+    monkeypatch.setattr(docs_checks, "check_banners", lambda _repo_root: (stale_path,), raising=False)
+
+    rc = main(["--repo-root", str(tmp_path)])
+
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "Banner source drift check failed" in captured.out
+    assert str(stale_path) in captured.out
 
 
 def test_main_fails_when_start_here_doc_is_present(tmp_path: Path) -> None:

--- a/src/dnadesign/devtools/tests/support/assets/testsupport-banner.svg
+++ b/src/dnadesign/devtools/tests/support/assets/testsupport-banner.svg
@@ -1,14 +1,17 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="240" viewBox="0 0 1200 240" role="img" aria-labelledby="title desc">
-  <title id="title">testsupport banner</title>
-  <desc id="desc">Minimal banner for the dnadesign testsupport package.</desc>
-  <defs>
-    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
-      <stop offset="0%" stop-color="#0f2d46"/>
-      <stop offset="100%" stop-color="#214f59"/>
-    </linearGradient>
-  </defs>
-  <rect width="1200" height="240" fill="url(#bg)"/>
-  <rect x="48" y="48" width="1104" height="144" rx="20" fill="#f3f1e8" fill-opacity="0.08" stroke="#f3f1e8" stroke-opacity="0.16"/>
-  <text x="80" y="118" fill="#f3f1e8" font-family="Menlo, Consolas, monospace" font-size="46" font-weight="700">dnadesign.devtools.testsupport</text>
-  <text x="80" y="164" fill="#d5ddd5" font-family="Menlo, Consolas, monospace" font-size="24">shared cross-tool test fixtures</text>
+<svg width="1200" height="180" viewBox="0 0 1200 180" fill="none"
+  xmlns="http://www.w3.org/2000/svg" role="img"
+  aria-labelledby="testsupport-banner-title testsupport-banner-description" shape-rendering="crispEdges">
+  <title id="testsupport-banner-title">testsupport: share test fixtures</title>
+  <desc id="testsupport-banner-description">Share test-only fixtures across repository tools.</desc>
+  <rect width="1200" height="180" fill="#1E1D1A"/>
+  <g font-family="Menlo, Monaco, Consolas, monospace">
+    <text x="48" y="78" fill="#F3EFE7" font-size="42" font-weight="700" letter-spacing="-1">testsupport</text>
+    <text x="50" y="114" fill="#969087" font-size="12" font-weight="700" letter-spacing="1.2">SHARE TEST FIXTURES</text>
+    <rect x="50" y="132" width="32" height="5" fill="#D97757"/>
+  </g>
+  <path d="M510 34V146" stroke="#3F3C37" stroke-width="2"/>
+  <path d="M584 124H1144" stroke="#5A5650" stroke-width="2"/>
+  <g transform="translate(720 48)">
+    <path d="M0 12H42V50H0ZM60 12H102V50H60Z" stroke="#969087" stroke-width="3" fill="none"/><path d="M9 31L18 40L34 20M69 31L78 40L94 20" stroke="#D97757" stroke-width="4" fill="none"/>
+  </g>
 </svg>

--- a/src/dnadesign/folding/assets/folding-banner.svg
+++ b/src/dnadesign/folding/assets/folding-banner.svg
@@ -1,12 +1,12 @@
 <svg width="1200" height="180" viewBox="0 0 1200 180" fill="none"
   xmlns="http://www.w3.org/2000/svg" role="img"
   aria-labelledby="folding-banner-title folding-banner-description" shape-rendering="crispEdges">
-  <title id="folding-banner-title">folding: predict structure</title>
-  <desc id="folding-banner-description">Predict and render secondary structure for sequence artifacts.</desc>
+  <title id="folding-banner-title">folding: draw rna structures</title>
+  <desc id="folding-banner-description">Predict and draw RNA secondary structures from sequence records.</desc>
   <rect width="1200" height="180" fill="#1E1D1A"/>
   <g font-family="Menlo, Monaco, Consolas, monospace">
     <text x="48" y="78" fill="#F3EFE7" font-size="42" font-weight="700" letter-spacing="-1">folding</text>
-    <text x="50" y="114" fill="#969087" font-size="12" font-weight="700" letter-spacing="1.2">PREDICT STRUCTURE</text>
+    <text x="50" y="114" fill="#969087" font-size="12" font-weight="700" letter-spacing="1.2">DRAW RNA STRUCTURES</text>
     <rect x="50" y="132" width="32" height="5" fill="#D97757"/>
   </g>
   <path d="M510 34V146" stroke="#3F3C37" stroke-width="2"/>

--- a/src/dnadesign/folding/assets/folding-banner.svg
+++ b/src/dnadesign/folding/assets/folding-banner.svg
@@ -1,10 +1,17 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="180" viewBox="0 0 1200 180" role="img" aria-labelledby="title desc">
-  <title id="title">folding</title>
-  <desc id="desc">secondary-structure prediction for sequence artifacts.</desc>
-  <rect width="1200" height="180" fill="#111827" />
-  <path d="M72 48H1128" stroke="#94a3b8" stroke-opacity="0.28" stroke-width="2" />
-  <g font-family="Helvetica, Arial, sans-serif">
-    <text x="72" y="106" fill="#f8fafc" font-size="54" font-weight="700">folding</text>
-    <text x="74" y="140" fill="#cbd5e1" font-size="22">secondary-structure prediction for sequence artifacts</text>
+<svg width="1200" height="180" viewBox="0 0 1200 180" fill="none"
+  xmlns="http://www.w3.org/2000/svg" role="img"
+  aria-labelledby="folding-banner-title folding-banner-description" shape-rendering="crispEdges">
+  <title id="folding-banner-title">folding: predict structure</title>
+  <desc id="folding-banner-description">Predict and render secondary structure for sequence artifacts.</desc>
+  <rect width="1200" height="180" fill="#1E1D1A"/>
+  <g font-family="Menlo, Monaco, Consolas, monospace">
+    <text x="48" y="78" fill="#F3EFE7" font-size="42" font-weight="700" letter-spacing="-1">folding</text>
+    <text x="50" y="114" fill="#969087" font-size="12" font-weight="700" letter-spacing="1.2">PREDICT STRUCTURE</text>
+    <rect x="50" y="132" width="32" height="5" fill="#D97757"/>
+  </g>
+  <path d="M510 34V146" stroke="#3F3C37" stroke-width="2"/>
+  <path d="M584 124H1144" stroke="#5A5650" stroke-width="2"/>
+  <g transform="translate(720 48)">
+    <path d="M0 45C14 45 14 10 32 10C50 10 50 45 66 45C82 45 82 20 98 20" stroke="#F3EFE7" stroke-width="4" fill="none"/><rect x="29" y="7" width="6" height="6" fill="#D97757"/>
   </g>
 </svg>

--- a/src/dnadesign/infer/assets/infer-banner.svg
+++ b/src/dnadesign/infer/assets/infer-banner.svg
@@ -1,12 +1,12 @@
 <svg width="1200" height="180" viewBox="0 0 1200 180" fill="none"
   xmlns="http://www.w3.org/2000/svg" role="img"
   aria-labelledby="infer-banner-title infer-banner-description" shape-rendering="crispEdges">
-  <title id="infer-banner-title">infer: run sequence models</title>
-  <desc id="infer-banner-description">Run sequence models and publish namespaced results.</desc>
+  <title id="infer-banner-title">infer: add model results</title>
+  <desc id="infer-banner-description">Run sequence models and add their results to datasets.</desc>
   <rect width="1200" height="180" fill="#1E1D1A"/>
   <g font-family="Menlo, Monaco, Consolas, monospace">
     <text x="48" y="78" fill="#F3EFE7" font-size="42" font-weight="700" letter-spacing="-1">infer</text>
-    <text x="50" y="114" fill="#969087" font-size="12" font-weight="700" letter-spacing="1.2">RUN SEQUENCE MODELS</text>
+    <text x="50" y="114" fill="#969087" font-size="12" font-weight="700" letter-spacing="1.2">ADD MODEL RESULTS</text>
     <rect x="50" y="132" width="32" height="5" fill="#D97757"/>
   </g>
   <path d="M510 34V146" stroke="#3F3C37" stroke-width="2"/>

--- a/src/dnadesign/infer/assets/infer-banner.svg
+++ b/src/dnadesign/infer/assets/infer-banner.svg
@@ -1,10 +1,17 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="180" viewBox="0 0 1200 180" role="img" aria-labelledby="title desc">
-  <title id="title">infer</title>
-  <desc id="desc">sequence-model inference into datasets.</desc>
-  <rect width="1200" height="180" fill="#111827" />
-  <path d="M72 48H1128" stroke="#94a3b8" stroke-opacity="0.28" stroke-width="2" />
-  <g font-family="Helvetica, Arial, sans-serif">
-    <text x="72" y="106" fill="#f8fafc" font-size="54" font-weight="700">infer</text>
-    <text x="74" y="140" fill="#cbd5e1" font-size="22">sequence-model inference into datasets</text>
+<svg width="1200" height="180" viewBox="0 0 1200 180" fill="none"
+  xmlns="http://www.w3.org/2000/svg" role="img"
+  aria-labelledby="infer-banner-title infer-banner-description" shape-rendering="crispEdges">
+  <title id="infer-banner-title">infer: run sequence models</title>
+  <desc id="infer-banner-description">Run sequence models and publish namespaced results.</desc>
+  <rect width="1200" height="180" fill="#1E1D1A"/>
+  <g font-family="Menlo, Monaco, Consolas, monospace">
+    <text x="48" y="78" fill="#F3EFE7" font-size="42" font-weight="700" letter-spacing="-1">infer</text>
+    <text x="50" y="114" fill="#969087" font-size="12" font-weight="700" letter-spacing="1.2">RUN SEQUENCE MODELS</text>
+    <rect x="50" y="132" width="32" height="5" fill="#D97757"/>
+  </g>
+  <path d="M510 34V146" stroke="#3F3C37" stroke-width="2"/>
+  <path d="M584 124H1144" stroke="#5A5650" stroke-width="2"/>
+  <g transform="translate(720 48)">
+    <path d="M0 28H30M30 28L48 10M30 28H54M30 28L48 46" stroke="#969087" stroke-width="3" fill="none"/><rect x="62" y="9" width="34" height="8" fill="#F3EFE7"/><rect x="62" y="24" width="48" height="8" fill="#D97757"/><rect x="62" y="39" width="26" height="8" fill="#969087"/>
   </g>
 </svg>

--- a/src/dnadesign/latentdna/docs/assets/latentdna-banner.svg
+++ b/src/dnadesign/latentdna/docs/assets/latentdna-banner.svg
@@ -1,12 +1,12 @@
 <svg width="1200" height="180" viewBox="0 0 1200 180" fill="none"
   xmlns="http://www.w3.org/2000/svg" role="img"
   aria-labelledby="latentdna-banner-title latentdna-banner-description" shape-rendering="crispEdges">
-  <title id="latentdna-banner-title">latentdna: compare sequence features</title>
-  <desc id="latentdna-banner-description">Compare numerical sequence features in declared workspaces.</desc>
+  <title id="latentdna-banner-title">latentdna: compare sequence data</title>
+  <desc id="latentdna-banner-description">Compare numerical sequence features and save review-ready results.</desc>
   <rect width="1200" height="180" fill="#1E1D1A"/>
   <g font-family="Menlo, Monaco, Consolas, monospace">
     <text x="48" y="78" fill="#F3EFE7" font-size="42" font-weight="700" letter-spacing="-1">latentdna</text>
-    <text x="50" y="114" fill="#969087" font-size="12" font-weight="700" letter-spacing="1.2">COMPARE SEQUENCE FEATURES</text>
+    <text x="50" y="114" fill="#969087" font-size="12" font-weight="700" letter-spacing="1.2">COMPARE SEQUENCE DATA</text>
     <rect x="50" y="132" width="32" height="5" fill="#D97757"/>
   </g>
   <path d="M510 34V146" stroke="#3F3C37" stroke-width="2"/>

--- a/src/dnadesign/latentdna/docs/assets/latentdna-banner.svg
+++ b/src/dnadesign/latentdna/docs/assets/latentdna-banner.svg
@@ -1,10 +1,17 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="180" viewBox="0 0 1200 180" role="img" aria-labelledby="title desc">
-  <title id="title">latentdna</title>
-  <desc id="desc">embedding geometry tables, plots, and notebooks.</desc>
-  <rect width="1200" height="180" fill="#111827" />
-  <path d="M72 48H1128" stroke="#94a3b8" stroke-opacity="0.28" stroke-width="2" />
-  <g font-family="Helvetica, Arial, sans-serif">
-    <text x="72" y="106" fill="#f8fafc" font-size="54" font-weight="700">latentdna</text>
-    <text x="74" y="140" fill="#cbd5e1" font-size="22">embedding geometry tables, plots, and notebooks</text>
+<svg width="1200" height="180" viewBox="0 0 1200 180" fill="none"
+  xmlns="http://www.w3.org/2000/svg" role="img"
+  aria-labelledby="latentdna-banner-title latentdna-banner-description" shape-rendering="crispEdges">
+  <title id="latentdna-banner-title">latentdna: compare representations</title>
+  <desc id="latentdna-banner-description">Compare learned sequence representations in workspaces.</desc>
+  <rect width="1200" height="180" fill="#1E1D1A"/>
+  <g font-family="Menlo, Monaco, Consolas, monospace">
+    <text x="48" y="78" fill="#F3EFE7" font-size="42" font-weight="700" letter-spacing="-1">latentdna</text>
+    <text x="50" y="114" fill="#969087" font-size="12" font-weight="700" letter-spacing="1.2">COMPARE REPRESENTATIONS</text>
+    <rect x="50" y="132" width="32" height="5" fill="#D97757"/>
+  </g>
+  <path d="M510 34V146" stroke="#3F3C37" stroke-width="2"/>
+  <path d="M584 124H1144" stroke="#5A5650" stroke-width="2"/>
+  <g transform="translate(720 48)">
+    <path d="M0 49L28 9L55 49" stroke="#5A5650" stroke-width="3" fill="none"/><circle cx="13" cy="34" r="5" fill="#F3EFE7"/><circle cx="33" cy="27" r="5" fill="#D97757"/><circle cx="47" cy="41" r="4" fill="#969087"/><path d="M70 49L98 9L125 49" stroke="#5A5650" stroke-width="3" fill="none"/>
   </g>
 </svg>

--- a/src/dnadesign/latentdna/docs/assets/latentdna-banner.svg
+++ b/src/dnadesign/latentdna/docs/assets/latentdna-banner.svg
@@ -1,12 +1,12 @@
 <svg width="1200" height="180" viewBox="0 0 1200 180" fill="none"
   xmlns="http://www.w3.org/2000/svg" role="img"
   aria-labelledby="latentdna-banner-title latentdna-banner-description" shape-rendering="crispEdges">
-  <title id="latentdna-banner-title">latentdna: compare representations</title>
-  <desc id="latentdna-banner-description">Compare learned sequence representations in workspaces.</desc>
+  <title id="latentdna-banner-title">latentdna: compare sequence features</title>
+  <desc id="latentdna-banner-description">Compare numerical sequence features in declared workspaces.</desc>
   <rect width="1200" height="180" fill="#1E1D1A"/>
   <g font-family="Menlo, Monaco, Consolas, monospace">
     <text x="48" y="78" fill="#F3EFE7" font-size="42" font-weight="700" letter-spacing="-1">latentdna</text>
-    <text x="50" y="114" fill="#969087" font-size="12" font-weight="700" letter-spacing="1.2">COMPARE REPRESENTATIONS</text>
+    <text x="50" y="114" fill="#969087" font-size="12" font-weight="700" letter-spacing="1.2">COMPARE SEQUENCE FEATURES</text>
     <rect x="50" y="132" width="32" height="5" fill="#D97757"/>
   </g>
   <path d="M510 34V146" stroke="#3F3C37" stroke-width="2"/>

--- a/src/dnadesign/libshuffle/assets/libshuffle-banner.svg
+++ b/src/dnadesign/libshuffle/assets/libshuffle-banner.svg
@@ -1,10 +1,17 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="180" viewBox="0 0 1200 180" role="img" aria-labelledby="title desc">
-  <title id="title">libshuffle</title>
-  <desc id="desc">diverse subsampling for sequence libraries.</desc>
-  <rect width="1200" height="180" fill="#111827" />
-  <path d="M72 48H1128" stroke="#94a3b8" stroke-opacity="0.28" stroke-width="2" />
-  <g font-family="Helvetica, Arial, sans-serif">
-    <text x="72" y="106" fill="#f8fafc" font-size="54" font-weight="700">libshuffle</text>
-    <text x="74" y="140" fill="#cbd5e1" font-size="22">diverse subsampling for sequence libraries</text>
+<svg width="1200" height="180" viewBox="0 0 1200 180" fill="none"
+  xmlns="http://www.w3.org/2000/svg" role="img"
+  aria-labelledby="libshuffle-banner-title libshuffle-banner-description" shape-rendering="crispEdges">
+  <title id="libshuffle-banner-title">libshuffle: select diverse sets</title>
+  <desc id="libshuffle-banner-description">Select representative subsets from dense sequence libraries.</desc>
+  <rect width="1200" height="180" fill="#1E1D1A"/>
+  <g font-family="Menlo, Monaco, Consolas, monospace">
+    <text x="48" y="78" fill="#F3EFE7" font-size="42" font-weight="700" letter-spacing="-1">libshuffle</text>
+    <text x="50" y="114" fill="#969087" font-size="12" font-weight="700" letter-spacing="1.2">SELECT DIVERSE SETS</text>
+    <rect x="50" y="132" width="32" height="5" fill="#D97757"/>
+  </g>
+  <path d="M510 34V146" stroke="#3F3C37" stroke-width="2"/>
+  <path d="M584 124H1144" stroke="#5A5650" stroke-width="2"/>
+  <g transform="translate(720 48)">
+    <path d="M0 12H24C48 12 48 46 72 46H104" stroke="#969087" stroke-width="3" fill="none"/><path d="M0 46H24C48 46 48 12 72 12H104" stroke="#D97757" stroke-width="3" fill="none"/>
   </g>
 </svg>

--- a/src/dnadesign/nmf/assets/nmf-banner.svg
+++ b/src/dnadesign/nmf/assets/nmf-banner.svg
@@ -1,12 +1,12 @@
 <svg width="1200" height="180" viewBox="0 0 1200 180" fill="none"
   xmlns="http://www.w3.org/2000/svg" role="img"
   aria-labelledby="nmf-banner-title nmf-banner-description" shape-rendering="crispEdges">
-  <title id="nmf-banner-title">nmf: find motif programs</title>
-  <desc id="nmf-banner-description">Factor motif tables into recurring programs.</desc>
+  <title id="nmf-banner-title">nmf: find motif patterns</title>
+  <desc id="nmf-banner-description">Find recurring combinations in motif tables.</desc>
   <rect width="1200" height="180" fill="#1E1D1A"/>
   <g font-family="Menlo, Monaco, Consolas, monospace">
     <text x="48" y="78" fill="#F3EFE7" font-size="42" font-weight="700" letter-spacing="-1">nmf</text>
-    <text x="50" y="114" fill="#969087" font-size="12" font-weight="700" letter-spacing="1.2">FIND MOTIF PROGRAMS</text>
+    <text x="50" y="114" fill="#969087" font-size="12" font-weight="700" letter-spacing="1.2">FIND MOTIF PATTERNS</text>
     <rect x="50" y="132" width="32" height="5" fill="#D97757"/>
   </g>
   <path d="M510 34V146" stroke="#3F3C37" stroke-width="2"/>

--- a/src/dnadesign/nmf/assets/nmf-banner.svg
+++ b/src/dnadesign/nmf/assets/nmf-banner.svg
@@ -1,10 +1,17 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="180" viewBox="0 0 1200 180" role="img" aria-labelledby="title desc">
-  <title id="title">nmf</title>
-  <desc id="desc">motif-program factorization for dense arrays.</desc>
-  <rect width="1200" height="180" fill="#111827" />
-  <path d="M72 48H1128" stroke="#94a3b8" stroke-opacity="0.28" stroke-width="2" />
-  <g font-family="Helvetica, Arial, sans-serif">
-    <text x="72" y="106" fill="#f8fafc" font-size="54" font-weight="700">nmf</text>
-    <text x="74" y="140" fill="#cbd5e1" font-size="22">motif-program factorization for dense arrays</text>
+<svg width="1200" height="180" viewBox="0 0 1200 180" fill="none"
+  xmlns="http://www.w3.org/2000/svg" role="img"
+  aria-labelledby="nmf-banner-title nmf-banner-description" shape-rendering="crispEdges">
+  <title id="nmf-banner-title">nmf: find motif programs</title>
+  <desc id="nmf-banner-description">Factor motif tables into recurring programs.</desc>
+  <rect width="1200" height="180" fill="#1E1D1A"/>
+  <g font-family="Menlo, Monaco, Consolas, monospace">
+    <text x="48" y="78" fill="#F3EFE7" font-size="42" font-weight="700" letter-spacing="-1">nmf</text>
+    <text x="50" y="114" fill="#969087" font-size="12" font-weight="700" letter-spacing="1.2">FIND MOTIF PROGRAMS</text>
+    <rect x="50" y="132" width="32" height="5" fill="#D97757"/>
+  </g>
+  <path d="M510 34V146" stroke="#3F3C37" stroke-width="2"/>
+  <path d="M584 124H1144" stroke="#5A5650" stroke-width="2"/>
+  <g transform="translate(720 48)">
+    <rect x="0" y="8" width="44" height="44" fill="#969087"/><rect x="8" y="16" width="10" height="10" fill="#F3EFE7"/><rect x="26" y="34" width="10" height="10" fill="#D97757"/><path d="M56 30H72" stroke="#5A5650" stroke-width="3" fill="none"/><rect x="82" y="8" width="10" height="44" fill="#F3EFE7"/><rect x="102" y="8" width="10" height="44" fill="#D97757"/>
   </g>
 </svg>

--- a/src/dnadesign/notify/assets/notify-banner.svg
+++ b/src/dnadesign/notify/assets/notify-banner.svg
@@ -1,12 +1,12 @@
 <svg width="1200" height="180" viewBox="0 0 1200 180" fill="none"
   xmlns="http://www.w3.org/2000/svg" role="img"
   aria-labelledby="notify-banner-title notify-banner-description" shape-rendering="crispEdges">
-  <title id="notify-banner-title">notify: watch data events</title>
-  <desc id="notify-banner-description">Watch sequence-record events and send notifications.</desc>
+  <title id="notify-banner-title">notify: send run updates</title>
+  <desc id="notify-banner-description">Send notifications for local and scheduled jobs.</desc>
   <rect width="1200" height="180" fill="#1E1D1A"/>
   <g font-family="Menlo, Monaco, Consolas, monospace">
     <text x="48" y="78" fill="#F3EFE7" font-size="42" font-weight="700" letter-spacing="-1">notify</text>
-    <text x="50" y="114" fill="#969087" font-size="12" font-weight="700" letter-spacing="1.2">WATCH DATA EVENTS</text>
+    <text x="50" y="114" fill="#969087" font-size="12" font-weight="700" letter-spacing="1.2">SEND RUN UPDATES</text>
     <rect x="50" y="132" width="32" height="5" fill="#D97757"/>
   </g>
   <path d="M510 34V146" stroke="#3F3C37" stroke-width="2"/>

--- a/src/dnadesign/notify/assets/notify-banner.svg
+++ b/src/dnadesign/notify/assets/notify-banner.svg
@@ -1,10 +1,17 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="180" viewBox="0 0 1200 180" role="img" aria-labelledby="title desc">
-  <title id="title">notify</title>
-  <desc id="desc">webhook status from run events.</desc>
-  <rect width="1200" height="180" fill="#111827" />
-  <path d="M72 48H1128" stroke="#94a3b8" stroke-opacity="0.28" stroke-width="2" />
-  <g font-family="Helvetica, Arial, sans-serif">
-    <text x="72" y="106" fill="#f8fafc" font-size="54" font-weight="700">notify</text>
-    <text x="74" y="140" fill="#cbd5e1" font-size="22">webhook status from run events</text>
+<svg width="1200" height="180" viewBox="0 0 1200 180" fill="none"
+  xmlns="http://www.w3.org/2000/svg" role="img"
+  aria-labelledby="notify-banner-title notify-banner-description" shape-rendering="crispEdges">
+  <title id="notify-banner-title">notify: watch data events</title>
+  <desc id="notify-banner-description">Watch sequence-record events and send notifications.</desc>
+  <rect width="1200" height="180" fill="#1E1D1A"/>
+  <g font-family="Menlo, Monaco, Consolas, monospace">
+    <text x="48" y="78" fill="#F3EFE7" font-size="42" font-weight="700" letter-spacing="-1">notify</text>
+    <text x="50" y="114" fill="#969087" font-size="12" font-weight="700" letter-spacing="1.2">WATCH DATA EVENTS</text>
+    <rect x="50" y="132" width="32" height="5" fill="#D97757"/>
+  </g>
+  <path d="M510 34V146" stroke="#3F3C37" stroke-width="2"/>
+  <path d="M584 124H1144" stroke="#5A5650" stroke-width="2"/>
+  <g transform="translate(720 48)">
+    <path d="M0 33H18L28 12L42 48L54 24L68 33H106" stroke="#F3EFE7" stroke-width="4" fill="none"/><rect x="102" y="29" width="8" height="8" fill="#D97757"/>
   </g>
 </svg>

--- a/src/dnadesign/opal/assets/opal-banner.svg
+++ b/src/dnadesign/opal/assets/opal-banner.svg
@@ -2,7 +2,7 @@
   xmlns="http://www.w3.org/2000/svg" role="img"
   aria-labelledby="opal-banner-title opal-banner-description" shape-rendering="crispEdges">
   <title id="opal-banner-title">opal: select next designs</title>
-  <desc id="opal-banner-description">Run contract-driven active-learning campaigns.</desc>
+  <desc id="opal-banner-description">Choose the next designs from measured sequence results.</desc>
   <rect width="1200" height="180" fill="#1E1D1A"/>
   <g font-family="Menlo, Monaco, Consolas, monospace">
     <text x="48" y="78" fill="#F3EFE7" font-size="42" font-weight="700" letter-spacing="-1">opal</text>

--- a/src/dnadesign/opal/assets/opal-banner.svg
+++ b/src/dnadesign/opal/assets/opal-banner.svg
@@ -1,10 +1,17 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="180" viewBox="0 0 1200 180" role="img" aria-labelledby="title desc">
-  <title id="title">opal</title>
-  <desc id="desc">active learning for sequence design.</desc>
-  <rect width="1200" height="180" fill="#111827" />
-  <path d="M72 48H1128" stroke="#94a3b8" stroke-opacity="0.28" stroke-width="2" />
-  <g font-family="Helvetica, Arial, sans-serif">
-    <text x="72" y="106" fill="#f8fafc" font-size="54" font-weight="700">opal</text>
-    <text x="74" y="140" fill="#cbd5e1" font-size="22">active learning for sequence design</text>
+<svg width="1200" height="180" viewBox="0 0 1200 180" fill="none"
+  xmlns="http://www.w3.org/2000/svg" role="img"
+  aria-labelledby="opal-banner-title opal-banner-description" shape-rendering="crispEdges">
+  <title id="opal-banner-title">opal: select next designs</title>
+  <desc id="opal-banner-description">Run contract-driven active-learning campaigns.</desc>
+  <rect width="1200" height="180" fill="#1E1D1A"/>
+  <g font-family="Menlo, Monaco, Consolas, monospace">
+    <text x="48" y="78" fill="#F3EFE7" font-size="42" font-weight="700" letter-spacing="-1">opal</text>
+    <text x="50" y="114" fill="#969087" font-size="12" font-weight="700" letter-spacing="1.2">SELECT NEXT DESIGNS</text>
+    <rect x="50" y="132" width="32" height="5" fill="#D97757"/>
+  </g>
+  <path d="M510 34V146" stroke="#3F3C37" stroke-width="2"/>
+  <path d="M584 124H1144" stroke="#5A5650" stroke-width="2"/>
+  <g transform="translate(720 48)">
+    <path d="M0 45L25 34L48 38L74 17L100 8" stroke="#969087" stroke-width="3" fill="none"/><circle cx="74" cy="17" r="7" fill="#D97757"/><path d="M92 8H108V24" stroke="#F3EFE7" stroke-width="3" fill="none"/>
   </g>
 </svg>

--- a/src/dnadesign/ops/assets/ops-banner.svg
+++ b/src/dnadesign/ops/assets/ops-banner.svg
@@ -1,12 +1,12 @@
 <svg width="1200" height="180" viewBox="0 0 1200 180" fill="none"
   xmlns="http://www.w3.org/2000/svg" role="img"
   aria-labelledby="ops-banner-title ops-banner-description" shape-rendering="crispEdges">
-  <title id="ops-banner-title">ops: run shared workflows</title>
-  <desc id="ops-banner-description">Discover, inspect, and run tool-owned workflows.</desc>
+  <title id="ops-banner-title">ops: find and run jobs</title>
+  <desc id="ops-banner-description">Find, run, and inspect jobs owned by repository tools.</desc>
   <rect width="1200" height="180" fill="#1E1D1A"/>
   <g font-family="Menlo, Monaco, Consolas, monospace">
     <text x="48" y="78" fill="#F3EFE7" font-size="42" font-weight="700" letter-spacing="-1">ops</text>
-    <text x="50" y="114" fill="#969087" font-size="12" font-weight="700" letter-spacing="1.2">RUN SHARED WORKFLOWS</text>
+    <text x="50" y="114" fill="#969087" font-size="12" font-weight="700" letter-spacing="1.2">FIND AND RUN JOBS</text>
     <rect x="50" y="132" width="32" height="5" fill="#D97757"/>
   </g>
   <path d="M510 34V146" stroke="#3F3C37" stroke-width="2"/>

--- a/src/dnadesign/ops/assets/ops-banner.svg
+++ b/src/dnadesign/ops/assets/ops-banner.svg
@@ -1,10 +1,17 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="180" viewBox="0 0 1200 180" role="img" aria-labelledby="title desc">
-  <title id="title">ops</title>
-  <desc id="desc">batch orchestration and status routing.</desc>
-  <rect width="1200" height="180" fill="#111827" />
-  <path d="M72 48H1128" stroke="#94a3b8" stroke-opacity="0.28" stroke-width="2" />
-  <g font-family="Helvetica, Arial, sans-serif">
-    <text x="72" y="106" fill="#f8fafc" font-size="54" font-weight="700">ops</text>
-    <text x="74" y="140" fill="#cbd5e1" font-size="22">batch orchestration and status routing</text>
+<svg width="1200" height="180" viewBox="0 0 1200 180" fill="none"
+  xmlns="http://www.w3.org/2000/svg" role="img"
+  aria-labelledby="ops-banner-title ops-banner-description" shape-rendering="crispEdges">
+  <title id="ops-banner-title">ops: run shared workflows</title>
+  <desc id="ops-banner-description">Discover, inspect, and run tool-owned workflows.</desc>
+  <rect width="1200" height="180" fill="#1E1D1A"/>
+  <g font-family="Menlo, Monaco, Consolas, monospace">
+    <text x="48" y="78" fill="#F3EFE7" font-size="42" font-weight="700" letter-spacing="-1">ops</text>
+    <text x="50" y="114" fill="#969087" font-size="12" font-weight="700" letter-spacing="1.2">RUN SHARED WORKFLOWS</text>
+    <rect x="50" y="132" width="32" height="5" fill="#D97757"/>
+  </g>
+  <path d="M510 34V146" stroke="#3F3C37" stroke-width="2"/>
+  <path d="M584 124H1144" stroke="#5A5650" stroke-width="2"/>
+  <g transform="translate(720 48)">
+    <path d="M0 28H26M26 28L50 10M26 28L50 46M50 10H102M50 46H84" stroke="#F3EFE7" stroke-width="3" fill="none"/><rect x="96" y="6" width="10" height="8" fill="#D97757"/>
   </g>
 </svg>

--- a/src/dnadesign/ops/tests/test_ops_docs_progressive_disclosure_contracts.py
+++ b/src/dnadesign/ops/tests/test_ops_docs_progressive_disclosure_contracts.py
@@ -357,7 +357,7 @@ def test_repo_root_readme_lists_ops_in_docs_and_tool_catalog() -> None:
 
 def test_root_ops_row_is_tool_agnostic() -> None:
     text = _read(_repo_root() / "README.md")
-    expected_row = "| [**ops**](src/dnadesign/ops/README.md) | Plan, submit, and inspect batch runbooks across tools. |"
+    expected_row = "| [**ops**](src/dnadesign/ops/README.md) | Find, run, and inspect jobs owned by repository tools. |"
     assert expected_row in text
 
 

--- a/src/dnadesign/permuter/assets/permuter-banner.svg
+++ b/src/dnadesign/permuter/assets/permuter-banner.svg
@@ -1,10 +1,17 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="180" viewBox="0 0 1200 180" role="img" aria-labelledby="title desc">
-  <title id="title">permuter</title>
-  <desc id="desc">variant generation and scoring.</desc>
-  <rect width="1200" height="180" fill="#111827" />
-  <path d="M72 48H1128" stroke="#94a3b8" stroke-opacity="0.28" stroke-width="2" />
-  <g font-family="Helvetica, Arial, sans-serif">
-    <text x="72" y="106" fill="#f8fafc" font-size="54" font-weight="700">permuter</text>
-    <text x="74" y="140" fill="#cbd5e1" font-size="22">variant generation and scoring</text>
+<svg width="1200" height="180" viewBox="0 0 1200 180" fill="none"
+  xmlns="http://www.w3.org/2000/svg" role="img"
+  aria-labelledby="permuter-banner-title permuter-banner-description" shape-rendering="crispEdges">
+  <title id="permuter-banner-title">permuter: generate variants</title>
+  <desc id="permuter-banner-description">Generate and score sequence variants through explicit evaluators.</desc>
+  <rect width="1200" height="180" fill="#1E1D1A"/>
+  <g font-family="Menlo, Monaco, Consolas, monospace">
+    <text x="48" y="78" fill="#F3EFE7" font-size="42" font-weight="700" letter-spacing="-1">permuter</text>
+    <text x="50" y="114" fill="#969087" font-size="12" font-weight="700" letter-spacing="1.2">GENERATE VARIANTS</text>
+    <rect x="50" y="132" width="32" height="5" fill="#D97757"/>
+  </g>
+  <path d="M510 34V146" stroke="#3F3C37" stroke-width="2"/>
+  <path d="M584 124H1144" stroke="#5A5650" stroke-width="2"/>
+  <g transform="translate(720 48)">
+    <path d="M0 14H104M0 30H104M0 46H104" stroke="#5A5650" stroke-width="3" fill="none"/><rect x="22" y="9" width="18" height="10" fill="#F3EFE7"/><rect x="48" y="25" width="18" height="10" fill="#D97757"/><rect x="74" y="41" width="18" height="10" fill="#969087"/>
   </g>
 </svg>

--- a/src/dnadesign/permuter/assets/permuter-banner.svg
+++ b/src/dnadesign/permuter/assets/permuter-banner.svg
@@ -1,12 +1,12 @@
 <svg width="1200" height="180" viewBox="0 0 1200 180" fill="none"
   xmlns="http://www.w3.org/2000/svg" role="img"
   aria-labelledby="permuter-banner-title permuter-banner-description" shape-rendering="crispEdges">
-  <title id="permuter-banner-title">permuter: generate variants</title>
-  <desc id="permuter-banner-description">Generate and score sequence variants through explicit evaluators.</desc>
+  <title id="permuter-banner-title">permuter: make and score variants</title>
+  <desc id="permuter-banner-description">Generate sequence variants and score them with chosen tools.</desc>
   <rect width="1200" height="180" fill="#1E1D1A"/>
   <g font-family="Menlo, Monaco, Consolas, monospace">
     <text x="48" y="78" fill="#F3EFE7" font-size="42" font-weight="700" letter-spacing="-1">permuter</text>
-    <text x="50" y="114" fill="#969087" font-size="12" font-weight="700" letter-spacing="1.2">GENERATE VARIANTS</text>
+    <text x="50" y="114" fill="#969087" font-size="12" font-weight="700" letter-spacing="1.2">MAKE AND SCORE VARIANTS</text>
     <rect x="50" y="132" width="32" height="5" fill="#D97757"/>
   </g>
   <path d="M510 34V146" stroke="#3F3C37" stroke-width="2"/>

--- a/src/dnadesign/studies/assets/studies-banner.svg
+++ b/src/dnadesign/studies/assets/studies-banner.svg
@@ -1,10 +1,17 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="180" viewBox="0 0 1200 180" role="img" aria-labelledby="title desc">
-  <title id="title">studies</title>
-  <desc id="desc">checked-in study records and helpers.</desc>
-  <rect width="1200" height="180" fill="#111827" />
-  <path d="M72 48H1128" stroke="#94a3b8" stroke-opacity="0.28" stroke-width="2" />
-  <g font-family="Helvetica, Arial, sans-serif">
-    <text x="72" y="106" fill="#f8fafc" font-size="54" font-weight="700">studies</text>
-    <text x="74" y="140" fill="#cbd5e1" font-size="22">checked-in study records and helpers</text>
+<svg width="1200" height="180" viewBox="0 0 1200 180" fill="none"
+  xmlns="http://www.w3.org/2000/svg" role="img"
+  aria-labelledby="studies-banner-title studies-banner-description" shape-rendering="crispEdges">
+  <title id="studies-banner-title">studies: own study logic</title>
+  <desc id="studies-banner-description">Keep study-specific code with its checked-in records.</desc>
+  <rect width="1200" height="180" fill="#1E1D1A"/>
+  <g font-family="Menlo, Monaco, Consolas, monospace">
+    <text x="48" y="78" fill="#F3EFE7" font-size="42" font-weight="700" letter-spacing="-1">studies</text>
+    <text x="50" y="114" fill="#969087" font-size="12" font-weight="700" letter-spacing="1.2">OWN STUDY LOGIC</text>
+    <rect x="50" y="132" width="32" height="5" fill="#D97757"/>
+  </g>
+  <path d="M510 34V146" stroke="#3F3C37" stroke-width="2"/>
+  <path d="M584 124H1144" stroke="#5A5650" stroke-width="2"/>
+  <g transform="translate(720 48)">
+    <path d="M0 10H42V48H0ZM58 10H100V48H58Z" stroke="#969087" stroke-width="3" fill="none"/><rect x="8" y="19" width="26" height="5" fill="#F3EFE7"/><rect x="66" y="19" width="26" height="5" fill="#D97757"/><rect x="8" y="31" width="18" height="5" fill="#5A5650"/><rect x="66" y="31" width="22" height="5" fill="#F3EFE7"/>
   </g>
 </svg>

--- a/src/dnadesign/studies/assets/studies-banner.svg
+++ b/src/dnadesign/studies/assets/studies-banner.svg
@@ -1,12 +1,12 @@
 <svg width="1200" height="180" viewBox="0 0 1200 180" fill="none"
   xmlns="http://www.w3.org/2000/svg" role="img"
   aria-labelledby="studies-banner-title studies-banner-description" shape-rendering="crispEdges">
-  <title id="studies-banner-title">studies: own study logic</title>
-  <desc id="studies-banner-description">Keep study-specific code with its checked-in records.</desc>
+  <title id="studies-banner-title">studies: organize studies</title>
+  <desc id="studies-banner-description">Keep study methods, records, and decisions together.</desc>
   <rect width="1200" height="180" fill="#1E1D1A"/>
   <g font-family="Menlo, Monaco, Consolas, monospace">
     <text x="48" y="78" fill="#F3EFE7" font-size="42" font-weight="700" letter-spacing="-1">studies</text>
-    <text x="50" y="114" fill="#969087" font-size="12" font-weight="700" letter-spacing="1.2">OWN STUDY LOGIC</text>
+    <text x="50" y="114" fill="#969087" font-size="12" font-weight="700" letter-spacing="1.2">ORGANIZE STUDIES</text>
     <rect x="50" y="132" width="32" height="5" fill="#D97757"/>
   </g>
   <path d="M510 34V146" stroke="#3F3C37" stroke-width="2"/>

--- a/src/dnadesign/tfkdanalysis/assets/tfkdanalysis-banner.svg
+++ b/src/dnadesign/tfkdanalysis/assets/tfkdanalysis-banner.svg
@@ -1,10 +1,17 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="180" viewBox="0 0 1200 180" role="img" aria-labelledby="title desc">
-  <title id="title">tfkdanalysis</title>
-  <desc id="desc">transcription-factor knockdown analysis.</desc>
-  <rect width="1200" height="180" fill="#111827" />
-  <path d="M72 48H1128" stroke="#94a3b8" stroke-opacity="0.28" stroke-width="2" />
-  <g font-family="Helvetica, Arial, sans-serif">
-    <text x="72" y="106" fill="#f8fafc" font-size="54" font-weight="700">tfkdanalysis</text>
-    <text x="74" y="140" fill="#cbd5e1" font-size="22">transcription-factor knockdown analysis</text>
+<svg width="1200" height="180" viewBox="0 0 1200 180" fill="none"
+  xmlns="http://www.w3.org/2000/svg" role="img"
+  aria-labelledby="tfkdanalysis-banner-title tfkdanalysis-banner-description" shape-rendering="crispEdges">
+  <title id="tfkdanalysis-banner-title">tfkdanalysis: summarize knockdowns</title>
+  <desc id="tfkdanalysis-banner-description">Summarize transcription-factor knockdown responses.</desc>
+  <rect width="1200" height="180" fill="#1E1D1A"/>
+  <g font-family="Menlo, Monaco, Consolas, monospace">
+    <text x="48" y="78" fill="#F3EFE7" font-size="42" font-weight="700" letter-spacing="-1">tfkdanalysis</text>
+    <text x="50" y="114" fill="#969087" font-size="12" font-weight="700" letter-spacing="1.2">SUMMARIZE KNOCKDOWNS</text>
+    <rect x="50" y="132" width="32" height="5" fill="#D97757"/>
+  </g>
+  <path d="M510 34V146" stroke="#3F3C37" stroke-width="2"/>
+  <path d="M584 124H1144" stroke="#5A5650" stroke-width="2"/>
+  <g transform="translate(720 48)">
+    <rect x="0" y="8" width="10" height="42" fill="#F3EFE7"/><rect x="22" y="19" width="10" height="31" fill="#969087"/><rect x="44" y="30" width="10" height="20" fill="#D97757"/><path d="M70 8V50M62 42L70 50L78 42" stroke="#F3EFE7" stroke-width="4" fill="none"/>
   </g>
 </svg>

--- a/src/dnadesign/thread/assets/thread-banner.svg
+++ b/src/dnadesign/thread/assets/thread-banner.svg
@@ -1,21 +1,17 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="180" viewBox="0 0 1200 180" role="img" aria-labelledby="title desc">
-  <title id="title">dnadesign thread banner</title>
-  <desc id="desc">A restrained fixed-backbone design request banner with chain, mask, and backend adapter lanes.</desc>
-  <rect width="1200" height="180" fill="#f6f8fa"/>
-  <g fill="none" stroke="#1f2937" stroke-width="8" stroke-linecap="round" stroke-linejoin="round">
-    <path d="M360 98 C450 48 540 148 630 98 C720 48 810 148 900 98 C975 58 1035 118 1090 98"/>
-    <path d="M360 124 C450 74 540 174 630 124 C720 74 810 174 900 124 C975 84 1035 144 1090 124" opacity="0.35"/>
+<svg width="1200" height="180" viewBox="0 0 1200 180" fill="none"
+  xmlns="http://www.w3.org/2000/svg" role="img"
+  aria-labelledby="thread-banner-title thread-banner-description" shape-rendering="crispEdges">
+  <title id="thread-banner-title">thread: prepare protein designs</title>
+  <desc id="thread-banner-description">Prepare fixed-backbone design requests and fold checks.</desc>
+  <rect width="1200" height="180" fill="#1E1D1A"/>
+  <g font-family="Menlo, Monaco, Consolas, monospace">
+    <text x="48" y="78" fill="#F3EFE7" font-size="42" font-weight="700" letter-spacing="-1">thread</text>
+    <text x="50" y="114" fill="#969087" font-size="12" font-weight="700" letter-spacing="1.2">PREPARE PROTEIN DESIGNS</text>
+    <rect x="50" y="132" width="32" height="5" fill="#D97757"/>
   </g>
-  <g font-family="Inter, Arial, sans-serif" fill="#111827">
-    <text x="90" y="78" font-size="44" font-weight="700">thread</text>
-    <text x="90" y="112" font-size="22">fixed-backbone request artifacts</text>
-  </g>
-  <g fill="#2563eb">
-    <circle cx="630" cy="98" r="10"/>
-    <circle cx="900" cy="98" r="10"/>
-  </g>
-  <g fill="#dc2626">
-    <circle cx="540" cy="124" r="8"/>
-    <circle cx="1035" cy="124" r="8"/>
+  <path d="M510 34V146" stroke="#3F3C37" stroke-width="2"/>
+  <path d="M584 124H1144" stroke="#5A5650" stroke-width="2"/>
+  <g transform="translate(720 48)">
+    <path d="M0 16C20 16 20 44 40 44S60 16 80 16S100 44 120 44" stroke="#F3EFE7" stroke-width="4" fill="none"/><rect x="37" y="39" width="7" height="10" fill="#D97757"/><rect x="77" y="11" width="7" height="10" fill="#969087"/>
   </g>
 </svg>

--- a/src/dnadesign/usr/assets/usr-banner.svg
+++ b/src/dnadesign/usr/assets/usr-banner.svg
@@ -1,12 +1,12 @@
 <svg width="1200" height="180" viewBox="0 0 1200 180" fill="none"
   xmlns="http://www.w3.org/2000/svg" role="img"
   aria-labelledby="usr-banner-title usr-banner-description" shape-rendering="crispEdges">
-  <title id="usr-banner-title">usr: store sequence records</title>
-  <desc id="usr-banner-description">Store sequence records, overlays, and mutation events.</desc>
+  <title id="usr-banner-title">usr: manage sequence tables</title>
+  <desc id="usr-banner-description">Store, check, and sync tables of sequence records.</desc>
   <rect width="1200" height="180" fill="#1E1D1A"/>
   <g font-family="Menlo, Monaco, Consolas, monospace">
     <text x="48" y="78" fill="#F3EFE7" font-size="42" font-weight="700" letter-spacing="-1">usr</text>
-    <text x="50" y="114" fill="#969087" font-size="12" font-weight="700" letter-spacing="1.2">STORE SEQUENCE RECORDS</text>
+    <text x="50" y="114" fill="#969087" font-size="12" font-weight="700" letter-spacing="1.2">MANAGE SEQUENCE TABLES</text>
     <rect x="50" y="132" width="32" height="5" fill="#D97757"/>
   </g>
   <path d="M510 34V146" stroke="#3F3C37" stroke-width="2"/>

--- a/src/dnadesign/usr/assets/usr-banner.svg
+++ b/src/dnadesign/usr/assets/usr-banner.svg
@@ -1,10 +1,17 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="180" viewBox="0 0 1200 180" role="img" aria-labelledby="title desc">
-  <title id="title">usr</title>
-  <desc id="desc">sequence datasets with overlay contracts.</desc>
-  <rect width="1200" height="180" fill="#111827" />
-  <path d="M72 48H1128" stroke="#94a3b8" stroke-opacity="0.28" stroke-width="2" />
-  <g font-family="Helvetica, Arial, sans-serif">
-    <text x="72" y="106" fill="#f8fafc" font-size="54" font-weight="700">usr</text>
-    <text x="74" y="140" fill="#cbd5e1" font-size="22">sequence datasets with overlay contracts</text>
+<svg width="1200" height="180" viewBox="0 0 1200 180" fill="none"
+  xmlns="http://www.w3.org/2000/svg" role="img"
+  aria-labelledby="usr-banner-title usr-banner-description" shape-rendering="crispEdges">
+  <title id="usr-banner-title">usr: store sequence records</title>
+  <desc id="usr-banner-description">Store sequence records, overlays, and mutation events.</desc>
+  <rect width="1200" height="180" fill="#1E1D1A"/>
+  <g font-family="Menlo, Monaco, Consolas, monospace">
+    <text x="48" y="78" fill="#F3EFE7" font-size="42" font-weight="700" letter-spacing="-1">usr</text>
+    <text x="50" y="114" fill="#969087" font-size="12" font-weight="700" letter-spacing="1.2">STORE SEQUENCE RECORDS</text>
+    <rect x="50" y="132" width="32" height="5" fill="#D97757"/>
+  </g>
+  <path d="M510 34V146" stroke="#3F3C37" stroke-width="2"/>
+  <path d="M584 124H1144" stroke="#5A5650" stroke-width="2"/>
+  <g transform="translate(720 48)">
+    <path d="M0 8H88V22H0ZM0 27H104V41H0ZM0 46H76V60H0Z" stroke="#969087" stroke-width="3" fill="none"/><rect x="92" y="10" width="8" height="8" fill="#D97757"/>
   </g>
 </svg>


### PR DESCRIPTION
## Summary

- give the root and 22 tool documentation surfaces one dark, quiet, lo-fi banner family
- keep each tool distinguishable with restrained semantic glyphs while sharing type, spacing, color, and accessibility rules
- generate every SVG deterministically from a semantic catalog instead of maintaining unrelated hand-drawn assets
- remove version, date, schema, agent, numbered-node, and square-rail motifs
- avoid a duplicate visible Markdown title above the root banner
- reduce the root badges to CI, Codecov, and MIT
- describe public tools in plain language for readers who do not already know project jargon

## Verification

- banner asset, inventory, accessibility, XML, and drift tests pass
- documentation checks pass across 505 Markdown files
- Ruff, formatting, and diff checks pass
- representative root, OPAL, and Cruncher renders were visually inspected before rebase