### PR TITLE
ci: isolate Codecov telemetry failures

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -267,14 +267,17 @@ jobs:
           name: quality-score-coverage-summary
           path: quality-score-coverage-summary.json
 
-      - name: Upload core-lane coverage to Codecov
+      # Local tests and coverage thresholds are authoritative; this upload is telemetry.
+      - name: Publish core-lane coverage to Codecov (non-blocking)
         if: needs.detect-ci-scope.outputs.run-coverage-gate == 'true'
+        continue-on-error: true
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: coverage-core.xml
           flags: core
           use_oidc: true
           fail_ci_if_error: true
+          version: v11.3.1
           verbose: true
 
       - name: Build (sdist + wheel)
@@ -381,13 +384,16 @@ jobs:
             --lane-name external-integration \
             --required-tools-csv "${{ needs.detect-ci-scope.outputs.external-integration-tools-csv }}"
 
-      - name: Upload external-integration coverage to Codecov
+      # The integration tests gate this job; Codecov availability does not.
+      - name: Publish external-integration coverage to Codecov (non-blocking)
+        continue-on-error: true
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           files: coverage-external-integration.xml
           flags: external_integration
           use_oidc: true
           fail_ci_if_error: true
+          version: v11.3.1
           verbose: true
 
   quality-score-inputs:

--- a/src/dnadesign/devtools/tests/ci/test_workflow_contract.py
+++ b/src/dnadesign/devtools/tests/ci/test_workflow_contract.py
@@ -251,18 +251,23 @@ def test_checkout_and_artifact_actions_use_current_node24_releases() -> None:
         assert set(observed_refs[action]) == {expected_ref}
 
 
-def test_codecov_uploads_use_node24_compatible_action() -> None:
+def test_codecov_uploads_are_pinned_verified_and_non_gating() -> None:
     workflow = _workflow()
     expected_ref = "codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f"
 
-    upload_refs = [
-        str(step.get("uses", ""))
+    upload_steps = [
+        step
         for job in workflow["jobs"].values()
         for step in job.get("steps", ())
         if str(step.get("uses", "")).startswith("codecov/codecov-action@")
     ]
 
-    assert upload_refs == [expected_ref, expected_ref]
+    assert [str(step["uses"]) for step in upload_steps] == [expected_ref, expected_ref]
+    for step in upload_steps:
+        assert step["continue-on-error"] is True
+        assert step["with"]["fail_ci_if_error"] is True
+        assert step["with"]["use_oidc"] is True
+        assert step["with"]["version"] == "v11.3.1"
 
 
 def test_quality_entropy_job_uses_stdlib_only_runtime() -> None:


### PR DESCRIPTION
## Summary

- pin the Codecov CLI used by the SHA-pinned action
- keep Codecov verification strict while treating the remote upload as non-blocking telemetry
- enforce the boundary in the CI workflow contract

## Evidence

- reproduced post-merge failure after all FIMO/MEME tests passed: Codecov could not import its Keybase signing key
- `25` workflow-contract tests passed
- Ruff and format checks passed
- YAML and GitHub workflow validation passed
- the pinned `v11.3.1` checksum endpoint responds successfully

The repository-local test and coverage gates remain required. Only third-party coverage publication is non-gating.