### PR TITLE
Clarify the stress-promoter study handoff path

### DIFF
--- a/docs/studies/stress_ethanol_cipro_growth/README.md
+++ b/docs/studies/stress_ethanol_cipro_growth/README.md
@@ -3,7 +3,7 @@ doc_id: study-stress-ethanol-cipro-growth
 surface: study-root
 study_id: stress_ethanol_cipro_growth
 owner: dnadesign-maintainers
-last_verified: 2026-05-18
+last_verified: 2026-08-01
 first_hop: routes/README.md
 status_surface: studies.stress-ethanol-cipro-growth.status
 preflight_surface: studies.stress-ethanol-cipro-growth.preflight
@@ -11,18 +11,42 @@ preflight_surface: studies.stress-ethanol-cipro-growth.preflight
 
 ## Stress Ethanol Cipro Growth Study
 
-**Owner:** dnadesign-maintainers
-**Last verified:** 2026-05-18
+This directory is the checked-in entry point for the stress promoter study. It
+routes work; it does not duplicate measured data, objective mathematics, or
+campaign state.
 
-This study keeps only the ontology router at the root. Durable factual state,
-operating declarations, route maps, context bindings, and audits live in typed
-subdirectories.
+### Start here
 
-### Directory Ontology
+1. Read the [route map](routes/README.md) to choose the owner and next artifact.
+2. Read the [checked-in status](record/status.md) before relying on campaign or
+   dataset state.
+3. Use the status and preflight commands when current runtime evidence matters:
+
+```bash
+uv run ops progress show studies.stress-ethanol-cipro-growth.status --json
+uv run ops progress show studies.stress-ethanol-cipro-growth.preflight \
+  --scope next --command-timeout-seconds 30 --json
+```
+
+### Ownership boundaries
+
+| Concern | Owner | First local surface |
+| --- | --- | --- |
+| Assay measurements, event alignment, reductions, and experiment plots | Reader | [Study route map](routes/README.md#reader-to-opal-path) |
+| Promoter aliases, candidate and sequence identity, repeat decisions, and observation publication | Stress study | [Study source map](../../../src/dnadesign/studies/units/stress_ethanol_cipro_growth/README.md) |
+| Candidate features and study-approved labels | Stress study contracts consumed by OPAL | [OPAL context](contexts/opal/README.md) |
+| Objective mathematics, model fitting, scoring, and selection | OPAL | [OPAL route](routes/decision/opal/README.md) |
+| Factual phase, accepted handoffs, and blockers | Checked-in study record | [Status](record/status.md) |
+
+SFXI, RMF, and MSRB are objective or comparison semantics downstream of Reader
+measurements. Their source-of-truth documents remain in the study and OPAL
+surfaces linked above.
+
+### Directory map
 
 ```text
 stress_ethanol_cipro_growth/
-  README.md        # this directory ontology
+  README.md        # this entry point
   record/          # factual study record
     campaign.yaml
     datasets.yaml
@@ -55,16 +79,7 @@ stress_ethanol_cipro_growth/
     usr-sync/      # machine-readable USR sync evidence
 ```
 
-Use `routes/README.md` first for owner-surface navigation. Use
-`record/status.md` only for factual current state, `operations/ops.study.yaml`
-as the one-hop contract index, and `operations/runtime/command-groups/pipeline.yaml`
-for machine-loaded command groups. Use
-`operations/runtime/command-groups/README.md` when a human or naive agent needs
-the progressive-disclosure lane map before opening the full pipeline. Split
-execution and readiness fragments under
-`operations/contract/` by owner lane; do not flatten them back into one YAML
-shelf. Use `operations/catalog/` when the task is status or readiness,
-`contexts/promoter-design-intent.md` when a reader needs the study's
-higher-level biological motivation, semantic guardrails, or manuscript framing,
-`contexts/latentdna/` when LatentDNA needs durable study context, and
-`audits/readiness/` or `audits/usr-sync/` for evidence payloads.
+Keep factual state in `record/`, executable declarations in `operations/`,
+owner handoffs in `routes/`, durable interpretation in `contexts/`, and review
+evidence in `audits/`. The [route map](routes/README.md) provides the one-jump
+human path; `operations/ops.study.yaml` is the machine-readable contract index.

--- a/docs/studies/stress_ethanol_cipro_growth/contexts/opal/README.md
+++ b/docs/studies/stress_ethanol_cipro_growth/contexts/opal/README.md
@@ -3,7 +3,7 @@ id: stress-ethanol-cipro-growth-opal-context-index
 title: Stress OPAL context
 owner: dnadesign-maintainers
 status: active
-last_verified: 2026-07-22
+last_verified: 2026-08-01
 audience:
   - operator
   - agent
@@ -11,11 +11,20 @@ audience:
 
 ## Stress OPAL Context
 
+This index separates the data passed to OPAL from the objective used to score
+it and the campaign that records decisions.
+
+| Need | Open |
+| --- | --- |
+| Current phase, blockers, and accepted handoff | [Study status](../../record/status.md) |
+| Candidate universe, model features, and label sources | [Candidate-table contract](candidate-table.md) |
+| Reader measurement to study label lineage | [MSRB evidence path](multistate-response-behavior.md#end-to-end-evidence-path) |
+| Objective definition and study-specific interpretation | [MSRB study application](multistate-response-behavior.md) and [symbol walkthrough](multistate-response-behavior-walkthrough.html) |
+| Read-only campaign checks | [Campaign commands](../../routes/decision/opal/campaign-commands.md#read-only-campaign-verification) |
+
 `secg_msrb_greedy` is the sole executable stress-study campaign and uses
 `multistate_response_behavior_v1`. SFXI and RMF remain source or comparator
-evidence. Start with the [study status](../../record/status.md), the [MSRB assay
-binding](multistate-response-behavior.md), or [read-only campaign
-verification](../../routes/decision/opal/campaign-commands.md#read-only-campaign-verification).
+evidence; neither is an alternate active campaign.
 
 ### Current campaign
 

--- a/docs/studies/stress_ethanol_cipro_growth/routes/README.md
+++ b/docs/studies/stress_ethanol_cipro_growth/routes/README.md
@@ -3,7 +3,7 @@ doc_id: study-stress-ethanol-cipro-growth-routes
 surface: study-route-map
 study_id: stress_ethanol_cipro_growth
 owner: dnadesign-maintainers
-last_verified: 2026-07-22
+last_verified: 2026-08-01
 entrypoint: self
 status_surface: studies.stress-ethanol-cipro-growth.status
 preflight_surface: studies.stress-ethanol-cipro-growth.preflight
@@ -11,27 +11,44 @@ preflight_surface: studies.stress-ethanol-cipro-growth.preflight
 
 ## stress_ethanol_cipro_growth Routes
 
-**Owner:** dnadesign-maintainers
-
-**Last verified:** 2026-07-22
-
-Use this page after the checked-in study status tells you where the record stands. Keep this file as the one-hop handoff map; put downstream detail in focused files under this directory.
+Use this page to choose one owner and one next artifact. Current facts belong in
+the [checked-in status](../record/status.md); detailed scientific interpretation
+belongs in `contexts/`; executable declarations belong in `operations/`.
 
 - Status summary: `uv run ops progress show studies.stress-ethanol-cipro-growth.status --json | jq '{state, summary, opal: .evidence.opal}'`
 - Preflight: `uv run ops progress show studies.stress-ethanol-cipro-growth.preflight --scope next --command-timeout-seconds 30 --json`
 - Snapshot route inventory: `evidence.analysis_surfaces.{densegen,latentdna,cluster}`
 
-### Navigation Header
+### First checks
 
 | Need | Surface |
 | --- | --- |
-| Primary route | this page |
+| Primary route | This page |
 | Status | `uv run ops progress show studies.stress-ethanol-cipro-growth.status --json \| jq '{state, summary, opal: .evidence.opal}'` |
 | Preflight | `uv run ops progress show studies.stress-ethanol-cipro-growth.preflight --scope next --command-timeout-seconds 30 --json` |
 | Machine-readable contract | `../operations/ops.study.yaml` |
 | Study intent and semantic guardrails | [Promoter design intent](../contexts/promoter-design-intent.md) |
 
-### Route Index
+### Reader-to-OPAL path
+
+These are sequential contracts, not interchangeable names for one dataset.
+Each step verifies its input before publishing the next artifact.
+
+| Step | Owner | Input and output | Open next |
+| --- | --- | --- | --- |
+| Measured records | Reader | Raw assay sources become verified measurement, event-window, and plot records. Reader does not assign study candidates or objectives. | [Study observation adapter](../../../../src/dnadesign/studies/units/stress_ethanol_cipro_growth/response_window_observations/README.md) |
+| Candidate identity | Stress study | Reader aliases resolve to exact promoter candidates and sequence digests. | [Candidate bindings](../../../../src/dnadesign/studies/units/stress_ethanol_cipro_growth/promoter_candidate_bindings/README.md) |
+| Candidate observations | Stress study | Verified Reader reductions plus explicit repeat decisions become objective-neutral candidate observations. | [Response-window observations](../../../../src/dnadesign/studies/units/stress_ethanol_cipro_growth/response_window_observations/README.md) |
+| Candidate features | Stress study and LatentDNA | The candidate table binds each candidate to the selected fixed-length model input. | [Candidate-table contract](../contexts/opal/candidate-table.md) |
+| Observed labels | Stress study | An approved observation bundle becomes an immutable OPAL label publication; this step does not score an objective. | [Label promotion](../../../../src/dnadesign/studies/units/stress_ethanol_cipro_growth/decision/opal/response_window_label_promotion/README.md) |
+| Objective interpretation | OPAL mathematics plus stress-study policy | SFXI, RMF, and MSRB interpret declared vectors under separate contracts. The active campaign uses MSRB; SFXI and RMF remain comparison evidence. | [OPAL context](../contexts/opal/README.md) |
+| Campaign state | OPAL plus checked-in study record | Validated features and labels feed model fitting, scoring, selection, ledgers, and the recorded physical handoff. | [OPAL route and commands](decision/opal/README.md) |
+
+Stop when the next contract is absent or fails validation. Do not infer a study
+candidate from a Reader `design_id`, synthesize response-window labels from an
+SFXI score, or treat an accepted physical handoff as evidence of model support.
+
+### Other study routes
 
 | Surface | Owner | State | Detail |
 | --- | --- | --- | --- |
@@ -40,7 +57,6 @@ Use this page after the checked-in study status tells you where the record stand
 | Construct anchor/context refresh | `usr` plus `construct` | `complete` | [Construct](source/construct.md) |
 | LatentDNA comparison surface | `latentdna` | `x_selected_appendix_optional` | [LatentDNA](analysis/latentdna.md) (`routes/analysis/latentdna.md`) |
 | Cluster exploration | `cluster` | `planned` | [Cluster](analysis/cluster.md) |
-| Reader observations and candidate identity | `stress study` | `label_truth_ready` | `src/dnadesign/studies/units/stress_ethanol_cipro_growth/{response_window_observations,promoter_candidate_bindings}/` |
 | OPAL campaigns and synthesis handoff | `opal` plus stress study | `opal_assay_b1_order_ready` | [OPAL](decision/opal/) (`routes/decision/opal/README.md`) |
 | Objective semantics | `opal` mathematics plus `stress study` masks, scales, and decisions | MSRB active learning probe; SFXI and RMF comparison evidence | [MSRB symbol walkthrough](../contexts/opal/multistate-response-behavior-walkthrough.html), [MSRB study binding](../contexts/opal/multistate-response-behavior.md), [SFXI](../contexts/opal/sfxi-round0-source-evidence.md), and [RMF](../contexts/opal/response-magnitude-feasibility.md) |
 

--- a/src/dnadesign/studies/units/stress_ethanol_cipro_growth/README.md
+++ b/src/dnadesign/studies/units/stress_ethanol_cipro_growth/README.md
@@ -3,7 +3,7 @@ id: stress-ethanol-cipro-growth-source
 title: Stress promoter study source surfaces
 owner: stress_ethanol_cipro_growth
 status: active
-last_verified: 2026-07-15
+last_verified: 2026-08-01
 first_hop: ../../../../../docs/studies/stress_ethanol_cipro_growth/routes/README.md
 ---
 
@@ -14,21 +14,40 @@ curation records for the stress / ethanol / ciprofloxacin promoter study. Use
 the docs-side study record for verified status, and use this source package
 when the task needs executable study surfaces or checked-in review artifacts.
 
+## Open the owning surface
+
+| Need | Surface |
+| --- | --- |
+| Current study phase or blocker | [Checked-in status](../../../../../docs/studies/stress_ethanol_cipro_growth/record/status.md) |
+| Reader reductions as candidate observations | [response_window_observations](response_window_observations/README.md) |
+| Promoter alias, candidate, and sequence identity | [promoter_candidate_bindings](promoter_candidate_bindings/README.md) |
+| Approved observations as OPAL labels | [response_window_label_promotion](decision/opal/response_window_label_promotion/README.md) |
+| Objective interpretation, campaign inputs, or synthesis handoff | [OPAL decision surfaces](decision/opal/README.md) |
+| Status and preflight implementation | [operations](operations/README.md) |
+| Checked-in analysis prose and review artifacts | [workbench deliverables](workbench/deliverables/README.md) |
+
+The path is Reader measurements → study identity and observation decisions →
+study-approved labels and candidate features → OPAL objective and campaign.
+None of these layers may silently supply a missing contract from another layer.
+
+## Source orientation
+
 - Binding file: [contexts/latentdna/binding.yaml](../../../../../docs/studies/stress_ethanol_cipro_growth/contexts/latentdna/binding.yaml)
 - Workspace snapshot consumer doc: [stress-ethanol-cipro-representation-comparison.md](../../../latentdna/docs/workflows/stress-ethanol-cipro-representation-comparison.md)
+- Deliverable docs: [workbench/deliverables/README.md](workbench/deliverables/README.md)
+- Study notes: [workbench/notes/README.md](workbench/notes/README.md)
+
+### LatentDNA review inventory
+
 - Active deliverables: `dataset_overview`, `representation_health_summary`, `design_structure_summary`, `sigma35_ordinal_audit`, `context_robustness_summary`, `candidate_decision_frontier`, `candidate_x_selection_scorecard`
 - Companion visuals: `balanced_design_family_margin_gallery`, `sigma35_margin_ladder_gallery`, `sigma35_stress_margin_gallery`, `context_pair_summary`, `reference_to_plan_centroid_heatmap`, `reference_standard_strength_audit`
 - Appendix support: `sigma35_centroid_distance_gallery`, `design_centroid_margin_gallery`, `reference_alignment_summary`, `representation_scree_diagnostic`
 - Appendix deliverables: `appendix_geometry_review`, `appendix_umap_gallery`
-- Deliverable docs: [workbench/deliverables/README.md](workbench/deliverables/README.md)
 - Reference-view branch: `usr_promoter_references` -> `construct_prom_eth_cip_reference_core60` -> `construct_prom_eth_cip_reference_contexts` -> `infer_prom_eth_cip_reference_views_7b`
-- Study notes: [workbench/notes/README.md](workbench/notes/README.md)
 - Bidirectional-context audit: [2026-05-09 bidirectional context-anchor mean confidence](workbench/notes/audits/2026-05-09-bidirectional-context-anchor-mean-confidence.md)
 - View-language prose audit: [2026-05-09 view-language prose](workbench/notes/audits/2026-05-09-view-language-prose.md)
 - Candidate-X rationale and story surfaces: [2026-05-10 candidate-X story surfaces](workbench/notes/rationale/2026-05-10-candidate-x-story-surfaces.md)
 - Native reference processing and ontology audit: [2026-05-10 native reference processing and ontology](workbench/notes/audits/2026-05-10-native-reference-processing-and-ontology.md)
-
-## Source Orientation
 
 ```text
 stress_ethanol_cipro_growth/


### PR DESCRIPTION
## Outcome\n\nMakes the stress-promoter study's first hop explicit without changing scientific data, formulas, objective identifiers, or campaign state.\n\n- separates Reader measurements from study identity, observations, features, labels, and objective interpretation\n- routes the active MSRB campaign distinctly from SFXI and RMF comparison evidence\n- adds one-jump human and machine navigation across the checked-in study surfaces\n- preserves all existing study-owned artifact names and generated deliverables\n\n## Validation\n\n- documentation checks across 505 Markdown files\n- complete stress-study test suite (7 expected skips for unavailable local generated artifacts)\n- Ruff lint and format checks\n- architecture boundaries\n- pre-commit and secret checks\n\nA separate follow-up migrates the preserved historical Reader-consumer recipe to the neutral four-state publication; this documentation does not claim that migration has already landed.