### PR TITLE
build: align security, packaging, and Junction contracts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -137,7 +137,7 @@ jobs:
         run: uv run python -m dnadesign.devtools.architecture.boundaries
 
       - name: Package layout contracts
-        run: uv run pytest -q src/dnadesign/devtools/tests/package/test_layout.py
+        run: uv run pytest -q src/dnadesign/devtools/tests/package
 
       - name: Pre-commit (non-Ruff hooks)
         env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,8 +114,35 @@ test = ["pytest>=9.0.3", "pytest-cov", "hypothesis>=6.100"]
 lint = ["ruff>=0.4", "pre-commit>=3.7"]
 dev  = [{ include-group = "test" }, { include-group = "lint" }]
 
+[tool.setuptools]
+# Runtime-owned resource trees rely on Git-backed package data in addition to
+# the targeted package-data declarations below.
+include-package-data = true
+
 [tool.setuptools.packages.find]
 where = ["src"]
+exclude = [
+  "dnadesign.archived",
+  "dnadesign.archived.*",
+  "dnadesign.prototypes",
+  "dnadesign.prototypes.*",
+  "dnadesign.usr.archived",
+  "dnadesign.usr.archived.*",
+  "dnadesign.usr.datasets.usr_regulondb_native_promoters",
+  "dnadesign.usr.datasets.usr_regulondb_native_promoters.*",
+  "dnadesign.opal.campaigns.*.notebooks",
+  "dnadesign.opal.campaigns.*.notebooks.*",
+  "dnadesign.densegen.workspaces.*.outputs.notebooks",
+  "dnadesign.densegen.workspaces.*.outputs.notebooks.*",
+  "dnadesign.latentdna.workspaces.*.outputs.notebooks",
+  "dnadesign.latentdna.workspaces.*.outputs.notebooks.*",
+  "dnadesign.studies.units.*.workspaces.*.outputs.*.notebooks",
+  "dnadesign.studies.units.*.workspaces.*.outputs.*.notebooks.*",
+  "dnadesign.studies.units.*.workbench.outputs",
+  "dnadesign.studies.units.*.workbench.outputs.*",
+  "dnadesign.studies.units.*.workbench.source_evidence.*.notebooks",
+  "dnadesign.studies.units.*.workbench.source_evidence.*.notebooks.*",
+]
 
 [tool.setuptools.package-data]
 "dnadesign.cruncher" = [
@@ -184,6 +211,15 @@ where = ["src"]
 ]
 "dnadesign.usr" = [
   "ops/status.registry.yaml",
+]
+
+[tool.setuptools.exclude-package-data]
+"*" = [
+  "reader_spop_*.parquet",
+  "remotes.yaml",
+]
+"dnadesign.densegen" = [
+  "workspaces/*/config.probe.*.yaml",
 ]
 
 [tool.pytest.ini_options]

--- a/src/dnadesign/devtools/tests/ci/test_workflow_contract.py
+++ b/src/dnadesign/devtools/tests/ci/test_workflow_contract.py
@@ -128,7 +128,7 @@ def test_core_lane_fails_fast_on_package_layout_contracts() -> None:
     step_names = [str(step.get("name", "")) for step in steps]
     layout_step = next(step for step in steps if step.get("name") == "Package layout contracts")
 
-    assert layout_step["run"] == "uv run pytest -q src/dnadesign/devtools/tests/package/test_layout.py"
+    assert layout_step["run"] == "uv run pytest -q src/dnadesign/devtools/tests/package"
     assert step_names.index("Package layout contracts") < step_names.index("Tests (core lane) + coverage report")
 
 

--- a/src/dnadesign/devtools/tests/package/test_distribution.py
+++ b/src/dnadesign/devtools/tests/package/test_distribution.py
@@ -1,0 +1,219 @@
+"""
+--------------------------------------------------------------------------------
+dnadesign
+src/dnadesign/devtools/tests/package/test_distribution.py
+
+Distribution discovery and content-boundary contract tests.
+
+Module Author(s): Eric J. South
+--------------------------------------------------------------------------------
+"""
+
+from __future__ import annotations
+
+import subprocess
+import tomllib
+import zipfile
+from pathlib import Path
+
+from setuptools import Distribution, find_namespace_packages
+from setuptools.config.pyprojecttoml import apply_configuration
+
+_DISTRIBUTION_EXCLUDES = [
+    "dnadesign.archived",
+    "dnadesign.archived.*",
+    "dnadesign.prototypes",
+    "dnadesign.prototypes.*",
+    "dnadesign.usr.archived",
+    "dnadesign.usr.archived.*",
+    "dnadesign.usr.datasets.usr_regulondb_native_promoters",
+    "dnadesign.usr.datasets.usr_regulondb_native_promoters.*",
+    "dnadesign.opal.campaigns.*.notebooks",
+    "dnadesign.opal.campaigns.*.notebooks.*",
+    "dnadesign.densegen.workspaces.*.outputs.notebooks",
+    "dnadesign.densegen.workspaces.*.outputs.notebooks.*",
+    "dnadesign.latentdna.workspaces.*.outputs.notebooks",
+    "dnadesign.latentdna.workspaces.*.outputs.notebooks.*",
+    "dnadesign.studies.units.*.workspaces.*.outputs.*.notebooks",
+    "dnadesign.studies.units.*.workspaces.*.outputs.*.notebooks.*",
+    "dnadesign.studies.units.*.workbench.outputs",
+    "dnadesign.studies.units.*.workbench.outputs.*",
+    "dnadesign.studies.units.*.workbench.source_evidence.*.notebooks",
+    "dnadesign.studies.units.*.workbench.source_evidence.*.notebooks.*",
+]
+_DISTRIBUTION_DATA_EXCLUDES = [
+    "reader_spop_*.parquet",
+    "remotes.yaml",
+]
+_DENSEGEN_DATA_EXCLUDES = [
+    "workspaces/*/config.probe.*.yaml",
+]
+_EXCLUDED_PACKAGE_SENTINELS = {
+    "dnadesign.archived.legacy",
+    "dnadesign.prototypes.sketch",
+    "dnadesign.usr.archived.legacy",
+    "dnadesign.usr.datasets.usr_regulondb_native_promoters.local",
+    "dnadesign.opal.campaigns.demo.notebooks",
+    "dnadesign.densegen.workspaces.demo.outputs.notebooks",
+    "dnadesign.latentdna.workspaces.demo.outputs.notebooks",
+    "dnadesign.studies.units.demo.workspaces.demo.outputs.review.notebooks",
+    "dnadesign.studies.units.demo.workbench.outputs.review",
+    "dnadesign.studies.units.demo.workbench.source_evidence.legacy.notebooks",
+}
+_RETAINED_PACKAGE_SENTINELS = {
+    "dnadesign.opal.campaigns.demo.notebooks_api",
+    "dnadesign.densegen.workspaces.demo.outputs.notebooks_api",
+    "dnadesign.latentdna.workspaces.demo.outputs.notebooks_api",
+    "dnadesign.studies.units.demo.workspaces.demo.outputs.review.notebooks_api",
+    "dnadesign.studies.units.demo.workbench.outputs_api",
+    "dnadesign.studies.units.demo.workbench.source_evidence.legacy.notebooks_api",
+}
+_REQUIRED_WHEEL_MEMBERS = {
+    "dnadesign/baserender/styles/style_v1/presentation_default.yaml",
+    "dnadesign/opal/campaigns/demo_gp_topn/configs/campaign.yaml",
+    "dnadesign/opal/campaigns/demo_rf_sfxi_topn/records.parquet",
+    "dnadesign/usr/datasets/registry.yaml",
+}
+_FORBIDDEN_WHEEL_PREFIXES = (
+    "dnadesign/archived/",
+    "dnadesign/prototypes/",
+    "dnadesign/usr/archived/",
+    "dnadesign/usr/datasets/usr_regulondb_native_promoters/",
+)
+
+
+def _repo_root() -> Path:
+    current = Path(__file__).resolve()
+    return next(parent for parent in current.parents if (parent / "pyproject.toml").exists())
+
+
+def test_distribution_excludes_internal_source_shelves(tmp_path: Path) -> None:
+    repo_root = _repo_root()
+    project = tomllib.loads((repo_root / "pyproject.toml").read_text(encoding="utf-8"))
+    discovery = project["tool"]["setuptools"]["packages"]["find"]
+    excluded = discovery["exclude"]
+
+    assert project["tool"]["setuptools"]["include-package-data"] is True
+    assert excluded == _DISTRIBUTION_EXCLUDES
+    assert project["tool"]["setuptools"]["exclude-package-data"]["*"] == _DISTRIBUTION_DATA_EXCLUDES
+    assert project["tool"]["setuptools"]["exclude-package-data"]["dnadesign.densegen"] == _DENSEGEN_DATA_EXCLUDES
+
+    source_root = tmp_path / "src"
+    (source_root / "dnadesign" / "active").mkdir(parents=True)
+    for package in _EXCLUDED_PACKAGE_SENTINELS | _RETAINED_PACKAGE_SENTINELS:
+        (source_root / package.replace(".", "/")).mkdir(parents=True)
+
+    discovered = set(
+        find_namespace_packages(
+            where=str(source_root),
+            exclude=excluded,
+        )
+    )
+
+    assert {"dnadesign", "dnadesign.active"} <= discovered
+    assert discovered.isdisjoint(_EXCLUDED_PACKAGE_SENTINELS)
+    assert _RETAINED_PACKAGE_SENTINELS <= discovered
+
+
+def test_distribution_contains_no_ignored_python_sources() -> None:
+    repo_root = _repo_root()
+    project = tomllib.loads((repo_root / "pyproject.toml").read_text(encoding="utf-8"))
+    discovery = project["tool"]["setuptools"]["packages"]["find"]
+    source_root = repo_root / discovery["where"][0]
+    packages = find_namespace_packages(
+        where=str(source_root),
+        exclude=discovery["exclude"],
+    )
+    packaged_sources = {
+        path.resolve() for package in packages for path in (source_root / package.replace(".", "/")).glob("*.py")
+    }
+
+    accepted = subprocess.run(
+        [
+            "git",
+            "ls-files",
+            "-z",
+            "--cached",
+            "--others",
+            "--exclude-standard",
+            "--",
+            "src/dnadesign",
+        ],
+        cwd=repo_root,
+        check=True,
+        capture_output=True,
+    ).stdout.split(b"\0")
+    accepted_sources = {
+        (repo_root / relative.decode()).resolve() for relative in accepted if relative and relative.endswith(b".py")
+    }
+
+    assert packaged_sources <= accepted_sources
+
+
+def test_distribution_excludes_private_and_generated_package_data() -> None:
+    repo_root = _repo_root()
+    distribution = Distribution()
+    distribution.script_name = "pyproject.toml"
+    apply_configuration(distribution, repo_root / "pyproject.toml")
+    command = distribution.get_command_obj("build_py")
+    command.ensure_finalized()
+
+    excluded_cases = (
+        (
+            "dnadesign.densegen",
+            repo_root / "src/dnadesign/densegen",
+            "workspaces/demo/config.probe.stall10.yaml",
+        ),
+        (
+            "dnadesign.usr",
+            repo_root / "src/dnadesign/usr",
+            "remotes.yaml",
+        ),
+        (
+            "dnadesign.latentdna.workspaces.demo.study_inputs",
+            repo_root / "src/dnadesign/latentdna/workspaces/demo/study_inputs",
+            "reader_spop_observations.parquet",
+        ),
+    )
+    for package, source_dir, relative_path in excluded_cases:
+        candidate = str(source_dir / relative_path)
+        assert command.exclude_data_files(package, str(source_dir), [candidate]) == []
+
+    retained_cases = (
+        (
+            "dnadesign.usr",
+            repo_root / "src/dnadesign/usr",
+            "ops/status.registry.yaml",
+        ),
+        (
+            "dnadesign.opal.campaigns.demo",
+            repo_root / "src/dnadesign/opal/campaigns/demo",
+            "records.parquet",
+        ),
+    )
+    for package, source_dir, relative_path in retained_cases:
+        candidate = str(source_dir / relative_path)
+        assert command.exclude_data_files(package, str(source_dir), [candidate]) == [candidate]
+
+
+def test_built_wheel_retains_runtime_resources_without_internal_shelves(tmp_path: Path) -> None:
+    repo_root = _repo_root()
+    subprocess.run(
+        ["uv", "build", "--wheel", "--out-dir", str(tmp_path)],
+        cwd=repo_root,
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    wheels = list(tmp_path.glob("*.whl"))
+    assert len(wheels) == 1
+
+    with zipfile.ZipFile(wheels[0]) as wheel:
+        members = set(wheel.namelist())
+
+    assert _REQUIRED_WHEEL_MEMBERS <= members
+    assert not any(member.startswith(_FORBIDDEN_WHEEL_PREFIXES) for member in members)
+    assert not any("config.probe." in member for member in members)
+    assert "dnadesign/usr/remotes.yaml" not in members
+    assert not any("/reader_spop_" in member for member in members)

--- a/src/dnadesign/devtools/tests/security/test_dependency_security_contract.py
+++ b/src/dnadesign/devtools/tests/security/test_dependency_security_contract.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import ast
 import pickle
 import re
+import subprocess
 import tomllib
 from datetime import date
 from pathlib import Path
@@ -29,6 +30,42 @@ def _repo_root() -> Path:
 def _pyproject() -> dict[str, object]:
     with (_repo_root() / "pyproject.toml").open("rb") as handle:
         return tomllib.load(handle)
+
+
+def _repository_source_files(
+    repo_root: Path,
+    *,
+    roots: tuple[str, ...],
+    suffixes: frozenset[str],
+) -> tuple[Path, ...]:
+    completed = subprocess.run(
+        [
+            "git",
+            "-C",
+            str(repo_root),
+            "ls-files",
+            "-z",
+            "--cached",
+            "--others",
+            "--exclude-standard",
+            "--",
+            *roots,
+        ],
+        check=False,
+        capture_output=True,
+    )
+    if completed.returncode != 0:
+        detail = completed.stderr.decode("utf-8", errors="replace").strip()
+        raise RuntimeError(f"git ls-files failed: {detail or 'unknown error'}")
+
+    sources: list[Path] = []
+    for raw_path in completed.stdout.split(b"\0"):
+        if not raw_path:
+            continue
+        relative_path = Path(raw_path.decode("utf-8"))
+        if relative_path.suffix in suffixes:
+            sources.append(relative_path)
+    return tuple(sorted(sources))
 
 
 def test_security_floors_are_published_by_their_owning_dependency_sets() -> None:
@@ -70,14 +107,16 @@ def test_bounded_dependency_exception_does_not_enter_supported_code() -> None:
     forbidden = ("torch.jit." + "script",)
     violations: list[str] = []
 
-    for root in (repo_root / ".github", repo_root / "src"):
-        for path in root.rglob("*"):
-            if not path.is_file() or path.suffix not in {".json", ".py", ".toml", ".yaml", ".yml"}:
-                continue
-            text = path.read_text(encoding="utf-8")
-            for symbol in forbidden:
-                if symbol in text:
-                    violations.append(f"{path.relative_to(repo_root)}: {symbol}")
+    source_files = _repository_source_files(
+        repo_root,
+        roots=(".github", "src"),
+        suffixes=frozenset({".json", ".py", ".toml", ".yaml", ".yml"}),
+    )
+    for relative_path in source_files:
+        text = (repo_root / relative_path).read_text(encoding="utf-8")
+        for symbol in forbidden:
+            if symbol in text:
+                violations.append(f"{relative_path}: {symbol}")
 
     assert violations == []
 
@@ -197,17 +236,48 @@ def _torch_boundary_violations(source: str, *, filename: str) -> list[str]:
 def test_torch_deserialization_and_execution_boundaries_fail_closed() -> None:
     repo_root = _repo_root()
     violations: list[str] = []
-    for path in (repo_root / "src" / "dnadesign").rglob("*.py"):
-        if "tests" in path.parts:
+    source_files = _repository_source_files(
+        repo_root,
+        roots=("src/dnadesign",),
+        suffixes=frozenset({".py"}),
+    )
+    for relative_path in source_files:
+        if "tests" in relative_path.parts:
             continue
+        path = repo_root / relative_path
         violations.extend(
             _torch_boundary_violations(
                 path.read_text(encoding="utf-8"),
-                filename=path.relative_to(repo_root).as_posix(),
+                filename=relative_path.as_posix(),
             )
         )
 
     assert violations == []
+
+
+def test_torch_boundary_scope_includes_new_source_and_excludes_ignored_archives(tmp_path: Path) -> None:
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+    tracked = tmp_path / "src" / "dnadesign" / "live.py"
+    tracked.parent.mkdir(parents=True)
+    tracked.write_text("import torch\ntorch.load('safe.pt', weights_only=True)\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(tmp_path), "add", tracked.relative_to(tmp_path)], check=True)
+
+    candidate = tmp_path / "src" / "dnadesign" / "candidate.py"
+    candidate.write_text("import torch\ntorch.load('unsafe.pt')\n", encoding="utf-8")
+
+    (tmp_path / ".gitignore").write_text("src/dnadesign/archived/\n", encoding="utf-8")
+    ignored = tmp_path / "src" / "dnadesign" / "archived" / "legacy.py"
+    ignored.parent.mkdir(parents=True)
+    ignored.write_text("import torch\ntorch.load('unsafe.pt')\n", encoding="utf-8")
+
+    assert _repository_source_files(
+        tmp_path,
+        roots=("src/dnadesign",),
+        suffixes=frozenset({".py"}),
+    ) == (
+        Path("src/dnadesign/candidate.py"),
+        Path("src/dnadesign/live.py"),
+    )
 
 
 @pytest.mark.parametrize(

--- a/src/dnadesign/junction/docs/getting-started.md
+++ b/src/dnadesign/junction/docs/getting-started.md
@@ -3,7 +3,7 @@
 **Type:** tutorial
 **Audience:** first-time users
 **Owner:** dnadesign-maintainers
-**Last verified:** 2026-08-02
+**Last verified:** 2026-08-03
 
 This tutorial publishes and verifies one small synthetic design. Its short
 oligos, 8-nt toeholds, loose composition bounds, and small search budgets make
@@ -70,9 +70,11 @@ primers or predict PCR behavior. The order labels are copied into the output;
 the tool does not choose a supplier or submit an order.
 
 `nominal_fragment_oligo_length` sets the planner's locus geometry. It is not a
-promise that every fragment order has that length: candidate offsets can
-produce an order as long as the nominal value plus `search_range - 1`, and a
-terminal fragment can be shorter. The tutorial sets
+promise that every fragment order has that length. The maximum is the larger
+of the offset-expanded length `L + R - 1` and the terminal-complement length
+`L - b + t`, where `L`, `R`, `b`, and `t` are the nominal length, search range,
+barcode length, and toehold length. A terminal fragment can also be shorter.
+The tutorial sets
 `minimum_fragment_oligo_length: 1` only so its small synthetic example is easy
 to run. Choose and review a real minimum for synthesis work. `junction` checks
 the declared minimum and maximum as string lengths; it does not judge whether

--- a/src/dnadesign/junction/docs/guides/prepare-a-request.md
+++ b/src/dnadesign/junction/docs/guides/prepare-a-request.md
@@ -3,7 +3,7 @@
 **Type:** guide
 **Audience:** users turning exact targets into a reviewed design request
 **Owner:** dnadesign-maintainers
-**Last verified:** 2026-08-02
+**Last verified:** 2026-08-03
 
 `junction` does not infer a complete design from a sequence alone. Before
 planning, supply five things:
@@ -126,11 +126,17 @@ The tool never relaxes these values automatically. Candidate exhaustion fails
 with the original request preserved.
 
 `nominal_fragment_oligo_length` is a coordinate parameter, not a physical
-length guarantee. The current method can emit fragment orders as long as
-`nominal_fragment_oligo_length + search_range - 1`; terminal fragment orders
-can be shorter than the nominal value. This differs from the Nature paper's
-use of `L` for the physical input-oligo length. Inspect the planned order
-lengths instead of treating the field name as a purchasing specification.
+length guarantee. The longest possible fragment order is the larger of:
+
+- `nominal_fragment_oligo_length + search_range - 1`, for an offset-expanded
+  strand; and
+- `nominal_fragment_oligo_length - barcode_length + toehold_length`, for a
+  terminal complement strand.
+
+Terminal fragment orders can also be shorter than the nominal value. This
+differs from the Nature paper's use of `L` for the physical input-oligo length.
+Inspect the planned order lengths instead of treating the field name as a
+purchasing specification.
 
 ## Declare order metadata
 


### PR DESCRIPTION
## Summary

- enumerate tracked and new non-ignored source files through Git for dependency-security scans
- retain fail-closed coverage for new ship-candidate Python and configuration files
- add a regression fixture covering tracked, untracked, and ignored source
- state both executable fragment-order length bounds in the Junction tutorial and request guide
- exclude ignored archive, prototype, generated-notebook, output-review, and private local-data content from wheel discovery
- retain Git-backed runtime resources and test the built wheel for BaseRender, OPAL, USR, and forbidden-path boundaries
- fail the package-contract lane if any discovered Python build source is ignored by Git

## Failures reproduced

The previous filesystem-wide security scan failed locally on seven unsafe `torch.load` calls under the 4.4 GB ignored and untracked `src/dnadesign/archived/` tree. CI stayed green because that local archive is absent from the checkout. `git ls-files src/dnadesign/archived/**` returns no tracked files.

Reviewer 2 also found that two Junction guides described only the offset-expanded order-length bound. The request contract and implementation already enforce the larger of `L + R - 1` and `L - b + t`; the prose now matches that executable rule.

A direct local-wheel audit reproduced 241 ignored Python modules and two generated probe configs eligible for publication from the populated checkout; an older stale wheel also retained retired local-data paths. Exact namespace and package-data exclusions block those paths without disabling Git-backed package data. The built-wheel test proves that tracked BaseRender styles, OPAL demo campaign data, tracked demo Parquet, and the USR registry remain present. The ignored local trees are not deleted.

Manual in-place builds can still reuse stale egg-info for additional already-tracked files. Dnadesign is not published to PyPI; any future shared distribution must use a clean snapshot and inspect the archive inventory.

## Verification

- security, package, and workflow-contract tests — 57 passed
- `pytest -q src/dnadesign/devtools/tests/package` — 9 passed, including a real wheel build
- populated-checkout package-source audit — zero ignored Python sources after exclusions
- built-wheel resource smoke — BaseRender, OPAL, tracked Parquet, and USR resources present; forbidden shelves absent
- focused Junction request/method tests — passed
- all Junction tests — 260 passed
- docs checks — 521 Markdown files passed
- Ruff check and format — passed
- focused pre-commit hooks — passed
- architecture boundaries — passed
