### PR TITLE
Standardize current Node 24 GitHub Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,7 @@ jobs:
       external-integration-tools-csv: ${{ steps.scope.outputs.external_integration_tools_csv }}
 
     steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -60,7 +60,7 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
@@ -100,7 +100,7 @@ jobs:
       MPLCONFIGDIR: ${{ github.workspace }}/.tmp/matplotlib
 
     steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -255,7 +255,7 @@ jobs:
 
       - name: Upload quality-score coverage summary artifact
         if: needs.detect-ci-scope.outputs.run-full-core == 'true'
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: quality-score-coverage-summary
           path: quality-score-coverage-summary.json
@@ -287,7 +287,7 @@ jobs:
       MPLCONFIGDIR: ${{ github.workspace }}/.tmp/matplotlib
 
     steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -394,7 +394,7 @@ jobs:
       (needs.external-integration.result == 'success' || needs.external-integration.result == 'skipped')
 
     steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
@@ -402,7 +402,7 @@ jobs:
           python-version-file: ".python-version"
 
       - name: Download quality-score coverage summary artifact
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: quality-score-coverage-summary
           path: .
@@ -418,7 +418,7 @@ jobs:
             --output-json quality-score-inputs.json
 
       - name: Upload quality score inputs artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: quality-score-inputs
           path: quality-score-inputs.json

--- a/.github/workflows/quality-entropy.yaml
+++ b/.github/workflows/quality-entropy.yaml
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
@@ -37,7 +37,7 @@ jobs:
 
       - name: Upload quality entropy artifact
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: quality-entropy-report
           path: quality-entropy-report.md

--- a/src/dnadesign/devtools/tests/ci/test_workflow_contract.py
+++ b/src/dnadesign/devtools/tests/ci/test_workflow_contract.py
@@ -27,6 +27,11 @@ def _workflow(filename: str = "ci.yaml") -> dict:
     return yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
 
 
+def _workflow_paths() -> list[Path]:
+    workflow_dir = _repo_root() / ".github" / "workflows"
+    return sorted((*workflow_dir.glob("*.yaml"), *workflow_dir.glob("*.yml")))
+
+
 def test_ci_workflow_uses_core_and_external_integration_lane_ids() -> None:
     workflow = _workflow()
     jobs = workflow["jobs"]
@@ -148,12 +153,8 @@ def test_fresh_ci_lanes_recreate_changed_file_list_before_resolving_test_targets
 
 
 def test_third_party_workflow_actions_are_pinned_to_full_commit_shas() -> None:
-    current = Path(__file__).resolve()
-    repo_root = next(parent for parent in current.parents if (parent / "pyproject.toml").exists())
-    workflow_paths = sorted((repo_root / ".github" / "workflows").glob("*.yaml"))
-
     unpinned: list[str] = []
-    for workflow_path in workflow_paths:
+    for workflow_path in _workflow_paths():
         workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
         for job_id, job in workflow.get("jobs", {}).items():
             for step in job.get("steps", ()):
@@ -178,6 +179,27 @@ def test_dependency_review_workflow_is_pr_only_and_least_privilege() -> None:
     assert "permissions" not in job
     review_step = next(step for step in job["steps"] if step["uses"].startswith("actions/dependency-review-action@"))
     assert review_step["with"]["fail-on-severity"] == "moderate"
+
+
+def test_checkout_and_artifact_actions_use_current_node24_releases() -> None:
+    expected_refs = {
+        "actions/checkout": "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
+        "actions/upload-artifact": "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
+        "actions/download-artifact": "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c",
+    }
+    observed_refs: dict[str, list[str]] = {action: [] for action in expected_refs}
+    for workflow_path in _workflow_paths():
+        workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+        for job in workflow.get("jobs", {}).values():
+            for step in job.get("steps", ()):
+                action_ref = str(step.get("uses", ""))
+                action = action_ref.partition("@")[0]
+                if action in observed_refs:
+                    observed_refs[action].append(action_ref)
+
+    for action, expected_ref in expected_refs.items():
+        assert observed_refs[action], f"expected at least one {action} use"
+        assert set(observed_refs[action]) == {expected_ref}
 
 
 def test_codecov_uploads_use_node24_compatible_action() -> None:


### PR DESCRIPTION
## Summary

- pin checkout, upload-artifact, and download-artifact to current Node 24 releases by exact commit SHA
- standardize checkout across CI and quality workflows
- enforce the approved refs across both `.yaml` and `.yml` workflow files

## Why

This removes Node 20 action-runtime warnings and makes artifact digest mismatches fail closed through the current download action. It does not change workflow permissions or the producer/consumer artifact names.

## Verification

- 21 workflow-contract tests passed
- a temporary stale checkout in a `.yml` workflow failed the new contract as intended
- all pre-commit hooks passed
- Ruff check and format passed
- independent adversarial review found no remaining findings

## Review focus

- exact action SHAs and Node 24 compatibility
- artifact upload/download interoperability
- repository-wide workflow discovery and least privilege