### PR TITLE
Add portable external study workspace contracts

### DIFF
--- a/docs/studies/README.md
+++ b/docs/studies/README.md
@@ -38,6 +38,7 @@ Use these surfaces by intent:
 | A request asks for status, history, blockers, or readiness | [Study Ops status surfaces](reference/study-status-ops-surfaces.md) | Use Ops only when the task is explicitly observation or readiness. |
 | A request asks how to add or refresh study records | [Study record authoring](reference/study-record-authoring.md) | Keep authoring and promoter-template details out of this top-level router. |
 | A study contains private sequences, measurements, campaign state, or unpublished intent | [Public/private study boundary](reference/public-private-boundary.md) | Keep the study in a private external workspace and depend on dnadesign's public contracts. |
+| An external repository needs a portable catalog and evidence inventory | [Study workspace contract](reference/study-workspace-contract.md) | Use the strict, tool-neutral `study/v1` contract instead of path-based discovery. |
 
 ### Checked-In Study Routes
 
@@ -178,6 +179,7 @@ instead of growing a study-local tool.
 - [Study status and preflight surfaces](reference/study-status-ops-surfaces.md)
 - [Study record authoring](reference/study-record-authoring.md)
 - [Public/private study boundary](reference/public-private-boundary.md)
+- [External study workspace contract](reference/study-workspace-contract.md)
 - [Study index](index.yaml)
 - [Retron hairpin route map](retron_hairpin_design/routes/README.md)
 - [Stress ethanol/cipro route map](stress_ethanol_cipro_growth/routes/README.md)

--- a/docs/studies/reference/README.md
+++ b/docs/studies/reference/README.md
@@ -1,13 +1,14 @@
 ## Study Reference Docs
 
 **Owner:** dnadesign-maintainers
-**Last verified:** 2026-05-18
+**Last verified:** 2026-08-08
 
-This directory holds maintainer-facing study-record rules. Keep live study
-records under `docs/studies/<study-id>/`; keep reusable authoring and Ops
-surface guidance here.
+This directory holds maintainer-facing study-record rules. Reusable contracts
+stay here. Private study records belong in an external workspace.
 
 Start with:
 
 - [Study status and preflight surfaces](study-status-ops-surfaces.md)
 - [Study record authoring](study-record-authoring.md)
+- [Public and private study boundary](public-private-boundary.md)
+- [External study workspace contract](study-workspace-contract.md)

--- a/docs/studies/reference/public-private-boundary.md
+++ b/docs/studies/reference/public-private-boundary.md
@@ -26,10 +26,10 @@ not a hidden subtree inside the public checkout. It depends on a pinned
 dnadesign version and calls public APIs or CLIs. dnadesign must not discover it
 through machine-specific paths or import its study modules.
 
-`dnadesign.studies.core` already loads `docs/studies/index.yaml` and
-`operations/ops.study.yaml` from an explicit repository root. The external
-repository therefore keeps the same record contract without becoming a
-dnadesign source subtree.
+`dnadesign.studies.core.load_study_workspace()` loads the portable
+[`study/v1` workspace contract](study-workspace-contract.md) from an explicit
+repository root. The external repository therefore owns its catalog and study
+records without becoming a dnadesign source subtree.
 
 ### External workspace contract
 
@@ -37,7 +37,7 @@ A private study workspace should declare:
 
 1. its own repository and access policy;
 2. a pinned dnadesign revision or release;
-3. one explicit study root;
+3. one `catalog/studies.yaml` entrypoint with stable study identifiers;
 4. typed inputs and outputs at each tool handoff; and
 5. private CI that runs its routes against that pinned dependency.
 

--- a/docs/studies/reference/study-workspace-contract.md
+++ b/docs/studies/reference/study-workspace-contract.md
@@ -1,0 +1,120 @@
+---
+doc_id: study-workspace-contract
+surface: study-architecture
+owner: dnadesign-maintainers
+last_verified: 2026-08-08
+---
+
+## Study workspace contract
+
+Use `study-catalog/v1` when studies live outside the dnadesign repository. The
+contract answers three questions without interpreting the science:
+
+1. Which programs and studies exist?
+2. Where does a reader start for each study and tool handoff?
+3. Which review artifacts are available, stale, superseded, or blocked?
+
+The catalog does not select a global active study. Callers must name the study
+they intend to inspect or run.
+
+### Catalog
+
+Place the catalog at `catalog/studies.yaml`:
+
+```yaml
+schema: study-catalog/v1
+programs:
+  - program_id: stress_response
+    title: Stress response
+    entrypoint: programs/stress-response/README.md
+studies:
+  - study_id: promoter_response
+    manifest: programs/stress-response/studies/promoter-response/study.yaml
+```
+
+`program_id` groups related work for navigation. It does not grant one study
+authority over another.
+
+### Study manifest
+
+Each catalog entry points to one `study.yaml`:
+
+```yaml
+schema: study/v1
+study_id: promoter_response
+program_id: stress_response
+title: Promoter response
+summary: Measures promoter responses across declared conditions.
+visibility: private
+status: active
+owners:
+  - stress-study-maintainers
+last_verified: 2026-08-08
+entrypoint: README.md
+operations: operations/ops.study.yaml
+evidence_index: evidence/index.yaml
+workflows:
+  - tool_id: reader
+    route: workflows/reader/README.md
+    requires: reader-workbench>=0.1
+  - tool_id: dnadesign
+    route: workflows/dnadesign/README.md
+    requires: dnadesign>=0.1
+```
+
+The manifest owns identity and routes, not formulas, sample metadata, or tool
+configuration. Put those details behind the declared entrypoints.
+
+### Evidence index
+
+`study-evidence-index/v1` records reviewable outputs without putting raw data
+or large generated bundles in Git:
+
+```yaml
+schema: study-evidence-index/v1
+study_id: promoter_response
+artifacts:
+  - artifact_id: response_review
+    artifact_type: review-figure
+    status: available
+    path: review/response-review.svg
+    media_type: image/svg+xml
+    content_digest: sha256:<64 lowercase hex characters>
+    source_revisions:
+      reader: record:response-window@sha256:<digest>
+    generated_by:
+      - uv
+      - run
+      - study
+      - render
+      - promoter_response
+```
+
+An available, stale, or superseded artifact must declare exactly one tracked
+`path` or external `uri`, a SHA-256 digest, source revisions, and the command
+that produced it. A blocked artifact declares a `blocker` and no output
+location.
+
+### Python API
+
+```python
+from pathlib import Path
+
+from dnadesign.studies.core import load_study_workspace
+
+workspace = load_study_workspace(Path("../research-studies"))
+study = workspace.study_index["promoter_response"]
+print(study.entrypoint)
+```
+
+Loading fails on unknown keys, duplicate identifiers, undeclared programs,
+identity drift, missing routes, path traversal, symlink escapes, invalid
+artifact states, and tracked-file digest mismatches. External URIs are syntax
+checked but not downloaded; the owning study CI verifies remote availability.
+
+### Ownership boundary
+
+- dnadesign owns the loader and validation rules.
+- The external repository owns catalog instances, study meaning, and evidence.
+- Reader, dnadesign, and OPAL remain owners of their public workflow APIs.
+- Workspace routers may point to the catalog but must not copy study facts.

--- a/src/dnadesign/studies/README.md
+++ b/src/dnadesign/studies/README.md
@@ -10,6 +10,7 @@ status and preflight APIs; `core` owns neutral record parsing.
 - [Study records index](../../../docs/studies/README.md): checked-in study
   manifests, routes, and status notes.
 - [Public/private boundary](../../../docs/studies/reference/public-private-boundary.md): decide whether a study may live in this public repository.
+- [External workspace contract](../../../docs/studies/reference/study-workspace-contract.md): load a private repository's catalog, study manifests, and evidence indexes.
 - [Ops README](../ops/README.md): status, preflight, and orchestration entry
   points.
 - [Repository docs index](../../../docs/README.md): cross-tool workflow routing.
@@ -17,8 +18,8 @@ status and preflight APIs; `core` owns neutral record parsing.
 ## Source Layout
 
 - `assets/`: study-package visual/static assets.
-- `core/`: study-record contracts, loaders, selectors, and preflight planning
-  primitives that are not tied to one study.
+- `core/`: study-record contracts, portable workspace loading, selectors, and
+  preflight planning primitives that are not tied to one study.
 - `units/<study-id>/`: concrete study source units. Study-specific status,
   preflight, compiler, or handoff logic stays inside the owning study.
 - `units/<study-id>/tests/`: concrete study tests. Study-specific tests stay

--- a/src/dnadesign/studies/core/__init__.py
+++ b/src/dnadesign/studies/core/__init__.py
@@ -49,6 +49,16 @@ from .record_locator import (
     discover_study_selection_for_status_kind,
 )
 from .registry import StudyIndex, StudyIndexEntry, load_study_index
+from .workspace import (
+    StudyArtifact,
+    StudyCatalogProgram,
+    StudyEvidenceIndex,
+    StudyManifest,
+    StudyWorkflow,
+    StudyWorkspace,
+    load_study_evidence_index,
+    load_study_workspace,
+)
 
 __all__ = [
     "ActiveStudySelection",
@@ -68,6 +78,10 @@ __all__ = [
     "ReaderResolvedRecord",
     "StudyIndex",
     "StudyIndexEntry",
+    "StudyArtifact",
+    "StudyCatalogProgram",
+    "StudyEvidenceIndex",
+    "StudyManifest",
     "StudyOpsContract",
     "StudyPhaseContract",
     "StudyPreflightContract",
@@ -75,11 +89,15 @@ __all__ = [
     "StudyPreflightPlan",
     "StudyStatusService",
     "StudyStatusContext",
+    "StudyWorkflow",
+    "StudyWorkspace",
     "build_study_preflight_plan",
     "discover_active_study_selection",
     "discover_study_selection_for_status_kind",
     "load_study_index",
+    "load_study_evidence_index",
     "load_study_ops_contract",
+    "load_study_workspace",
     "normalize_study_preflight_scope",
     "parse_record_inputs",
     "parse_record_producer",

--- a/src/dnadesign/studies/core/workspace/__init__.py
+++ b/src/dnadesign/studies/core/workspace/__init__.py
@@ -1,0 +1,23 @@
+"""Portable, fail-fast contracts for external study workspaces."""
+
+from .contracts import (
+    StudyArtifact,
+    StudyCatalogProgram,
+    StudyEvidenceIndex,
+    StudyManifest,
+    StudyWorkflow,
+    StudyWorkspace,
+)
+from .evidence import load_study_evidence_index
+from .loading import load_study_workspace
+
+__all__ = [
+    "StudyArtifact",
+    "StudyCatalogProgram",
+    "StudyEvidenceIndex",
+    "StudyManifest",
+    "StudyWorkflow",
+    "StudyWorkspace",
+    "load_study_evidence_index",
+    "load_study_workspace",
+]

--- a/src/dnadesign/studies/core/workspace/__init__.py
+++ b/src/dnadesign/studies/core/workspace/__init__.py
@@ -1,4 +1,13 @@
-"""Portable, fail-fast contracts for external study workspaces."""
+"""
+--------------------------------------------------------------------------------
+dnadesign
+src/dnadesign/studies/core/workspace/__init__.py
+
+Package exports for portable external study workspace contracts.
+
+Module Author(s): Eric J. South
+--------------------------------------------------------------------------------
+"""
 
 from .contracts import (
     StudyArtifact,

--- a/src/dnadesign/studies/core/workspace/contracts.py
+++ b/src/dnadesign/studies/core/workspace/contracts.py
@@ -1,0 +1,108 @@
+"""Immutable values exposed by the study workspace contract."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+StudyVisibility = Literal["private", "public", "restricted"]
+StudyStatus = Literal["planned", "active", "paused", "complete", "archived"]
+StudyArtifactStatus = Literal["available", "stale", "superseded", "blocked"]
+
+
+@dataclass(frozen=True, slots=True)
+class StudyCatalogProgram:
+    """One declared grouping boundary in a research workspace."""
+
+    program_id: str
+    title: str
+    entrypoint: Path
+
+
+@dataclass(frozen=True, slots=True)
+class StudyWorkflow:
+    """A thin route from a study to a versioned tool surface."""
+
+    tool_id: str
+    route: Path
+    requires: str
+
+
+@dataclass(frozen=True, slots=True)
+class StudyArtifact:
+    """One reviewable or explicitly blocked study deliverable."""
+
+    artifact_id: str
+    artifact_type: str
+    status: StudyArtifactStatus
+    source_revisions: dict[str, str]
+    path: Path | None = None
+    uri: str | None = None
+    media_type: str | None = None
+    content_digest: str | None = None
+    generated_by: tuple[str, ...] = ()
+    blocker: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class StudyEvidenceIndex:
+    """Typed evidence inventory for one study."""
+
+    schema: str
+    study_id: str
+    path: Path
+    artifacts: tuple[StudyArtifact, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class StudyManifest:
+    """Portable identity and navigation contract for one study."""
+
+    schema: str
+    study_id: str
+    program_id: str
+    title: str
+    summary: str
+    visibility: StudyVisibility
+    status: StudyStatus
+    owners: tuple[str, ...]
+    last_verified: str
+    root: Path
+    manifest_path: Path
+    entrypoint: Path
+    evidence: StudyEvidenceIndex
+    workflows: tuple[StudyWorkflow, ...]
+    operations: Path | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class StudyWorkspace:
+    """Validated catalog plus all referenced study manifests."""
+
+    schema: str
+    root: Path
+    catalog_path: Path
+    programs: tuple[StudyCatalogProgram, ...]
+    studies: tuple[StudyManifest, ...]
+
+    @property
+    def program_index(self) -> dict[str, StudyCatalogProgram]:
+        return {program.program_id: program for program in self.programs}
+
+    @property
+    def study_index(self) -> dict[str, StudyManifest]:
+        return {study.study_id: study for study in self.studies}
+
+
+__all__ = [
+    "StudyArtifact",
+    "StudyArtifactStatus",
+    "StudyCatalogProgram",
+    "StudyEvidenceIndex",
+    "StudyManifest",
+    "StudyStatus",
+    "StudyVisibility",
+    "StudyWorkflow",
+    "StudyWorkspace",
+]

--- a/src/dnadesign/studies/core/workspace/contracts.py
+++ b/src/dnadesign/studies/core/workspace/contracts.py
@@ -1,4 +1,13 @@
-"""Immutable values exposed by the study workspace contract."""
+"""
+--------------------------------------------------------------------------------
+dnadesign
+src/dnadesign/studies/core/workspace/contracts.py
+
+Immutable values exposed by the study workspace contract.
+
+Module Author(s): Eric J. South
+--------------------------------------------------------------------------------
+"""
 
 from __future__ import annotations
 

--- a/src/dnadesign/studies/core/workspace/evidence.py
+++ b/src/dnadesign/studies/core/workspace/evidence.py
@@ -1,0 +1,177 @@
+"""Load and verify study evidence indexes."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import yaml
+
+from .contracts import StudyArtifact, StudyEvidenceIndex
+from .validation import (
+    artifact_uri,
+    identifier,
+    mapping,
+    optional_text,
+    reject_unknown_keys,
+    relative_file,
+    require_keys,
+    sequence,
+    sha256_digest,
+    string_mapping,
+    text,
+)
+
+_INDEX_KEYS = frozenset({"schema", "study_id", "artifacts"})
+_ARTIFACT_KEYS = frozenset(
+    {
+        "artifact_id",
+        "artifact_type",
+        "status",
+        "path",
+        "uri",
+        "media_type",
+        "content_digest",
+        "source_revisions",
+        "generated_by",
+        "blocker",
+    }
+)
+_ARTIFACT_REQUIRED_KEYS = frozenset({"artifact_id", "artifact_type", "status", "source_revisions"})
+_MATERIALIZED_STATUSES = frozenset({"available", "stale", "superseded"})
+
+
+def load_study_evidence_index(
+    index_path: Path,
+    *,
+    study_root: Path,
+    expected_study_id: str,
+) -> StudyEvidenceIndex:
+    """Load one evidence index and verify every tracked artifact digest."""
+
+    resolved_study_root = study_root.expanduser().resolve()
+    resolved_index_path = index_path.expanduser().resolve()
+    _require_contained(resolved_index_path, resolved_study_root, label="evidence index")
+    try:
+        payload = yaml.safe_load(resolved_index_path.read_text(encoding="utf-8")) or {}
+    except OSError as exc:
+        raise ValueError(f"could not read evidence index {resolved_index_path}: {exc}") from exc
+    index = mapping(payload, label="evidence index")
+    reject_unknown_keys(index, allowed=_INDEX_KEYS, label="evidence index")
+    require_keys(index, required=_INDEX_KEYS, label="evidence index")
+    schema = text(index.get("schema"), label="evidence index schema")
+    if schema != "study-evidence-index/v1":
+        raise ValueError(f"unsupported evidence index schema {schema!r}: {resolved_index_path}")
+    study_id = identifier(index.get("study_id"), label="evidence index study_id")
+    if study_id != expected_study_id:
+        raise ValueError(f"evidence index study_id {study_id!r} does not match expected study_id {expected_study_id!r}")
+
+    artifacts: list[StudyArtifact] = []
+    seen_ids: set[str] = set()
+    for position, raw_artifact in enumerate(
+        sequence(index.get("artifacts"), label="evidence index artifacts", allow_empty=True),
+        start=1,
+    ):
+        artifact = _load_artifact(
+            raw_artifact,
+            position=position,
+            evidence_root=resolved_index_path.parent,
+            study_root=resolved_study_root,
+        )
+        if artifact.artifact_id in seen_ids:
+            raise ValueError(f"evidence index has duplicate artifact_id {artifact.artifact_id!r}")
+        seen_ids.add(artifact.artifact_id)
+        artifacts.append(artifact)
+
+    return StudyEvidenceIndex(
+        schema=schema,
+        study_id=study_id,
+        path=resolved_index_path,
+        artifacts=tuple(artifacts),
+    )
+
+
+def _load_artifact(
+    value: object,
+    *,
+    position: int,
+    evidence_root: Path,
+    study_root: Path,
+) -> StudyArtifact:
+    label = f"evidence artifact {position}"
+    payload = mapping(value, label=label)
+    reject_unknown_keys(payload, allowed=_ARTIFACT_KEYS, label=label)
+    require_keys(payload, required=_ARTIFACT_REQUIRED_KEYS, label=label)
+    artifact_id = identifier(payload.get("artifact_id"), label=f"{label}.artifact_id")
+    artifact_type = identifier(payload.get("artifact_type"), label=f"{label}.artifact_type")
+    status = text(payload.get("status"), label=f"{label}.status")
+    if status not in {*_MATERIALIZED_STATUSES, "blocked"}:
+        raise ValueError(f"{label} has unsupported status {status!r}")
+    source_revisions = string_mapping(payload.get("source_revisions"), label=f"{label}.source_revisions")
+    media_type = optional_text(payload.get("media_type"), label=f"{label}.media_type")
+    blocker = optional_text(payload.get("blocker"), label=f"{label}.blocker")
+
+    if status == "blocked":
+        forbidden = {"path", "uri", "content_digest", "generated_by", "media_type"}.intersection(payload)
+        if blocker is None or forbidden:
+            raise ValueError(f"{label}: blocked artifact requires blocker and must not define a location or output")
+        return StudyArtifact(
+            artifact_id=artifact_id,
+            artifact_type=artifact_type,
+            status="blocked",
+            source_revisions=source_revisions,
+            blocker=blocker,
+        )
+
+    has_path = "path" in payload
+    has_uri = "uri" in payload
+    if has_path == has_uri:
+        raise ValueError(f"{label} must define exactly one of path or uri")
+    require_keys(payload, required=frozenset({"content_digest", "generated_by"}), label=label)
+    content_digest = sha256_digest(payload.get("content_digest"), label=f"{label}.content_digest")
+    generated_by = _command(payload.get("generated_by"), label=f"{label}.generated_by")
+    path = None
+    uri = None
+    if has_path:
+        path = relative_file(
+            base=evidence_root,
+            value=payload.get("path"),
+            boundary=study_root,
+            label=f"{label}.path",
+        )
+        observed = "sha256:" + hashlib.sha256(path.read_bytes()).hexdigest()
+        if observed != content_digest:
+            raise ValueError(
+                f"{label} content digest mismatch for {path}: expected {content_digest}, observed {observed}"
+            )
+    else:
+        uri = artifact_uri(payload.get("uri"), label=f"{label}.uri")
+
+    return StudyArtifact(
+        artifact_id=artifact_id,
+        artifact_type=artifact_type,
+        status=status,  # type: ignore[arg-type]
+        source_revisions=source_revisions,
+        path=path,
+        uri=uri,
+        media_type=media_type,
+        content_digest=content_digest,
+        generated_by=generated_by,
+        blocker=blocker,
+    )
+
+
+def _command(value: object, *, label: str) -> tuple[str, ...]:
+    if not isinstance(value, list) or not value:
+        raise ValueError(f"{label} must be a non-empty list")
+    return tuple(text(item, label=f"{label}[{index}]") for index, item in enumerate(value))
+
+
+def _require_contained(path: Path, boundary: Path, *, label: str) -> None:
+    try:
+        path.relative_to(boundary)
+    except ValueError as exc:
+        raise ValueError(f"{label} escapes study root {boundary}: {path}") from exc
+
+
+__all__ = ["load_study_evidence_index"]

--- a/src/dnadesign/studies/core/workspace/evidence.py
+++ b/src/dnadesign/studies/core/workspace/evidence.py
@@ -1,4 +1,13 @@
-"""Load and verify study evidence indexes."""
+"""
+--------------------------------------------------------------------------------
+dnadesign
+src/dnadesign/studies/core/workspace/evidence.py
+
+Load and verify study evidence indexes.
+
+Module Author(s): Eric J. South
+--------------------------------------------------------------------------------
+"""
 
 from __future__ import annotations
 

--- a/src/dnadesign/studies/core/workspace/loading.py
+++ b/src/dnadesign/studies/core/workspace/loading.py
@@ -1,0 +1,260 @@
+"""Load a portable study workspace from one explicit repository root."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from .contracts import StudyCatalogProgram, StudyManifest, StudyWorkflow, StudyWorkspace
+from .evidence import load_study_evidence_index
+from .validation import (
+    identifier,
+    iso_date,
+    mapping,
+    reject_unknown_keys,
+    relative_file,
+    require_keys,
+    sequence,
+    text,
+)
+
+_CATALOG_KEYS = frozenset({"schema", "programs", "studies"})
+_PROGRAM_KEYS = frozenset({"program_id", "title", "entrypoint"})
+_CATALOG_STUDY_KEYS = frozenset({"study_id", "manifest"})
+_MANIFEST_KEYS = frozenset(
+    {
+        "schema",
+        "study_id",
+        "program_id",
+        "title",
+        "summary",
+        "visibility",
+        "status",
+        "owners",
+        "last_verified",
+        "entrypoint",
+        "operations",
+        "evidence_index",
+        "workflows",
+    }
+)
+_MANIFEST_REQUIRED_KEYS = _MANIFEST_KEYS.difference({"operations"})
+_WORKFLOW_KEYS = frozenset({"tool_id", "route", "requires"})
+_VISIBILITIES = frozenset({"private", "public", "restricted"})
+_STATUSES = frozenset({"planned", "active", "paused", "complete", "archived"})
+
+
+def load_study_workspace(root: Path) -> StudyWorkspace:
+    """Load a strict ``study-catalog/v1`` rooted at ``catalog/studies.yaml``."""
+
+    resolved_root = root.expanduser().resolve()
+    if not resolved_root.is_dir():
+        raise ValueError(f"study workspace root does not exist: {resolved_root}")
+    catalog_path = resolved_root / "catalog" / "studies.yaml"
+    try:
+        payload = yaml.safe_load(catalog_path.read_text(encoding="utf-8")) or {}
+    except OSError as exc:
+        raise ValueError(f"could not read study catalog {catalog_path}: {exc}") from exc
+    catalog = mapping(payload, label="study catalog")
+    reject_unknown_keys(catalog, allowed=_CATALOG_KEYS, label="study catalog")
+    require_keys(catalog, required=_CATALOG_KEYS, label="study catalog")
+    schema = text(catalog.get("schema"), label="study catalog schema")
+    if schema != "study-catalog/v1":
+        raise ValueError(f"unsupported study catalog schema {schema!r}: {catalog_path}")
+
+    programs = _load_programs(catalog.get("programs"), root=resolved_root)
+    program_ids = {program.program_id for program in programs}
+    studies = _load_studies(
+        catalog.get("studies"),
+        root=resolved_root,
+        program_ids=program_ids,
+    )
+    return StudyWorkspace(
+        schema=schema,
+        root=resolved_root,
+        catalog_path=catalog_path,
+        programs=programs,
+        studies=studies,
+    )
+
+
+def _load_programs(value: object, *, root: Path) -> tuple[StudyCatalogProgram, ...]:
+    programs: list[StudyCatalogProgram] = []
+    seen: set[str] = set()
+    for position, raw_program in enumerate(sequence(value, label="study catalog programs"), start=1):
+        label = f"study catalog program {position}"
+        payload = mapping(raw_program, label=label)
+        reject_unknown_keys(payload, allowed=_PROGRAM_KEYS, label=label)
+        require_keys(payload, required=_PROGRAM_KEYS, label=label)
+        program_id = identifier(payload.get("program_id"), label=f"{label}.program_id")
+        if program_id in seen:
+            raise ValueError(f"study catalog has duplicate program_id {program_id!r}")
+        seen.add(program_id)
+        programs.append(
+            StudyCatalogProgram(
+                program_id=program_id,
+                title=text(payload.get("title"), label=f"{label}.title"),
+                entrypoint=relative_file(
+                    base=root,
+                    value=payload.get("entrypoint"),
+                    boundary=root,
+                    label=f"{label}.entrypoint",
+                ),
+            )
+        )
+    return tuple(programs)
+
+
+def _load_studies(
+    value: object,
+    *,
+    root: Path,
+    program_ids: set[str],
+) -> tuple[StudyManifest, ...]:
+    studies: list[StudyManifest] = []
+    seen: set[str] = set()
+    for position, raw_study in enumerate(sequence(value, label="study catalog studies"), start=1):
+        label = f"study catalog entry {position}"
+        payload = mapping(raw_study, label=label)
+        reject_unknown_keys(payload, allowed=_CATALOG_STUDY_KEYS, label=label)
+        require_keys(payload, required=_CATALOG_STUDY_KEYS, label=label)
+        study_id = identifier(payload.get("study_id"), label=f"{label}.study_id")
+        if study_id in seen:
+            raise ValueError(f"study catalog has duplicate study_id {study_id!r}")
+        seen.add(study_id)
+        manifest_path = relative_file(
+            base=root,
+            value=payload.get("manifest"),
+            boundary=root,
+            label=f"{label}.manifest",
+        )
+        studies.append(
+            _load_manifest(
+                manifest_path,
+                root=root,
+                expected_study_id=study_id,
+                program_ids=program_ids,
+            )
+        )
+    return tuple(studies)
+
+
+def _load_manifest(
+    manifest_path: Path,
+    *,
+    root: Path,
+    expected_study_id: str,
+    program_ids: set[str],
+) -> StudyManifest:
+    payload = yaml.safe_load(manifest_path.read_text(encoding="utf-8")) or {}
+    manifest = mapping(payload, label=f"study manifest {manifest_path}")
+    reject_unknown_keys(manifest, allowed=_MANIFEST_KEYS, label="study manifest")
+    require_keys(manifest, required=_MANIFEST_REQUIRED_KEYS, label="study manifest")
+    schema = text(manifest.get("schema"), label="study manifest schema")
+    if schema != "study/v1":
+        raise ValueError(f"unsupported study manifest schema {schema!r}: {manifest_path}")
+    study_id = identifier(manifest.get("study_id"), label="study manifest study_id")
+    if study_id != expected_study_id:
+        raise ValueError(f"manifest study_id {study_id!r} does not match catalog study_id {expected_study_id!r}")
+    program_id = identifier(manifest.get("program_id"), label="study manifest program_id")
+    if program_id not in program_ids:
+        raise ValueError(f"study {study_id!r} references undeclared program_id {program_id!r}")
+    visibility = text(manifest.get("visibility"), label="study manifest visibility")
+    if visibility not in _VISIBILITIES:
+        raise ValueError(f"study manifest has unsupported visibility {visibility!r}")
+    status = text(manifest.get("status"), label="study manifest status")
+    if status not in _STATUSES:
+        raise ValueError(f"study manifest has unsupported status {status!r}")
+    owners = _unique_identifiers(manifest.get("owners"), label="study manifest owners")
+    study_root = manifest_path.parent
+    entrypoint = relative_file(
+        base=study_root,
+        value=manifest.get("entrypoint"),
+        boundary=study_root,
+        label=f"study {study_id} entrypoint",
+    )
+    evidence_path = relative_file(
+        base=study_root,
+        value=manifest.get("evidence_index"),
+        boundary=study_root,
+        label=f"study {study_id} evidence_index",
+    )
+    operations = None
+    if "operations" in manifest:
+        operations = relative_file(
+            base=study_root,
+            value=manifest.get("operations"),
+            boundary=study_root,
+            label=f"study {study_id} operations",
+        )
+    workflows = _load_workflows(manifest.get("workflows"), study_root=study_root, study_id=study_id)
+    return StudyManifest(
+        schema=schema,
+        study_id=study_id,
+        program_id=program_id,
+        title=text(manifest.get("title"), label="study manifest title"),
+        summary=text(manifest.get("summary"), label="study manifest summary"),
+        visibility=visibility,  # type: ignore[arg-type]
+        status=status,  # type: ignore[arg-type]
+        owners=owners,
+        last_verified=iso_date(manifest.get("last_verified"), label="study manifest last_verified"),
+        root=study_root,
+        manifest_path=manifest_path,
+        entrypoint=entrypoint,
+        operations=operations,
+        evidence=load_study_evidence_index(
+            evidence_path,
+            study_root=study_root,
+            expected_study_id=study_id,
+        ),
+        workflows=workflows,
+    )
+
+
+def _load_workflows(value: object, *, study_root: Path, study_id: str) -> tuple[StudyWorkflow, ...]:
+    workflows: list[StudyWorkflow] = []
+    seen: set[str] = set()
+    for position, raw_workflow in enumerate(
+        sequence(value, label=f"study {study_id} workflows", allow_empty=True),
+        start=1,
+    ):
+        label = f"study {study_id} workflow {position}"
+        payload = mapping(raw_workflow, label=label)
+        reject_unknown_keys(payload, allowed=_WORKFLOW_KEYS, label=label)
+        require_keys(payload, required=_WORKFLOW_KEYS, label=label)
+        tool_id = identifier(payload.get("tool_id"), label=f"{label}.tool_id")
+        if tool_id in seen:
+            raise ValueError(f"study {study_id} has duplicate workflow tool_id {tool_id!r}")
+        seen.add(tool_id)
+        try:
+            route = relative_file(
+                base=study_root,
+                value=payload.get("route"),
+                boundary=study_root,
+                label=f"workflow {tool_id} route",
+            )
+        except ValueError as exc:
+            if "does not exist" in str(exc):
+                raise ValueError(f"workflow {tool_id} route does not exist") from exc
+            raise
+        workflows.append(
+            StudyWorkflow(
+                tool_id=tool_id,
+                route=route,
+                requires=text(payload.get("requires"), label=f"{label}.requires"),
+            )
+        )
+    return tuple(workflows)
+
+
+def _unique_identifiers(value: object, *, label: str) -> tuple[str, ...]:
+    identifiers = tuple(
+        identifier(item, label=f"{label}[{index}]") for index, item in enumerate(sequence(value, label=label))
+    )
+    if len(set(identifiers)) != len(identifiers):
+        raise ValueError(f"{label} must not contain duplicates")
+    return identifiers
+
+
+__all__ = ["load_study_workspace"]

--- a/src/dnadesign/studies/core/workspace/loading.py
+++ b/src/dnadesign/studies/core/workspace/loading.py
@@ -1,4 +1,13 @@
-"""Load a portable study workspace from one explicit repository root."""
+"""
+--------------------------------------------------------------------------------
+dnadesign
+src/dnadesign/studies/core/workspace/loading.py
+
+Load a portable study workspace from one explicit repository root.
+
+Module Author(s): Eric J. South
+--------------------------------------------------------------------------------
+"""
 
 from __future__ import annotations
 

--- a/src/dnadesign/studies/core/workspace/validation.py
+++ b/src/dnadesign/studies/core/workspace/validation.py
@@ -52,6 +52,8 @@ def sha256_digest(value: object, *, label: str) -> str:
 
 
 def iso_date(value: object, *, label: str) -> str:
+    if type(value) is date:
+        return value.isoformat()
     token = text(value, label=label)
     try:
         date.fromisoformat(token)

--- a/src/dnadesign/studies/core/workspace/validation.py
+++ b/src/dnadesign/studies/core/workspace/validation.py
@@ -1,4 +1,13 @@
-"""Primitive validation shared by study workspace loaders."""
+"""
+--------------------------------------------------------------------------------
+dnadesign
+src/dnadesign/studies/core/workspace/validation.py
+
+Primitive validation shared by study workspace loaders.
+
+Module Author(s): Eric J. South
+--------------------------------------------------------------------------------
+"""
 
 from __future__ import annotations
 

--- a/src/dnadesign/studies/core/workspace/validation.py
+++ b/src/dnadesign/studies/core/workspace/validation.py
@@ -1,0 +1,122 @@
+"""Primitive validation shared by study workspace loaders."""
+
+from __future__ import annotations
+
+import re
+from datetime import date
+from pathlib import Path
+from urllib.parse import urlsplit
+
+_IDENTIFIER = re.compile(r"^[a-z0-9]+(?:[._-][a-z0-9]+)*$")
+_SHA256 = re.compile(r"^sha256:[0-9a-f]{64}$")
+_ARTIFACT_URI_SCHEMES = frozenset({"https", "s3", "gs"})
+
+
+def mapping(value: object, *, label: str) -> dict[str, object]:
+    if not isinstance(value, dict):
+        raise ValueError(f"{label} must be a mapping")
+    return dict(value)
+
+
+def sequence(value: object, *, label: str, allow_empty: bool = False) -> list[object]:
+    if not isinstance(value, list) or (not allow_empty and not value):
+        qualifier = "a list" if allow_empty else "a non-empty list"
+        raise ValueError(f"{label} must be {qualifier}")
+    return list(value)
+
+
+def text(value: object, *, label: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{label} must be a non-empty string")
+    return value.strip()
+
+
+def optional_text(value: object, *, label: str) -> str | None:
+    if value is None:
+        return None
+    return text(value, label=label)
+
+
+def identifier(value: object, *, label: str) -> str:
+    token = text(value, label=label)
+    if not _IDENTIFIER.fullmatch(token):
+        raise ValueError(f"{label} must be a lowercase identifier")
+    return token
+
+
+def sha256_digest(value: object, *, label: str) -> str:
+    token = text(value, label=label)
+    if not _SHA256.fullmatch(token):
+        raise ValueError(f"{label} must be a lowercase sha256 digest")
+    return token
+
+
+def iso_date(value: object, *, label: str) -> str:
+    token = text(value, label=label)
+    try:
+        date.fromisoformat(token)
+    except ValueError as exc:
+        raise ValueError(f"{label} must be an ISO 8601 calendar date") from exc
+    return token
+
+
+def require_keys(payload: dict[str, object], *, required: frozenset[str], label: str) -> None:
+    missing = sorted(key for key in required if key not in payload)
+    if missing:
+        raise ValueError(f"{label} is missing required key(s): {', '.join(missing)}")
+
+
+def reject_unknown_keys(payload: dict[str, object], *, allowed: frozenset[str], label: str) -> None:
+    unknown = sorted(str(key) for key in payload if str(key) not in allowed)
+    if unknown:
+        raise ValueError(f"{label} has unknown key(s): {', '.join(unknown)}")
+
+
+def relative_file(*, base: Path, value: object, boundary: Path, label: str) -> Path:
+    raw = text(value, label=label)
+    relative = Path(raw)
+    if relative.is_absolute() or relative == Path(".") or ".." in relative.parts:
+        raise ValueError(f"{label} must be a repository-relative path without '..'")
+    boundary_resolved = boundary.expanduser().resolve()
+    resolved = (base / relative).resolve()
+    try:
+        resolved.relative_to(boundary_resolved)
+    except ValueError as exc:
+        raise ValueError(f"{label} escapes workspace root {boundary_resolved}") from exc
+    if not resolved.is_file():
+        raise ValueError(f"{label} does not exist: {resolved}")
+    return resolved
+
+
+def artifact_uri(value: object, *, label: str) -> str:
+    uri = text(value, label=label)
+    parsed = urlsplit(uri)
+    if parsed.scheme not in _ARTIFACT_URI_SCHEMES or not parsed.netloc:
+        schemes = ", ".join(sorted(_ARTIFACT_URI_SCHEMES))
+        raise ValueError(f"{label} must use one of these external URI schemes: {schemes}")
+    if parsed.username is not None or parsed.password is not None:
+        raise ValueError(f"{label} must not embed credentials")
+    return uri
+
+
+def string_mapping(value: object, *, label: str) -> dict[str, str]:
+    payload = mapping(value, label=label)
+    if not payload:
+        raise ValueError(f"{label} is required and must not be empty")
+    return {identifier(key, label=f"{label} key"): text(item, label=f"{label}.{key}") for key, item in payload.items()}
+
+
+__all__ = [
+    "artifact_uri",
+    "identifier",
+    "iso_date",
+    "mapping",
+    "optional_text",
+    "relative_file",
+    "reject_unknown_keys",
+    "require_keys",
+    "sequence",
+    "sha256_digest",
+    "string_mapping",
+    "text",
+]

--- a/src/dnadesign/studies/tests/workspace/__init__.py
+++ b/src/dnadesign/studies/tests/workspace/__init__.py
@@ -1,1 +1,10 @@
-"""Tests for portable study workspace contracts."""
+"""
+--------------------------------------------------------------------------------
+dnadesign
+src/dnadesign/studies/tests/workspace/__init__.py
+
+Tests for portable study workspace contracts.
+
+Module Author(s): Eric J. South
+--------------------------------------------------------------------------------
+"""

--- a/src/dnadesign/studies/tests/workspace/__init__.py
+++ b/src/dnadesign/studies/tests/workspace/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for portable study workspace contracts."""

--- a/src/dnadesign/studies/tests/workspace/test_catalog.py
+++ b/src/dnadesign/studies/tests/workspace/test_catalog.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import date
 from pathlib import Path
 
 import pytest
@@ -180,3 +181,15 @@ def test_manifest_rejects_unresolved_workflow_route(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match="workflow reader route does not exist"):
         load_study_workspace(root)
+
+
+def test_manifest_accepts_yaml_calendar_date(tmp_path: Path) -> None:
+    root = _workspace(tmp_path)
+    manifest_path = root / "programs/stress-response/studies/promoter-response/study.yaml"
+    payload = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    payload["last_verified"] = date(2026, 8, 8)
+    _write_yaml(manifest_path, payload)
+
+    workspace = load_study_workspace(root)
+
+    assert workspace.studies[0].last_verified == "2026-08-08"

--- a/src/dnadesign/studies/tests/workspace/test_catalog.py
+++ b/src/dnadesign/studies/tests/workspace/test_catalog.py
@@ -1,4 +1,13 @@
-"""Contract tests for a portable study workspace catalog."""
+"""
+--------------------------------------------------------------------------------
+dnadesign
+src/dnadesign/studies/tests/workspace/test_catalog.py
+
+Contract tests for a portable study workspace catalog.
+
+Module Author(s): Eric J. South
+--------------------------------------------------------------------------------
+"""
 
 from __future__ import annotations
 

--- a/src/dnadesign/studies/tests/workspace/test_catalog.py
+++ b/src/dnadesign/studies/tests/workspace/test_catalog.py
@@ -1,0 +1,182 @@
+"""Contract tests for a portable study workspace catalog."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from dnadesign.studies.core.workspace import load_study_workspace
+
+
+def _write_yaml(path: Path, payload: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+
+
+def _workspace(tmp_path: Path) -> Path:
+    root = tmp_path / "research-studies"
+    program_root = root / "programs" / "stress-response"
+    study_root = program_root / "studies" / "promoter-response"
+    (program_root / "README.md").parent.mkdir(parents=True, exist_ok=True)
+    (program_root / "README.md").write_text("# Stress response\n", encoding="utf-8")
+    (study_root / "README.md").parent.mkdir(parents=True, exist_ok=True)
+    (study_root / "README.md").write_text("# Promoter response\n", encoding="utf-8")
+    (study_root / "workflows" / "reader").mkdir(parents=True, exist_ok=True)
+    (study_root / "workflows" / "reader" / "README.md").write_text("# Reader route\n", encoding="utf-8")
+    _write_yaml(
+        study_root / "evidence" / "index.yaml",
+        {
+            "schema": "study-evidence-index/v1",
+            "study_id": "promoter_response",
+            "artifacts": [],
+        },
+    )
+    _write_yaml(
+        study_root / "study.yaml",
+        {
+            "schema": "study/v1",
+            "study_id": "promoter_response",
+            "program_id": "stress_response",
+            "title": "Promoter response",
+            "summary": "Measures promoter responses across declared conditions.",
+            "visibility": "private",
+            "status": "active",
+            "owners": ["stress-study-maintainers"],
+            "last_verified": "2026-08-08",
+            "entrypoint": "README.md",
+            "evidence_index": "evidence/index.yaml",
+            "workflows": [
+                {
+                    "tool_id": "reader",
+                    "route": "workflows/reader/README.md",
+                    "requires": "reader-workbench>=0.1",
+                }
+            ],
+        },
+    )
+    _write_yaml(
+        root / "catalog" / "studies.yaml",
+        {
+            "schema": "study-catalog/v1",
+            "programs": [
+                {
+                    "program_id": "stress_response",
+                    "title": "Stress response",
+                    "entrypoint": "programs/stress-response/README.md",
+                }
+            ],
+            "studies": [
+                {
+                    "study_id": "promoter_response",
+                    "manifest": "programs/stress-response/studies/promoter-response/study.yaml",
+                }
+            ],
+        },
+    )
+    return root
+
+
+def test_load_study_workspace_resolves_declared_routes(tmp_path: Path) -> None:
+    root = _workspace(tmp_path)
+
+    workspace = load_study_workspace(root)
+
+    assert workspace.schema == "study-catalog/v1"
+    assert workspace.programs[0].program_id == "stress_response"
+    assert workspace.studies[0].study_id == "promoter_response"
+    assert workspace.studies[0].program_id == "stress_response"
+    assert (
+        workspace.studies[0].entrypoint
+        == (root / "programs/stress-response/studies/promoter-response/README.md").resolve()
+    )
+    assert workspace.studies[0].workflows[0].tool_id == "reader"
+
+
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    [
+        (lambda payload: payload.update({"active_study_id": "promoter_response"}), "unknown key"),
+        (lambda payload: payload["studies"].append(dict(payload["studies"][0])), "duplicate study_id"),
+        (lambda payload: payload["programs"].append(dict(payload["programs"][0])), "duplicate program_id"),
+    ],
+)
+def test_catalog_rejects_ambiguous_or_undeclared_state(
+    tmp_path: Path,
+    mutation,
+    message: str,
+) -> None:
+    root = _workspace(tmp_path)
+    catalog_path = root / "catalog" / "studies.yaml"
+    payload = yaml.safe_load(catalog_path.read_text(encoding="utf-8"))
+    mutation(payload)
+    _write_yaml(catalog_path, payload)
+
+    with pytest.raises(ValueError, match=message):
+        load_study_workspace(root)
+
+
+def test_catalog_rejects_manifest_identity_drift(tmp_path: Path) -> None:
+    root = _workspace(tmp_path)
+    manifest_path = root / "programs/stress-response/studies/promoter-response/study.yaml"
+    payload = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    payload["study_id"] = "another_study"
+    _write_yaml(manifest_path, payload)
+
+    with pytest.raises(ValueError, match="does not match catalog study_id"):
+        load_study_workspace(root)
+
+
+def test_catalog_rejects_undeclared_program(tmp_path: Path) -> None:
+    root = _workspace(tmp_path)
+    manifest_path = root / "programs/stress-response/studies/promoter-response/study.yaml"
+    payload = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    payload["program_id"] = "unregistered_program"
+    _write_yaml(manifest_path, payload)
+
+    with pytest.raises(ValueError, match="undeclared program_id"):
+        load_study_workspace(root)
+
+
+def test_catalog_rejects_path_traversal(tmp_path: Path) -> None:
+    root = _workspace(tmp_path)
+    catalog_path = root / "catalog" / "studies.yaml"
+    payload = yaml.safe_load(catalog_path.read_text(encoding="utf-8"))
+    payload["studies"][0]["manifest"] = "../outside.yaml"
+    _write_yaml(catalog_path, payload)
+
+    with pytest.raises(ValueError, match="repository-relative path"):
+        load_study_workspace(root)
+
+
+def test_catalog_rejects_symlink_escape(tmp_path: Path) -> None:
+    root = _workspace(tmp_path)
+    outside = tmp_path / "outside.md"
+    outside.write_text("outside\n", encoding="utf-8")
+    program_entrypoint = root / "programs/stress-response/README.md"
+    program_entrypoint.unlink()
+    program_entrypoint.symlink_to(outside)
+
+    with pytest.raises(ValueError, match="escapes workspace root"):
+        load_study_workspace(root)
+
+
+def test_manifest_rejects_unknown_keys(tmp_path: Path) -> None:
+    root = _workspace(tmp_path)
+    manifest_path = root / "programs/stress-response/studies/promoter-response/study.yaml"
+    payload = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    payload["objective"] = "study-specific meaning must not enter the generic manifest"
+    _write_yaml(manifest_path, payload)
+
+    with pytest.raises(ValueError, match="unknown key.*objective"):
+        load_study_workspace(root)
+
+
+def test_manifest_rejects_unresolved_workflow_route(tmp_path: Path) -> None:
+    root = _workspace(tmp_path)
+    route = root / "programs/stress-response/studies/promoter-response/workflows/reader/README.md"
+    route.unlink()
+
+    with pytest.raises(ValueError, match="workflow reader route does not exist"):
+        load_study_workspace(root)

--- a/src/dnadesign/studies/tests/workspace/test_evidence.py
+++ b/src/dnadesign/studies/tests/workspace/test_evidence.py
@@ -1,4 +1,13 @@
-"""Contract tests for study evidence indexes."""
+"""
+--------------------------------------------------------------------------------
+dnadesign
+src/dnadesign/studies/tests/workspace/test_evidence.py
+
+Contract tests for study evidence indexes.
+
+Module Author(s): Eric J. South
+--------------------------------------------------------------------------------
+"""
 
 from __future__ import annotations
 

--- a/src/dnadesign/studies/tests/workspace/test_evidence.py
+++ b/src/dnadesign/studies/tests/workspace/test_evidence.py
@@ -1,0 +1,135 @@
+"""Contract tests for study evidence indexes."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+import yaml
+
+from dnadesign.studies.core.workspace import load_study_evidence_index
+
+
+def _digest(content: bytes) -> str:
+    return "sha256:" + hashlib.sha256(content).hexdigest()
+
+
+def _write_yaml(path: Path, payload: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+
+
+def _evidence_index(tmp_path: Path) -> tuple[Path, Path, dict[str, object]]:
+    study_root = tmp_path / "study"
+    artifact_path = study_root / "evidence" / "review" / "summary.svg"
+    artifact_path.parent.mkdir(parents=True, exist_ok=True)
+    content = b"<svg xmlns='http://www.w3.org/2000/svg'/>\n"
+    artifact_path.write_bytes(content)
+    index_path = study_root / "evidence" / "index.yaml"
+    payload: dict[str, object] = {
+        "schema": "study-evidence-index/v1",
+        "study_id": "demo_study",
+        "artifacts": [
+            {
+                "artifact_id": "review_summary",
+                "artifact_type": "review-figure",
+                "status": "available",
+                "path": "review/summary.svg",
+                "media_type": "image/svg+xml",
+                "content_digest": _digest(content),
+                "source_revisions": {
+                    "dnadesign": "git:0123456789abcdef0123456789abcdef01234567",
+                    "reader": "record:response_window@sha256:abc",
+                },
+                "generated_by": ["uv", "run", "study", "render", "demo_study"],
+            },
+            {
+                "artifact_id": "external_bundle",
+                "artifact_type": "data-bundle",
+                "status": "available",
+                "uri": "s3://private-study-artifacts/demo/bundle.parquet",
+                "media_type": "application/vnd.apache.parquet",
+                "content_digest": "sha256:" + "a" * 64,
+                "source_revisions": {"reader": "record:aggregate@sha256:def"},
+                "generated_by": ["uv", "run", "study", "build", "demo_study"],
+            },
+            {
+                "artifact_id": "future_model",
+                "artifact_type": "model",
+                "status": "blocked",
+                "blocker": "Required measurements are not available.",
+                "source_revisions": {"reader": "missing"},
+            },
+        ],
+    }
+    _write_yaml(index_path, payload)
+    return study_root, index_path, payload
+
+
+def test_load_evidence_index_verifies_tracked_content(tmp_path: Path) -> None:
+    study_root, index_path, _ = _evidence_index(tmp_path)
+
+    index = load_study_evidence_index(index_path, study_root=study_root, expected_study_id="demo_study")
+
+    assert index.artifacts[0].path == (study_root / "evidence/review/summary.svg").resolve()
+    assert index.artifacts[1].uri == "s3://private-study-artifacts/demo/bundle.parquet"
+    assert index.artifacts[2].blocker == "Required measurements are not available."
+
+
+def test_evidence_index_rejects_digest_mismatch(tmp_path: Path) -> None:
+    study_root, index_path, payload = _evidence_index(tmp_path)
+    payload["artifacts"][0]["content_digest"] = "sha256:" + "0" * 64
+    _write_yaml(index_path, payload)
+
+    with pytest.raises(ValueError, match="content digest mismatch"):
+        load_study_evidence_index(index_path, study_root=study_root, expected_study_id="demo_study")
+
+
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    [
+        (lambda item: item.update({"uri": "https://example.invalid/also.svg"}), "exactly one of path or uri"),
+        (lambda item: item.pop("source_revisions"), "missing required key.*source_revisions"),
+        (lambda item: item.update({"generated_by": "uv run study"}), "generated_by must be a non-empty list"),
+        (lambda item: item.update({"status": "ready"}), "unsupported status"),
+    ],
+)
+def test_available_evidence_rejects_ambiguous_or_incomplete_records(
+    tmp_path: Path,
+    mutation,
+    message: str,
+) -> None:
+    study_root, index_path, payload = _evidence_index(tmp_path)
+    mutation(payload["artifacts"][0])
+    _write_yaml(index_path, payload)
+
+    with pytest.raises(ValueError, match=message):
+        load_study_evidence_index(index_path, study_root=study_root, expected_study_id="demo_study")
+
+
+def test_blocked_evidence_requires_blocker_and_forbids_location(tmp_path: Path) -> None:
+    study_root, index_path, payload = _evidence_index(tmp_path)
+    blocked = payload["artifacts"][2]
+    blocked.pop("blocker")
+    blocked["uri"] = "https://example.invalid/not-produced"
+    _write_yaml(index_path, payload)
+
+    with pytest.raises(ValueError, match="blocked artifact requires blocker and must not define a location"):
+        load_study_evidence_index(index_path, study_root=study_root, expected_study_id="demo_study")
+
+
+def test_evidence_index_rejects_path_escape(tmp_path: Path) -> None:
+    study_root, index_path, payload = _evidence_index(tmp_path)
+    payload["artifacts"][0]["path"] = "../../outside.svg"
+    _write_yaml(index_path, payload)
+
+    with pytest.raises(ValueError, match="repository-relative path"):
+        load_study_evidence_index(index_path, study_root=study_root, expected_study_id="demo_study")
+
+
+def test_evidence_index_rejects_identity_drift(tmp_path: Path) -> None:
+    study_root, index_path, _ = _evidence_index(tmp_path)
+
+    with pytest.raises(ValueError, match="does not match expected study_id"):
+        load_study_evidence_index(index_path, study_root=study_root, expected_study_id="another_study")


### PR DESCRIPTION
## Summary

- add strict `study-catalog/v1`, `study/v1`, and `study-evidence-index/v1` loaders
- validate stable identity, explicit program membership, routes, ownership, and tool requirements
- verify tracked evidence by SHA-256 and fail on traversal, symlink escape, malformed states, or identity drift
- document the public/private workspace boundary and Python API

## Validation

- 53 focused study tests pass
- 19 new workspace adversarial tests pass
- Ruff check and format pass
- architecture boundary checks pass
- 528 documentation checks pass
- pre-commit hooks, including secret detection, pass

## Rollout

This is the additive contract slice. Private study migration follows in `e-south/research-studies`; concrete public study units are removed only after the private owner passes its own checks.