### PR TITLE
Restore the stress route frontmatter budget

### DIFF
--- a/docs/studies/stress_ethanol_cipro_growth/routes/README.md
+++ b/docs/studies/stress_ethanol_cipro_growth/routes/README.md
@@ -15,15 +15,10 @@ Use this page to choose one owner and one next artifact. Current facts belong in
 the [checked-in status](../record/status.md); detailed scientific interpretation
 belongs in `contexts/`; executable declarations belong in `operations/`.
 
-- Status summary: `uv run ops progress show studies.stress-ethanol-cipro-growth.status --json | jq '{state, summary, opal: .evidence.opal}'`
-- Preflight: `uv run ops progress show studies.stress-ethanol-cipro-growth.preflight --scope next --command-timeout-seconds 30 --json`
-- Snapshot route inventory: `evidence.analysis_surfaces.{densegen,latentdna,cluster}`
-
 ### First checks
 
 | Need | Surface |
 | --- | --- |
-| Primary route | This page |
 | Status | `uv run ops progress show studies.stress-ethanol-cipro-growth.status --json \| jq '{state, summary, opal: .evidence.opal}'` |
 | Preflight | `uv run ops progress show studies.stress-ethanol-cipro-growth.preflight --scope next --command-timeout-seconds 30 --json` |
 | Machine-readable contract | `../operations/ops.study.yaml` |
@@ -60,14 +55,6 @@ SFXI score, or treat an accepted physical handoff as evidence of model support.
 | OPAL campaigns and synthesis handoff | `opal` plus stress study | `opal_assay_b1_order_ready` | [OPAL](decision/opal/) (`routes/decision/opal/README.md`) |
 | Objective semantics | `opal` mathematics plus `stress study` masks, scales, and decisions | MSRB active learning probe; SFXI and RMF comparison evidence | [MSRB symbol walkthrough](../contexts/opal/multistate-response-behavior-walkthrough.html), [MSRB study binding](../contexts/opal/multistate-response-behavior.md), [SFXI](../contexts/opal/sfxi-round0-source-evidence.md), and [RMF](../contexts/opal/response-magnitude-feasibility.md) |
 
-### Terminology Guardrails
+### Guardrails
 
-- The study's center of gravity is specification-driven promoter design across regulatory contexts; ethanol/ciprofloxacin is the tractable case study, not the whole contribution.
-- DenseGen generation plans are biological generation conditions such as `background_only`, `ethanol`, `ciprofloxacin`, and `ethanol_ciprofloxacin`.
-- OPAL campaigns are downstream objectives: ethanol factor, ciprofloxacin factor, and AND. AND is not a synonym for every `ethanol_ciprofloxacin` DenseGen row.
-- OPAL reads an `opal_candidate_feature_table`, not just a matrix. The materialized table is the dense generated promoter subset plus measured pDual-10 Reader round-0 rows in `usr_prom_eth_cip_opal_candidates` with X column `latentdna__evo2_7b__context_anchor_mean_bidir_concat`.
-- The shared assay state order is `[00, 10, 01, 11]`; each objective owns its own vector interpretation, masks, diagnostics, and claim boundary.
-- Repeat-label truth, model decision quality, and physical handoff acceptance are independent. The observation policy publishes 27 exact labels and eight exclusions; `model_support_ready` remains false even though the exact 18-candidate handoff is accepted for order.
-- Study lifecycle phases are record-plane state labels such as the current `opal_assay_b1_order_ready`; they are not DenseGen generation plans.
-- Infer lanes are model-family and dataset-target configs such as `anchor_only_20b` or `anchor_plus_template_7b`; they are not lifecycle phases.
-- Route `Plane` values use the repo-wide enum from `ARCHITECTURE.md`. If extra nuance is needed, use `Surface role` rather than inventing a new plane name.
+Use [Promoter design intent](../contexts/promoter-design-intent.md) for terminology and state boundaries; do not redefine them on this route map.


### PR DESCRIPTION
## Outcome

Restores the enforced 60-line first-hop budget for the stress study route map.

## Change

- removes duplicated status and preflight commands
- preserves the full Reader to study to OPAL contract chain
- routes detailed terminology to the existing promoter-design-intent authority
- keeps the progressive-disclosure test unchanged

## Verification

- focused route-boundary regression passed
- documentation checks passed across 505 Markdown files
- pre-commit hooks passed