### PR TITLE
Ground Junction order geometry and molecular review plots

### DIFF
--- a/src/dnadesign/baserender/docs/integrations/junction.md
+++ b/src/dnadesign/baserender/docs/integrations/junction.md
@@ -3,7 +3,7 @@ doc_id: baserender-junction-integration
 title: junction review integration
 owner: dnadesign-maintainers
 status: active
-last_verified: 2026-08-09
+last_verified: 2026-08-10
 ---
 
 # Review a junction design with BaseRender
@@ -35,7 +35,7 @@ directories use mode `0700`; files use mode `0600`.
 
 | Question | Renderer | Options |
 | --- | --- | --- |
-| Which fragment oligos are expected to pair? | `junction_annealed_fragments` | Optional `fragment_ids`; required when a target has more than 18 fragments. |
+| Which fragment oligos are expected to anneal? | `junction_annealed_fragments` | Optional `fragment_ids`; required when a target has more than 18 fragments. |
 | Where are all three-way interfaces on the target? | `junction_three_way_assembly` | `view: overview` |
 | Does a specific interface have the expected three-arm geometry? | `junction_three_way_assembly` | `view: junction_detail` and one to eight `junction_ids` |
 
@@ -48,11 +48,14 @@ record without forcing Matplotlib to allocate an unbounded number of artists.
 The target overview accepts at most 256 fragments; larger assemblies remain
 available as typed records but require a purpose-built aggregate view.
 
-The fragment map prints exact bases, strand ends, junction spans, and declared
-Watson–Crick edges. The target overview is intentionally symbolic. The junction
-detail uses a horizontal target helix, a perpendicular barcode helix, and an
-explicit complement-strand nick. It shows `t/t*` and `b/b*` on one shared
-three-arm node rather than as unrelated duplex rows.
+The fragment map prints exact bases, physical oligo lengths, strand ends,
+junction spans, and declared Watson–Crick edges on one nucleotide scale. The
+target overview is intentionally symbolic and labels each interface with a
+stable junction ID and target coordinate. The junction detail uses the same
+base spacing horizontally and vertically, centers a perpendicular barcode
+helix on the target helix, and marks the complement-strand nick. It shows
+`t/t*` and `b/b*` on one shared three-arm node rather than as unrelated duplex
+rows.
 
 These are sequence-derived schematics. They do not claim predicted secondary
 structure, thermodynamic stability, successful annealing or ligation, PCR

--- a/src/dnadesign/baserender/src/render/junction_annealed_fragments.py
+++ b/src/dnadesign/baserender/src/render/junction_annealed_fragments.py
@@ -3,7 +3,7 @@
 dnadesign
 src/dnadesign/baserender/src/render/junction_annealed_fragments.py
 
-Nucleotide-level maps of expected Junction fragment pairing.
+Registered renderer for nucleotide-level Junction fragment annealing.
 
 Module Author(s): Eric J. South
 --------------------------------------------------------------------------------
@@ -18,201 +18,24 @@ import matplotlib
 
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
-from matplotlib.collections import LineCollection
-from matplotlib.patches import Rectangle
-
-from dnadesign.contracts.visual import ThreeWayJunctionReviewV1
 
 from ..config import Style
-from ..core import Record, SchemaError
-from .junction_review_common import (
-    DOMAIN,
-    INK,
-    MUTED,
-    PAIR,
-    draw_base_run,
-    junction_color,
-    review_from_record,
-    safe_identifier,
-    selected_ids,
-    validate_figure_size,
-)
+from ..core import Record
+from .junction_review.annealed_panel import draw_annealed_panel, fragment_selection, validate_fragment_rows
+from .junction_review.foundation import review_from_record, validate_figure_size
 from .palette import Palette
-from .sequence_preview import bounded_svg_gid
 
 _RENDERER = "junction_annealed_fragments"
-_MAX_FRAGMENTS = 18
-_MAX_ROW_BASES = 140
 _FIGURE_WIDTH = 15.2
 
 
-def _fragment_selection(
-    review: ThreeWayJunctionReviewV1,
-    options: Mapping[str, object] | None,
-) -> tuple[int, ...]:
-    available = tuple(fragment.fragment_id for fragment in review.geometry.fragments)
-    chosen = selected_ids(
-        options,
-        key="fragment_ids",
-        available=available,
-        maximum=_MAX_FRAGMENTS,
-        required=len(available) > _MAX_FRAGMENTS,
-        renderer=_RENDERER,
-    )
-    by_id = {fragment_id: index for index, fragment_id in enumerate(available)}
-    return tuple(by_id[fragment_id] for fragment_id in chosen)
-
-
-def _row_geometry(review: ThreeWayJunctionReviewV1, index: int):
-    previous = None if index == 0 else review.geometry.junctions[index - 1]
-    following = None if index == len(review.strands) - 1 else review.geometry.junctions[index]
-    fragment = review.geometry.fragments[index]
-    strand = review.strands[index]
-    domain_length = fragment.domain_span.end - fragment.domain_span.start
-    top_domain_start = 0 if previous is None else len(previous.barcode)
-    bottom_domain_start = 0 if previous is None else len(previous.toehold)
-    aligned_domain_start = max(top_domain_start, bottom_domain_start)
-    top_offset = aligned_domain_start - top_domain_start
-    bottom_offset = aligned_domain_start - bottom_domain_start
-    top_spans: list[tuple[int, int, str, str]] = []
-    bottom_spans: list[tuple[int, int, str, str]] = []
-    if previous is not None:
-        color = junction_color(index - 1)
-        top_spans.append((0, len(previous.barcode), color, f"b{index}*"))
-        bottom_spans.append((0, len(previous.toehold), color, f"t{index}*"))
-    top_spans.append((top_domain_start, top_domain_start + domain_length, DOMAIN, "target"))
-    bottom_spans.append((bottom_domain_start, bottom_domain_start + domain_length, DOMAIN, "target"))
-    if following is not None:
-        color = junction_color(index)
-        start = top_domain_start + domain_length
-        top_spans.extend(
-            (
-                (start, start + len(following.toehold), color, f"t{index + 1}"),
-                (
-                    start + len(following.toehold),
-                    start + len(following.toehold) + len(following.barcode),
-                    color,
-                    f"b{index + 1}",
-                ),
-            )
-        )
-    return (
-        fragment,
-        strand,
-        strand.complement_sequence_5to3[::-1],
-        top_offset,
-        bottom_offset,
-        aligned_domain_start,
-        domain_length,
-        tuple(top_spans),
-        tuple(bottom_spans),
-    )
-
-
-def _validate_rows(review: ThreeWayJunctionReviewV1, indices: tuple[int, ...]) -> None:
-    for index in indices:
-        _, strand, bottom, top_offset, bottom_offset, *_ = _row_geometry(review, index)
-        width = max(top_offset + len(strand.barcode_bearing_sequence_5to3), bottom_offset + len(bottom))
-        if width > _MAX_ROW_BASES:
-            raise SchemaError(
-                f"{_RENDERER} fragment {strand.fragment_id!r} spans {width} displayed bases; "
-                f"the limit is {_MAX_ROW_BASES}"
-            )
-
-
-def _draw_spans(axis, *, spans, offset: int, x_for, y: float, height: float) -> None:
-    for start, end, color, label in spans:
-        left = x_for(offset + start) - 0.003
-        right = x_for(offset + end)
-        axis.add_patch(
-            Rectangle((left, y), right - left, height, facecolor=color, edgecolor="none", alpha=0.23, zorder=0)
-        )
-        axis.text(
-            (left + right) / 2,
-            y + height + 0.015,
-            label,
-            ha="center",
-            va="bottom",
-            fontsize=5.0,
-            color=color if color != DOMAIN else MUTED,
-        )
-
-
-def _draw_fragment(axis, review: ThreeWayJunctionReviewV1, *, index: int, y: float) -> None:
-    (
-        fragment,
-        strand,
-        bottom,
-        top_offset,
-        bottom_offset,
-        paired_start,
-        paired_length,
-        top_spans,
-        bottom_spans,
-    ) = _row_geometry(review, index)
-    width = max(top_offset + len(strand.barcode_bearing_sequence_5to3), bottom_offset + len(bottom))
-    left_x, right_x = 0.13, 0.97
-    step = (right_x - left_x) / max(width, 1)
-
-    def x_for(base: float) -> float:
-        return left_x + (base * step)
-
-    top_y, bottom_y = y, y - 0.18
-    _draw_spans(axis, spans=top_spans, offset=top_offset, x_for=x_for, y=top_y - 0.045, height=0.085)
-    _draw_spans(axis, spans=bottom_spans, offset=bottom_offset, x_for=x_for, y=bottom_y - 0.045, height=0.085)
-    pair_segments = [
-        ((x_for(base + 0.5), top_y - 0.055), (x_for(base + 0.5), bottom_y + 0.055))
-        for base in range(paired_start, paired_start + paired_length)
-    ]
-    pairs = LineCollection(pair_segments, colors=PAIR, linewidths=0.42, zorder=1)
-    pairs.set_gid(bounded_svg_gid(f"junction-annealed:{fragment.fragment_id}:watson-crick"))
-    axis.add_collection(pairs)
-    draw_base_run(
-        axis,
-        strand.barcode_bearing_sequence_5to3,
-        start_x=x_for(top_offset),
-        start_y=top_y,
-        delta_x=step,
-        delta_y=0,
-        gid_prefix=f"junction-annealed:{fragment.fragment_id}:top",
-        fontsize=5.4,
-    )
-    draw_base_run(
-        axis,
-        bottom,
-        start_x=x_for(bottom_offset),
-        start_y=bottom_y,
-        delta_x=step,
-        delta_y=0,
-        gid_prefix=f"junction-annealed:{fragment.fragment_id}:bottom",
-        fontsize=5.4,
-    )
-    axis.text(x_for(top_offset) - 0.008, top_y, "5′", ha="right", va="center", fontsize=5.4, color=MUTED)
-    axis.text(
-        x_for(top_offset + len(strand.barcode_bearing_sequence_5to3)) + 0.004,
-        top_y,
-        "3′",
-        va="center",
-        fontsize=5.4,
-        color=MUTED,
-    )
-    axis.text(x_for(bottom_offset) - 0.008, bottom_y, "3′", ha="right", va="center", fontsize=5.4, color=MUTED)
-    axis.text(x_for(bottom_offset + len(bottom)) + 0.004, bottom_y, "5′", va="center", fontsize=5.4, color=MUTED)
-    axis.text(
-        0.015,
-        y + 0.02,
-        f"F{index + 1:02d}\n{fragment.role}",
-        ha="left",
-        va="center",
-        fontsize=6.0,
-        fontweight="semibold",
-        color=INK,
-    )
+def _figure_height(fragment_count: int) -> float:
+    return 1.45 + 0.88 * fragment_count
 
 
 @dataclass(frozen=True)
 class JunctionAnnealedFragmentsRenderer:
-    """Render explicitly selected, sequence-derived fragment-pairing maps."""
+    """Render explicitly selected, sequence-derived fragment-annealing maps."""
 
     def preflight(
         self,
@@ -223,9 +46,14 @@ class JunctionAnnealedFragmentsRenderer:
     ) -> None:
         _ = palette
         review = review_from_record(record)
-        indices = _fragment_selection(review, options)
-        _validate_rows(review, indices)
-        validate_figure_size(style, renderer=_RENDERER, width=_FIGURE_WIDTH, height=1.2 + 0.65 * len(indices))
+        indices = fragment_selection(review, options, renderer=_RENDERER)
+        validate_fragment_rows(review, indices, renderer=_RENDERER)
+        validate_figure_size(
+            style,
+            renderer=_RENDERER,
+            width=_FIGURE_WIDTH,
+            height=_figure_height(len(indices)),
+        )
 
     def render(
         self,
@@ -236,56 +64,13 @@ class JunctionAnnealedFragmentsRenderer:
     ):
         _ = palette
         review = review_from_record(record)
-        indices = _fragment_selection(review, options)
-        _validate_rows(review, indices)
-        size = validate_figure_size(
-            style,
-            renderer=_RENDERER,
-            width=_FIGURE_WIDTH,
-            height=1.2 + 0.65 * len(indices),
-        )
+        indices = fragment_selection(review, options, renderer=_RENDERER)
+        validate_fragment_rows(review, indices, renderer=_RENDERER)
+        height = _figure_height(len(indices))
+        size = validate_figure_size(style, renderer=_RENDERER, width=_FIGURE_WIDTH, height=height)
         figure, axis = plt.subplots(figsize=size, dpi=style.dpi)
-        axis.set_gid("junction-annealed-fragments:map")
-        axis.set_xlim(0, 1)
-        axis.set_ylim(0, 1.2 + 0.65 * len(indices))
-        axis.axis("off")
-        height = 1.2 + 0.65 * len(indices)
-        axis.text(
-            0.015, height - 0.12, "Expected fragment pairing", fontsize=12.5, fontweight="semibold", color=INK, va="top"
-        )
-        axis.text(
-            0.015,
-            height - 0.42,
-            (
-                f"{safe_identifier(review.target.target_id)} · "
-                f"{len(review.target.sequence_5to3)} bp target · {len(indices)} selected fragments"
-            ),
-            fontsize=6.7,
-            color=MUTED,
-            va="top",
-        )
-        axis.text(
-            0.985,
-            height - 0.12,
-            "Bases and Watson–Crick edges come from the verified design record.",
-            fontsize=6.0,
-            color=MUTED,
-            ha="right",
-            va="top",
-        )
-        y = height - 0.92
-        for index in indices:
-            _draw_fragment(axis, review, index=index, y=y)
-            y -= 0.65
-        axis.text(
-            0.015,
-            0.08,
-            "Sequence-derived pairing schematic; not a thermodynamic prediction or experimental result.",
-            fontsize=6.0,
-            color=MUTED,
-            va="bottom",
-        )
-        figure.subplots_adjust(left=0.012, right=0.992, top=0.99, bottom=0.015)
+        draw_annealed_panel(axis, review, indices, height=height)
+        figure.subplots_adjust(left=0.008, right=0.995, top=0.995, bottom=0.01)
         return figure
 
 

--- a/src/dnadesign/baserender/src/render/junction_review/__init__.py
+++ b/src/dnadesign/baserender/src/render/junction_review/__init__.py
@@ -1,0 +1,10 @@
+"""
+--------------------------------------------------------------------------------
+dnadesign
+src/dnadesign/baserender/src/render/junction_review/__init__.py
+
+Package marker for study-neutral Junction review-rendering support.
+
+Module Author(s): Eric J. South
+--------------------------------------------------------------------------------
+"""

--- a/src/dnadesign/baserender/src/render/junction_review/annealed_panel.py
+++ b/src/dnadesign/baserender/src/render/junction_review/annealed_panel.py
@@ -1,0 +1,291 @@
+"""
+--------------------------------------------------------------------------------
+dnadesign
+src/dnadesign/baserender/src/render/junction_review/annealed_panel.py
+
+Selection, geometry, and composition for the fragment-annealing review panel.
+
+Module Author(s): Eric J. South
+--------------------------------------------------------------------------------
+"""
+
+from __future__ import annotations
+
+from typing import Mapping
+
+from matplotlib.collections import LineCollection
+
+from dnadesign.contracts.visual import ThreeWayJunctionReviewV1
+
+from ...core import SchemaError
+from ..sequence_preview import bounded_svg_gid
+from .foundation import (
+    BARCODE,
+    BARCODE_DARK,
+    DOMAIN,
+    DOMAIN_DARK,
+    INK,
+    MUTED,
+    PAIR,
+    TOEHOLD,
+    TOEHOLD_DARK,
+    fragment_order_lengths,
+    length_summary,
+    safe_identifier,
+    selected_ids,
+)
+from .primitives import draw_base_run, draw_segmented_strand
+
+MAX_FRAGMENTS = 18
+MAX_ROW_BASES = 140
+
+
+def fragment_selection(
+    review: ThreeWayJunctionReviewV1,
+    options: Mapping[str, object] | None,
+    *,
+    renderer: str,
+) -> tuple[int, ...]:
+    available = tuple(fragment.fragment_id for fragment in review.geometry.fragments)
+    chosen = selected_ids(
+        options,
+        key="fragment_ids",
+        available=available,
+        maximum=MAX_FRAGMENTS,
+        required=len(available) > MAX_FRAGMENTS,
+        renderer=renderer,
+    )
+    by_id = {fragment_id: index for index, fragment_id in enumerate(available)}
+    return tuple(by_id[fragment_id] for fragment_id in chosen)
+
+
+def _row_geometry(review: ThreeWayJunctionReviewV1, index: int):
+    previous = None if index == 0 else review.geometry.junctions[index - 1]
+    following = None if index == len(review.strands) - 1 else review.geometry.junctions[index]
+    fragment = review.geometry.fragments[index]
+    strand = review.strands[index]
+    domain_length = fragment.domain_span.end - fragment.domain_span.start
+    top_domain_start = 0 if previous is None else len(previous.barcode)
+    bottom_domain_start = 0 if previous is None else len(previous.toehold)
+    aligned_domain_start = max(top_domain_start, bottom_domain_start)
+    top_offset = aligned_domain_start - top_domain_start
+    bottom_offset = aligned_domain_start - bottom_domain_start
+    top_spans: list[tuple[int, int, str, str]] = []
+    bottom_spans: list[tuple[int, int, str, str]] = []
+    if previous is not None:
+        top_spans.append((0, len(previous.barcode), BARCODE, f"b{index}*"))
+        bottom_spans.append((0, len(previous.toehold), TOEHOLD, f"t{index}*"))
+    top_spans.append((top_domain_start, top_domain_start + domain_length, DOMAIN, "target"))
+    bottom_spans.append((bottom_domain_start, bottom_domain_start + domain_length, DOMAIN, "target"))
+    if following is not None:
+        start = top_domain_start + domain_length
+        top_spans.extend(
+            (
+                (start, start + len(following.toehold), TOEHOLD, f"t{index + 1}"),
+                (
+                    start + len(following.toehold),
+                    start + len(following.toehold) + len(following.barcode),
+                    BARCODE,
+                    f"b{index + 1}",
+                ),
+            )
+        )
+    return (
+        fragment,
+        strand,
+        strand.complement_sequence_5to3[::-1],
+        top_offset,
+        bottom_offset,
+        aligned_domain_start,
+        domain_length,
+        tuple(top_spans),
+        tuple(bottom_spans),
+    )
+
+
+def validate_fragment_rows(review: ThreeWayJunctionReviewV1, indices: tuple[int, ...], *, renderer: str) -> None:
+    for index in indices:
+        _, strand, bottom, top_offset, bottom_offset, *_ = _row_geometry(review, index)
+        width = max(top_offset + len(strand.barcode_bearing_sequence_5to3), bottom_offset + len(bottom))
+        if width > MAX_ROW_BASES:
+            raise SchemaError(
+                f"{renderer} fragment {strand.fragment_id!r} spans {width} displayed bases; "
+                f"the limit is {MAX_ROW_BASES}"
+            )
+
+
+def _component_text_color(color: str) -> str:
+    if color == BARCODE:
+        return BARCODE_DARK
+    if color == TOEHOLD:
+        return TOEHOLD_DARK
+    return DOMAIN_DARK
+
+
+def _draw_span_labels(axis, *, spans, start_x: float, base_step: float, y: float, above: bool) -> None:
+    for start, end, color, label in spans:
+        left = start_x + start * base_step
+        right = start_x + end * base_step
+        axis.text(
+            (left + right) / 2,
+            y,
+            label,
+            ha="center",
+            va="bottom" if above else "top",
+            fontsize=6.8,
+            color=_component_text_color(color),
+        )
+
+
+def _draw_fragment(
+    axis, review, *, index: int, y: float, base_step: float, maximum_width: int, fontsize: float
+) -> None:
+    fragment, strand, bottom, top_offset, bottom_offset, paired_start, paired_length, top_spans, bottom_spans = (
+        _row_geometry(review, index)
+    )
+    width = max(top_offset + len(strand.barcode_bearing_sequence_5to3), bottom_offset + len(bottom))
+    row_start = 0.16 + (maximum_width - width) * base_step / 2
+    top_start = row_start + top_offset * base_step
+    bottom_start = row_start + bottom_offset * base_step
+    top_y, bottom_y = y, y - 0.25
+    strand_height = 0.13
+    draw_segmented_strand(
+        axis,
+        start_x=top_start,
+        center_y=top_y,
+        base_step=base_step,
+        length=len(strand.barcode_bearing_sequence_5to3),
+        segments=tuple((start, end, color) for start, end, color, _label in top_spans),
+        height=strand_height,
+        gid_prefix=f"junction-annealed:{fragment.fragment_id}:top-strand",
+    )
+    draw_segmented_strand(
+        axis,
+        start_x=bottom_start,
+        center_y=bottom_y,
+        base_step=base_step,
+        length=len(bottom),
+        segments=tuple((start, end, color) for start, end, color, _label in bottom_spans),
+        height=strand_height,
+        gid_prefix=f"junction-annealed:{fragment.fragment_id}:bottom-strand",
+    )
+    _draw_span_labels(axis, spans=top_spans, start_x=top_start, base_step=base_step, y=top_y + 0.095, above=True)
+    _draw_span_labels(
+        axis,
+        spans=bottom_spans,
+        start_x=bottom_start,
+        base_step=base_step,
+        y=bottom_y - 0.095,
+        above=False,
+    )
+    pair_segments = [
+        (
+            (row_start + (base + 0.5) * base_step, top_y - 0.07),
+            (row_start + (base + 0.5) * base_step, bottom_y + 0.07),
+        )
+        for base in range(paired_start, paired_start + paired_length)
+    ]
+    pairs = LineCollection(pair_segments, colors=PAIR, linewidths=0.6, zorder=1)
+    pairs.set_gid(bounded_svg_gid(f"junction-annealed:{fragment.fragment_id}:watson-crick"))
+    axis.add_collection(pairs)
+    draw_base_run(
+        axis,
+        strand.barcode_bearing_sequence_5to3,
+        start_x=top_start,
+        start_y=top_y,
+        delta_x=base_step,
+        delta_y=0,
+        gid_prefix=f"junction-annealed:{fragment.fragment_id}:top",
+        fontsize=fontsize,
+    )
+    draw_base_run(
+        axis,
+        bottom,
+        start_x=bottom_start,
+        start_y=bottom_y,
+        delta_x=base_step,
+        delta_y=0,
+        gid_prefix=f"junction-annealed:{fragment.fragment_id}:bottom",
+        fontsize=fontsize,
+    )
+    axis.text(top_start - 0.008, top_y, "5′", ha="right", va="center", fontsize=7.2, color=MUTED)
+    axis.text(
+        top_start + len(strand.barcode_bearing_sequence_5to3) * base_step + 0.004,
+        top_y,
+        "3′",
+        va="center",
+        fontsize=7.2,
+        color=MUTED,
+    )
+    axis.text(bottom_start - 0.008, bottom_y, "3′", ha="right", va="center", fontsize=7.2, color=MUTED)
+    axis.text(bottom_start + len(bottom) * base_step + 0.004, bottom_y, "5′", va="center", fontsize=7.2, color=MUTED)
+    axis.text(
+        0.015,
+        y - 0.02,
+        (
+            f"F{index + 1:02d} · {fragment.role}\n"
+            f"{len(strand.barcode_bearing_sequence_5to3)} nt / "
+            f"{len(strand.complement_sequence_5to3)} nt"
+        ),
+        ha="left",
+        va="center",
+        fontsize=7.2,
+        fontweight="semibold",
+        color=INK,
+    )
+
+
+def draw_annealed_panel(axis, review: ThreeWayJunctionReviewV1, indices: tuple[int, ...], *, height: float) -> None:
+    axis.set_gid("junction-annealed-fragments:map")
+    axis.set_xlim(0, 1)
+    axis.set_ylim(0, height)
+    axis.axis("off")
+    rows = tuple(_row_geometry(review, index) for index in indices)
+    maximum_width = max(max(row[3] + len(row[1].barcode_bearing_sequence_5to3), row[4] + len(row[2])) for row in rows)
+    base_step = 0.80 / maximum_width
+    base_fontsize = min(7.8, max(5.8, 820 / maximum_width))
+    count = len(indices)
+    axis.text(
+        0.015,
+        height - 0.10,
+        (
+            f"{count} selected fragment {'pair is' if count == 1 else 'pairs are'} "
+            f"expected to anneal for {safe_identifier(review.target.target_id)}"
+        ),
+        fontsize=15.0,
+        fontweight="semibold",
+        color=INK,
+        va="top",
+    )
+    lengths = fragment_order_lengths(review, indices)
+    axis.text(
+        0.015,
+        height - 0.43,
+        (
+            f"The {len(review.target.sequence_5to3)} bp target contributes "
+            f"{len(lengths)} fragment oligos spanning {length_summary(lengths)}"
+        ),
+        fontsize=9.0,
+        color=MUTED,
+        va="top",
+    )
+    y = height - 1.02
+    for index in indices:
+        _draw_fragment(
+            axis,
+            review,
+            index=index,
+            y=y,
+            base_step=base_step,
+            maximum_width=maximum_width,
+            fontsize=base_fontsize,
+        )
+        y -= 0.88
+    axis.text(
+        0.015,
+        0.07,
+        "Base pairing is sequence-derived and does not establish thermodynamic or experimental success",
+        fontsize=8.0,
+        color=MUTED,
+        va="bottom",
+    )

--- a/src/dnadesign/baserender/src/render/junction_review/detail_geometry.py
+++ b/src/dnadesign/baserender/src/render/junction_review/detail_geometry.py
@@ -1,0 +1,72 @@
+"""
+--------------------------------------------------------------------------------
+dnadesign
+src/dnadesign/baserender/src/render/junction_review/detail_geometry.py
+
+Bounded local geometry for one nucleotide-level three-way-junction detail.
+
+Module Author(s): Eric J. South
+--------------------------------------------------------------------------------
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from dnadesign.contracts.visual.three_way_junction_review_v1 import (
+    FragmentGeometry,
+    JunctionGeometry,
+    ThreeWayJunctionReviewV1,
+)
+
+CONTEXT_BASES = 6
+MAX_RIGHT_CONTEXT_BASES = 16
+STRAND_WIDTH = 11.0
+COMPONENT_WIDTH = 8.5
+TOP_Y = 0.0
+BOTTOM_Y = -2.6
+STEM_LEFT_X = -0.72
+STEM_RIGHT_X = 0.72
+STEM_START_Y = 1.0
+
+
+@dataclass(frozen=True, slots=True)
+class LocalJunctionGeometry:
+    junction: JunctionGeometry
+    left_fragment: FragmentGeometry
+    right_fragment: FragmentGeometry
+    left_context: str
+    right_context: str
+    left_is_terminal: bool
+    right_is_terminal: bool
+
+
+def local_junction_geometry(review: ThreeWayJunctionReviewV1, index: int) -> LocalJunctionGeometry:
+    """Project one exact interface into a bounded, symmetric review window."""
+
+    junction = review.geometry.junctions[index]
+    left_fragment = review.geometry.fragments[index]
+    right_fragment = review.geometry.fragments[index + 1]
+    target = review.target.sequence_5to3
+    left_start = max(left_fragment.domain_span.start, junction.toehold_span.start - CONTEXT_BASES)
+    right_context_bases = min(CONTEXT_BASES + len(junction.toehold), MAX_RIGHT_CONTEXT_BASES)
+    right_end = min(right_fragment.domain_span.end, junction.toehold_span.end + right_context_bases)
+    return LocalJunctionGeometry(
+        junction=junction,
+        left_fragment=left_fragment,
+        right_fragment=right_fragment,
+        left_context=target[left_start : junction.toehold_span.start],
+        right_context=target[junction.toehold_span.end : right_end],
+        left_is_terminal=left_start == 0,
+        right_is_terminal=right_end == len(target),
+    )
+
+
+def junction_detail_base_glyph_count(review: ThreeWayJunctionReviewV1, index: int) -> int:
+    """Count the per-base text artists required by one local detail view."""
+
+    geometry = local_junction_geometry(review, index)
+    junction = geometry.junction
+    return 2 * (
+        len(geometry.left_context) + len(junction.toehold) + len(geometry.right_context) + len(junction.barcode)
+    )

--- a/src/dnadesign/baserender/src/render/junction_review/detail_primitives.py
+++ b/src/dnadesign/baserender/src/render/junction_review/detail_primitives.py
@@ -1,0 +1,61 @@
+"""
+--------------------------------------------------------------------------------
+dnadesign
+src/dnadesign/baserender/src/render/junction_review/detail_primitives.py
+
+Drawing marks used only by nucleotide-level Junction detail panels.
+
+Module Author(s): Eric J. South
+--------------------------------------------------------------------------------
+"""
+
+from __future__ import annotations
+
+from matplotlib.collections import LineCollection
+from matplotlib.lines import Line2D
+
+from ..sequence_preview import bounded_svg_gid
+from .detail_geometry import COMPONENT_WIDTH
+from .foundation import INK, PAIR
+from .primitives import draw_molecular_path
+
+
+def add_pairs(axis, segments, *, gid: str) -> None:
+    collection = LineCollection(segments, colors=PAIR, linewidths=0.8, zorder=1)
+    collection.set_gid(bounded_svg_gid(gid))
+    axis.add_collection(collection)
+
+
+def add_break(axis, *, x: float, y: float, gid: str) -> None:
+    """Mark a cropped strand with paired slashes, not a physical terminus."""
+
+    for index, offset in enumerate((-0.20, 0.20)):
+        xs = (x + offset - 0.18, x + offset + 0.18)
+        ys = (y - 0.48, y + 0.48)
+        axis.add_line(Line2D(xs, ys, color="white", linewidth=4.0, zorder=5))
+        mark = Line2D(xs, ys, color=INK, linewidth=1.0, zorder=6)
+        mark.set_gid(bounded_svg_gid(f"{gid}:{index}"))
+        axis.add_line(mark)
+
+
+def add_nick(axis, *, x: float, y: float, gid: str) -> None:
+    """Draw the one physical nick as a single diagonal mark."""
+
+    xs = (x - 0.22, x + 0.22)
+    ys = (y - 0.52, y + 0.52)
+    axis.add_line(Line2D(xs, ys, color="white", linewidth=4.2, zorder=5))
+    mark = Line2D(xs, ys, color=INK, linewidth=1.2, zorder=6)
+    mark.set_gid(bounded_svg_gid(gid))
+    axis.add_line(mark)
+
+
+def draw_component_path(axis, xs, ys, *, color: str, gid: str) -> None:
+    draw_molecular_path(
+        axis,
+        xs,
+        ys,
+        color=color,
+        gid=gid,
+        linewidth=COMPONENT_WIDTH,
+        zorder=0.5,
+    )

--- a/src/dnadesign/baserender/src/render/junction_review/foundation.py
+++ b/src/dnadesign/baserender/src/render/junction_review/foundation.py
@@ -1,9 +1,9 @@
 """
 --------------------------------------------------------------------------------
 dnadesign
-src/dnadesign/baserender/src/render/junction_review_common.py
+src/dnadesign/baserender/src/render/junction_review/foundation.py
 
-Shared contracts and bounds for Junction review renderers.
+Evidence access, selection, style, and resource policy for Junction review plots.
 
 Module Author(s): Eric J. South
 --------------------------------------------------------------------------------
@@ -12,32 +12,29 @@ Module Author(s): Eric J. South
 from __future__ import annotations
 
 import math
+import statistics
 from typing import Mapping, Sequence
 
 from pydantic import ValidationError
 
 from dnadesign.contracts.visual import ThreeWayJunctionReviewV1
 
-from ..config import Style
-from ..core import Record, RenderingError, SchemaError
-from ..core.pydantic_validation import format_validation_error
-from .sequence_preview import bounded_svg_gid, bounded_text_preview
+from ...config import Style
+from ...core import Record, RenderingError, SchemaError
+from ...core.pydantic_validation import format_validation_error
+from ..sequence_preview import bounded_text_preview
 
 INK = "#172033"
 MUTED = "#667085"
-PAIR = "#CDD3DB"
-DOMAIN = "#E9EDF2"
+PAIR = "#B8C0CC"
+DOMAIN = "#E8EBEF"
+DOMAIN_DARK = "#667085"
+TOEHOLD = "#F3D6A1"
+TOEHOLD_DARK = "#8A5A00"
+BARCODE = "#A9D8D5"
+BARCODE_DARK = "#1F6F70"
+STRAND_EDGE = "#7C8798"
 BACKGROUND = "#FFFFFF"
-JUNCTION_COLORS = (
-    "#4E79A7",
-    "#2A9D8F",
-    "#7A9E4E",
-    "#D4A72C",
-    "#D96C5F",
-    "#A06CD5",
-    "#5C8D89",
-    "#C76B98",
-)
 
 MAX_DPI = 600
 MAX_FIGURE_SCALE = 4.0
@@ -68,41 +65,36 @@ def safe_identifier(value: str) -> str:
     return preview.preview
 
 
-def junction_color(index: int) -> str:
-    return JUNCTION_COLORS[index % len(JUNCTION_COLORS)]
+def display_junction_id(value: str) -> str:
+    """Return the stable local part of a plan-scoped junction identifier."""
+
+    return safe_identifier(value.rsplit(":", 1)[-1])
 
 
-def draw_base_run(
-    axis,
-    sequence: str,
-    *,
-    start_x: float,
-    start_y: float,
-    delta_x: float,
-    delta_y: float,
-    gid_prefix: str,
-    fontsize: float,
-    color: str = INK,
-) -> tuple[object, ...]:
-    """Draw bases at explicit centers shared with pairing geometry."""
+def fragment_order_lengths(
+    review: ThreeWayJunctionReviewV1,
+    indices: Sequence[int] | None = None,
+) -> tuple[int, ...]:
+    """Return actual emitted fragment-strand lengths for a selected view."""
 
-    safe_gid_prefix = bounded_svg_gid(gid_prefix)
-    artists: list[object] = []
-    for index, base in enumerate(sequence):
-        artist = axis.text(
-            start_x + (index + 0.5) * delta_x,
-            start_y + (index + 0.5) * delta_y,
-            base,
-            family="monospace",
-            fontsize=fontsize,
-            color=color,
-            ha="center",
-            va="center",
-            zorder=3,
+    selected = range(len(review.strands)) if indices is None else indices
+    return tuple(
+        length
+        for index in selected
+        for length in (
+            len(review.strands[index].barcode_bearing_sequence_5to3),
+            len(review.strands[index].complement_sequence_5to3),
         )
-        artist.set_gid(f"{safe_gid_prefix}:base:{index}:{base}")
-        artists.append(artist)
-    return tuple(artists)
+    )
+
+
+def length_summary(lengths: Sequence[int]) -> str:
+    """Describe a non-empty set of physical oligo lengths concisely."""
+
+    if not lengths:
+        raise ValueError("oligo length summary requires at least one length")
+    median = statistics.median(lengths)
+    return f"{min(lengths)}–{max(lengths)} nt with median {median:g} nt"
 
 
 def validate_figure_size(
@@ -164,18 +156,3 @@ def selected_ids(
     if unknown:
         raise SchemaError(f"{renderer} received unknown {key}: {unknown[:5]}")
     return selected
-
-
-__all__ = [
-    "BACKGROUND",
-    "DOMAIN",
-    "INK",
-    "MUTED",
-    "PAIR",
-    "draw_base_run",
-    "junction_color",
-    "review_from_record",
-    "safe_identifier",
-    "selected_ids",
-    "validate_figure_size",
-]

--- a/src/dnadesign/baserender/src/render/junction_review/overview_panel.py
+++ b/src/dnadesign/baserender/src/render/junction_review/overview_panel.py
@@ -1,0 +1,193 @@
+"""
+--------------------------------------------------------------------------------
+dnadesign
+src/dnadesign/baserender/src/render/junction_review/overview_panel.py
+
+Target-scale composition for the three-way-junction assembly overview.
+
+Module Author(s): Eric J. South
+--------------------------------------------------------------------------------
+"""
+
+from __future__ import annotations
+
+from matplotlib.collections import LineCollection
+from matplotlib.lines import Line2D
+
+from dnadesign.contracts.visual import ThreeWayJunctionReviewV1
+
+from .foundation import (
+    BARCODE,
+    BARCODE_DARK,
+    DOMAIN,
+    INK,
+    MUTED,
+    PAIR,
+    TOEHOLD,
+    TOEHOLD_DARK,
+    display_junction_id,
+    fragment_order_lengths,
+    length_summary,
+    safe_identifier,
+)
+from .primitives import draw_molecular_path, draw_segmented_strand
+
+
+def draw_overview(axis, review: ThreeWayJunctionReviewV1) -> None:
+    """Draw one bounded locator map on target coordinates."""
+
+    axis.set_gid("junction-three-way-assembly:overview")
+    axis.set_xlim(0, 1)
+    axis.set_ylim(0, 1)
+    axis.axis("off")
+    fragment_count = len(review.geometry.fragments)
+    junction_count = len(review.geometry.junctions)
+    target_id = safe_identifier(review.target.target_id)
+    axis.text(
+        0.025,
+        0.95,
+        (
+            f"{junction_count} three-way "
+            f"{'junction links' if junction_count == 1 else 'junctions link'} "
+            f"{fragment_count} fragments across {target_id}"
+        ),
+        fontsize=15.0,
+        fontweight="semibold",
+        color=INK,
+        va="top",
+    )
+    lengths = fragment_order_lengths(review)
+    axis.text(
+        0.025,
+        0.84,
+        (
+            f"The {len(review.target.sequence_5to3)} bp target uses "
+            f"{len(lengths)} fragment oligos spanning {length_summary(lengths)}"
+        ),
+        fontsize=9.0,
+        color=MUTED,
+        va="top",
+    )
+    left, right = 0.055, 0.965
+    top_y, bottom_y = 0.47, 0.37
+    target_length = len(review.target.sequence_5to3)
+    base_step = (right - left) / target_length
+
+    def x_for(coordinate: int) -> float:
+        return left + base_step * coordinate
+
+    target_segments = tuple(
+        sorted(
+            (
+                *(
+                    (fragment.domain_span.start, fragment.domain_span.end, DOMAIN)
+                    for fragment in review.geometry.fragments
+                ),
+                *(
+                    (junction.toehold_span.start, junction.toehold_span.end, TOEHOLD)
+                    for junction in review.geometry.junctions
+                ),
+            ),
+            key=lambda item: item[0],
+        )
+    )
+    for y, role in ((top_y, "top"), (bottom_y, "bottom")):
+        draw_segmented_strand(
+            axis,
+            start_x=left,
+            center_y=y,
+            base_step=base_step,
+            length=target_length,
+            segments=target_segments,
+            height=0.052,
+            gid_prefix=f"junction-three-way-assembly:target:{role}",
+        )
+    for fragment in review.geometry.fragments:
+        x0, x1 = x_for(fragment.domain_span.start), x_for(fragment.domain_span.end)
+        axis.text(
+            (x0 + x1) / 2,
+            0.265,
+            f"F{fragment.index + 1:02d} · {fragment.role}",
+            fontsize=7.2,
+            color=INK,
+            ha="center",
+            va="top",
+        )
+    for junction in review.geometry.junctions:
+        x = x_for(junction.toehold_span.end)
+        stem_offset = 0.0038
+        stem_top = 0.69
+        draw_molecular_path(
+            axis,
+            [x - stem_offset, x - stem_offset],
+            [top_y, stem_top],
+            color=BARCODE,
+            gid=f"junction-three-way-assembly:{junction.junction_id}:barcode",
+            linewidth=7.0,
+        )
+        draw_molecular_path(
+            axis,
+            [x + stem_offset, x + stem_offset],
+            [stem_top, top_y],
+            color=BARCODE,
+            gid=f"junction-three-way-assembly:{junction.junction_id}:barcode-complement",
+            linewidth=7.0,
+        )
+        pairs = LineCollection(
+            [((x - stem_offset + 0.001, y), (x + stem_offset - 0.001, y)) for y in (0.54, 0.59, 0.64)],
+            colors=PAIR,
+            linewidths=0.75,
+            zorder=1,
+        )
+        axis.add_collection(pairs)
+        axis.text(
+            x,
+            0.735,
+            display_junction_id(junction.junction_id),
+            fontsize=7.4,
+            color=BARCODE_DARK,
+            ha="center",
+            va="bottom",
+        )
+        axis.text(
+            x,
+            0.705,
+            f"bp {junction.toehold_span.start + 1}–{junction.toehold_span.end}",
+            fontsize=6.2,
+            color=MUTED,
+            ha="center",
+            va="bottom",
+        )
+        nick_x = x_for(junction.toehold_span.start)
+        axis.add_line(
+            Line2D(
+                [nick_x - 0.0025, nick_x + 0.0025],
+                [bottom_y - 0.032, bottom_y + 0.032],
+                linewidth=1.1,
+                color=INK,
+                zorder=4,
+            )
+        )
+    axis.text(left - 0.008, top_y, "5′", fontsize=7.2, color=MUTED, ha="right", va="center")
+    axis.text(right + 0.008, top_y, "3′", fontsize=7.2, color=MUTED, ha="left", va="center")
+    axis.text(left - 0.008, bottom_y, "3′", fontsize=7.2, color=MUTED, ha="right", va="center")
+    axis.text(right + 0.008, bottom_y, "5′", fontsize=7.2, color=MUTED, ha="left", va="center")
+    axis.text(left, 0.57, "barcode stems", fontsize=7.0, color=BARCODE_DARK, ha="left", va="center")
+    axis.text(left, 0.43, "toeholds", fontsize=7.0, color=TOEHOLD_DARK, ha="left", va="center")
+    axis.text(
+        0.025,
+        0.08,
+        "Each stable junction ID opens an exact nucleotide-level view of the expected local annealing geometry",
+        fontsize=8.0,
+        color=MUTED,
+        va="bottom",
+    )
+    axis.text(
+        0.975,
+        0.08,
+        "The map is sequence-derived and does not establish assembly success",
+        fontsize=8.0,
+        color=MUTED,
+        ha="right",
+        va="bottom",
+    )

--- a/src/dnadesign/baserender/src/render/junction_review/primitives.py
+++ b/src/dnadesign/baserender/src/render/junction_review/primitives.py
@@ -1,0 +1,135 @@
+"""
+--------------------------------------------------------------------------------
+dnadesign
+src/dnadesign/baserender/src/render/junction_review/primitives.py
+
+Deterministic molecular drawing primitives for Junction review plots.
+
+Module Author(s): Eric J. South
+--------------------------------------------------------------------------------
+"""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+from matplotlib.lines import Line2D
+from matplotlib.patches import FancyBboxPatch, Rectangle
+
+from ..sequence_preview import bounded_svg_gid
+from .foundation import DOMAIN, INK, STRAND_EDGE
+
+
+def draw_segmented_strand(
+    axis,
+    *,
+    start_x: float,
+    center_y: float,
+    base_step: float,
+    length: int,
+    segments: Sequence[tuple[int, int, str]],
+    height: float,
+    gid_prefix: str,
+) -> None:
+    """Draw one contiguous oligo with clipped categorical component spans."""
+
+    if length < 1:
+        raise ValueError("segmented strand length must be positive")
+    width = base_step * length
+    rounding = min(height / 2, width / 2)
+    body = FancyBboxPatch(
+        (start_x, center_y - height / 2),
+        width,
+        height,
+        boxstyle=f"round,pad=0,rounding_size={rounding}",
+        facecolor=DOMAIN,
+        edgecolor=STRAND_EDGE,
+        linewidth=0.7,
+        zorder=0,
+    )
+    body.set_gid(bounded_svg_gid(f"{gid_prefix}:body"))
+    axis.add_patch(body)
+    for index, (start, end, color) in enumerate(segments):
+        if not 0 <= start < end <= length:
+            raise ValueError(f"invalid strand segment [{start}, {end}) for length {length}")
+        segment = Rectangle(
+            (start_x + start * base_step, center_y - height / 2),
+            (end - start) * base_step,
+            height,
+            facecolor=color,
+            edgecolor="none",
+            zorder=0.2,
+        )
+        segment.set_clip_path(body)
+        segment.set_gid(bounded_svg_gid(f"{gid_prefix}:segment:{index}"))
+        axis.add_patch(segment)
+    outline = FancyBboxPatch(
+        (start_x, center_y - height / 2),
+        width,
+        height,
+        boxstyle=f"round,pad=0,rounding_size={rounding}",
+        facecolor="none",
+        edgecolor=STRAND_EDGE,
+        linewidth=0.7,
+        zorder=0.4,
+    )
+    outline.set_gid(bounded_svg_gid(f"{gid_prefix}:outline"))
+    axis.add_patch(outline)
+
+
+def draw_molecular_path(
+    axis,
+    xs: Sequence[float],
+    ys: Sequence[float],
+    *,
+    color: str,
+    gid: str,
+    linewidth: float = 9.0,
+    zorder: float = 0.3,
+) -> None:
+    """Draw one contiguous molecular path with rounded termini and corners."""
+
+    line = Line2D(
+        xs,
+        ys,
+        color=color,
+        linewidth=linewidth,
+        solid_capstyle="round",
+        solid_joinstyle="round",
+        zorder=zorder,
+    )
+    line.set_gid(bounded_svg_gid(gid))
+    axis.add_line(line)
+
+
+def draw_base_run(
+    axis,
+    sequence: str,
+    *,
+    start_x: float,
+    start_y: float,
+    delta_x: float,
+    delta_y: float,
+    gid_prefix: str,
+    fontsize: float,
+    color: str = INK,
+) -> tuple[object, ...]:
+    """Draw bases at explicit centers shared with pairing geometry."""
+
+    safe_gid_prefix = bounded_svg_gid(gid_prefix)
+    artists: list[object] = []
+    for index, base in enumerate(sequence):
+        artist = axis.text(
+            start_x + (index + 0.5) * delta_x,
+            start_y + (index + 0.5) * delta_y,
+            base,
+            family="monospace",
+            fontsize=fontsize,
+            color=color,
+            ha="center",
+            va="center",
+            zorder=3,
+        )
+        artist.set_gid(f"{safe_gid_prefix}:base:{index}:{base}")
+        artists.append(artist)
+    return tuple(artists)

--- a/src/dnadesign/baserender/src/render/junction_three_way_assembly.py
+++ b/src/dnadesign/baserender/src/render/junction_three_way_assembly.py
@@ -3,7 +3,7 @@
 dnadesign
 src/dnadesign/baserender/src/render/junction_three_way_assembly.py
 
-Overview and selected-detail views for Junction three-way assemblies.
+Registered overview and selected-detail renderer for Junction assemblies.
 
 Module Author(s): Eric J. South
 --------------------------------------------------------------------------------
@@ -19,23 +19,23 @@ import matplotlib
 
 matplotlib.use("Agg")
 import matplotlib.pyplot as plt
-from matplotlib.lines import Line2D
-from matplotlib.patches import Rectangle
 
 from dnadesign.contracts.visual import ThreeWayJunctionReviewV1
 
 from ..config import Style
 from ..core import Record, SchemaError
-from .junction_review_common import (
+from .junction_review.detail_geometry import junction_detail_base_glyph_count
+from .junction_review.foundation import (
     INK,
     MUTED,
-    junction_color,
+    fragment_order_lengths,
+    length_summary,
     review_from_record,
-    safe_identifier,
     selected_ids,
     validate_figure_size,
 )
-from .junction_three_way_detail import draw_junction_detail, junction_detail_base_glyph_count
+from .junction_review.overview_panel import draw_overview
+from .junction_three_way_detail import draw_junction_detail
 from .palette import Palette
 
 _RENDERER = "junction_three_way_assembly"
@@ -76,15 +76,17 @@ def _resolve_options(
 
 
 def _overview_size(style: Style) -> tuple[float, float]:
-    return validate_figure_size(style, renderer=_RENDERER, width=_FIGURE_WIDTH, height=4.2)
+    return validate_figure_size(style, renderer=_RENDERER, width=_FIGURE_WIDTH, height=4.8)
 
 
 def _detail_size(style: Style, count: int) -> tuple[float, float]:
+    columns = min(2, count)
+    rows = math.ceil(count / columns)
     return validate_figure_size(
         style,
         renderer=_RENDERER,
-        width=_FIGURE_WIDTH,
-        height=1.15 + math.ceil(count / 2) * 4.0,
+        width=8.2 if columns == 1 else _FIGURE_WIDTH,
+        height=1.65 + rows * 4.8,
     )
 
 
@@ -108,74 +110,6 @@ def _validate_overview_workload(review: ThreeWayJunctionReviewV1) -> None:
         )
 
 
-def _draw_overview(axis, review: ThreeWayJunctionReviewV1) -> None:
-    axis.set_gid("junction-three-way-assembly:overview")
-    axis.set_xlim(0, 1)
-    axis.set_ylim(0, 1)
-    axis.axis("off")
-    axis.text(0.025, 0.94, "Three-way assembly map", fontsize=12.5, fontweight="semibold", color=INK, va="top")
-    fragment_count = len(review.geometry.fragments)
-    junction_count = len(review.geometry.junctions)
-    axis.text(
-        0.025,
-        0.86,
-        (
-            f"{safe_identifier(review.target.target_id)} · "
-            f"{fragment_count} {'fragment' if fragment_count == 1 else 'fragments'} · "
-            f"{junction_count} {'junction' if junction_count == 1 else 'junctions'}"
-        ),
-        fontsize=6.8,
-        color=MUTED,
-        va="top",
-    )
-    left, right = 0.055, 0.965
-    top_y, bottom_y = 0.47, 0.39
-    length = len(review.target.sequence_5to3)
-
-    def x_for(coordinate: int) -> float:
-        return left + ((right - left) * coordinate / length)
-
-    axis.add_line(Line2D([left, right], [top_y, top_y], linewidth=4.2, color="#6B7280"))
-    axis.add_line(Line2D([left, right], [bottom_y, bottom_y], linewidth=4.2, color="#9AA1AA"))
-    for fragment in review.geometry.fragments:
-        x0, x1 = x_for(fragment.domain_span.start), x_for(fragment.domain_span.end)
-        fill = "#E2E6EB" if fragment.index % 2 == 0 else "#D5DBE2"
-        axis.add_patch(Rectangle((x0, top_y - 0.024), x1 - x0, 0.048, facecolor=fill, edgecolor="none", zorder=2))
-        axis.text(
-            (x0 + x1) / 2,
-            0.31,
-            f"F{fragment.index + 1}",
-            fontsize=5.6,
-            color=INK,
-            ha="center",
-            va="top",
-        )
-    for index, junction in enumerate(review.geometry.junctions):
-        x = x_for(junction.toehold_span.end)
-        color = junction_color(index)
-        axis.add_line(Line2D([x - 0.005, x - 0.005], [top_y, 0.73], linewidth=3.2, color=color))
-        axis.add_line(Line2D([x + 0.005, x + 0.005], [top_y, 0.73], linewidth=3.2, color=color, alpha=0.68))
-        axis.text(x, 0.77, f"J{index + 1}", fontsize=5.5, color=color, ha="center", va="bottom")
-        axis.add_line(Line2D([x, x], [bottom_y - 0.025, bottom_y + 0.025], linewidth=1.0, color=INK))
-    axis.text(
-        0.025,
-        0.10,
-        "Each stem marks one barcode-mediated interface. Use view: junction_detail for exact bases.",
-        fontsize=6.2,
-        color=MUTED,
-        va="bottom",
-    )
-    axis.text(
-        0.975,
-        0.10,
-        "Sequence-derived topology; not a structure or assembly simulation.",
-        fontsize=6.0,
-        color=MUTED,
-        ha="right",
-        va="bottom",
-    )
-
-
 @dataclass(frozen=True)
 class JunctionThreeWayAssemblyRenderer:
     """Render a target overview or explicitly selected nucleotide-level 3WJs."""
@@ -192,9 +126,10 @@ class JunctionThreeWayAssemblyRenderer:
         resolved = _resolve_options(review, options)
         if resolved.view == "overview":
             _validate_overview_workload(review)
+            _overview_size(style)
         else:
             _validate_detail_workload(review, resolved.junction_indices)
-        _overview_size(style) if resolved.view == "overview" else _detail_size(style, len(resolved.junction_indices))
+            _detail_size(style, len(resolved.junction_indices))
 
     def render(
         self,
@@ -209,23 +144,49 @@ class JunctionThreeWayAssemblyRenderer:
         if resolved.view == "overview":
             _validate_overview_workload(review)
             figure, axis = plt.subplots(figsize=_overview_size(style), dpi=style.dpi)
-            _draw_overview(axis, review)
+            draw_overview(axis, review)
             figure.subplots_adjust(left=0.01, right=0.99, top=0.99, bottom=0.01)
             return figure
 
         _validate_detail_workload(review, resolved.junction_indices)
         count = len(resolved.junction_indices)
-        rows = math.ceil(count / 2)
-        figure, axes = plt.subplots(rows, 2, figsize=_detail_size(style, count), dpi=style.dpi, squeeze=False)
+        columns = min(2, count)
+        rows = math.ceil(count / columns)
+        figure, axes = plt.subplots(
+            rows,
+            columns,
+            figsize=_detail_size(style, count),
+            dpi=style.dpi,
+            squeeze=False,
+        )
         figure.suptitle(
-            f"Three-way junction details · {safe_identifier(review.target.target_id)}",
+            (
+                f"{count} selected three-way "
+                f"{'junction shows' if count == 1 else 'junctions show'} "
+                "the expected local annealing geometry"
+            ),
             x=0.02,
             y=0.995,
             ha="left",
             va="top",
-            fontsize=12.5,
+            fontsize=15.0,
             fontweight="semibold",
             color=INK,
+        )
+        lengths = fragment_order_lengths(review)
+        figure.text(
+            0.02,
+            0.95,
+            (
+                f"The {len(review.target.sequence_5to3)} bp target uses "
+                f"{len(review.geometry.junctions[0].toehold)} nt toeholds and "
+                f"{len(review.geometry.junctions[0].barcode)} nt barcodes; fragment oligos span "
+                f"{length_summary(lengths)}"
+            ),
+            fontsize=9.0,
+            color=MUTED,
+            ha="left",
+            va="top",
         )
         for axis, index in zip(axes.flat, resolved.junction_indices, strict=False):
             draw_junction_detail(axis, review, index)
@@ -234,12 +195,12 @@ class JunctionThreeWayAssemblyRenderer:
         figure.text(
             0.02,
             0.012,
-            "Exact local sequence mapping; topology is schematic, not a structure, ligation, or yield prediction.",
-            fontsize=6.0,
+            "Exact sequence mapping does not establish folding, ligation, yield, or experimental success",
+            fontsize=8.0,
             color=MUTED,
             va="bottom",
         )
-        figure.subplots_adjust(left=0.015, right=0.99, top=0.94, bottom=0.045, wspace=0.04, hspace=0.12)
+        figure.subplots_adjust(left=0.012, right=0.992, top=0.91, bottom=0.045, wspace=0.02, hspace=0.08)
         return figure
 
 

--- a/src/dnadesign/baserender/src/render/junction_three_way_detail.py
+++ b/src/dnadesign/baserender/src/render/junction_three_way_detail.py
@@ -11,249 +11,294 @@ Module Author(s): Eric J. South
 
 from __future__ import annotations
 
-from matplotlib.collections import LineCollection
-from matplotlib.lines import Line2D
-from matplotlib.patches import Rectangle
-
 from dnadesign.contracts.visual import ThreeWayJunctionReviewV1
 
-from .junction_review_common import INK, MUTED, PAIR, draw_base_run, junction_color, safe_identifier
+from .junction_review.detail_geometry import (
+    BOTTOM_Y,
+    STEM_LEFT_X,
+    STEM_RIGHT_X,
+    STEM_START_Y,
+    STRAND_WIDTH,
+    TOP_Y,
+    junction_detail_base_glyph_count,
+    local_junction_geometry,
+)
+from .junction_review.detail_primitives import add_break, add_nick, add_pairs, draw_component_path
+from .junction_review.foundation import (
+    BARCODE,
+    BARCODE_DARK,
+    DOMAIN,
+    INK,
+    MUTED,
+    STRAND_EDGE,
+    TOEHOLD,
+    TOEHOLD_DARK,
+    display_junction_id,
+)
+from .junction_review.primitives import draw_base_run, draw_molecular_path
 from .sequence_preview import bounded_svg_gid
-
-_CONTEXT_BASES = 6
-
-
-def _add_backbone(axis, xs, ys, *, gid: str, color: str = INK) -> None:
-    line = Line2D(xs, ys, color=color, linewidth=1.1, solid_capstyle="round", zorder=2)
-    line.set_gid(bounded_svg_gid(gid))
-    axis.add_line(line)
-
-
-def _add_pairs(axis, segments, *, gid: str) -> None:
-    collection = LineCollection(segments, colors=PAIR, linewidths=0.55, zorder=1)
-    collection.set_gid(bounded_svg_gid(gid))
-    axis.add_collection(collection)
-
-
-def _add_break(axis, *, x: float, y: float, gid: str) -> None:
-    """Mark a cropped strand without implying a physical terminus."""
-
-    for index, offset in enumerate((-0.012, 0.012)):
-        xs = (x + offset - 0.009, x + offset + 0.009)
-        ys = (y - 0.045, y + 0.045)
-        axis.add_line(Line2D(xs, ys, color="white", linewidth=3.2, zorder=4))
-        mark = Line2D(xs, ys, color=INK, linewidth=0.9, zorder=5)
-        mark.set_gid(bounded_svg_gid(f"{gid}:{index}"))
-        axis.add_line(mark)
-
-
-def junction_detail_base_glyph_count(review: ThreeWayJunctionReviewV1, index: int) -> int:
-    """Count the per-base text artists required by one local detail view."""
-
-    junction = review.geometry.junctions[index]
-    left_fragment = review.geometry.fragments[index]
-    right_fragment = review.geometry.fragments[index + 1]
-    left_bases = min(_CONTEXT_BASES, junction.toehold_span.start - left_fragment.domain_span.start)
-    right_bases = min(_CONTEXT_BASES, right_fragment.domain_span.end - junction.toehold_span.end)
-    return 2 * (left_bases + len(junction.toehold) + right_bases + len(junction.barcode))
 
 
 def draw_junction_detail(axis, review: ThreeWayJunctionReviewV1, index: int) -> None:
-    """Draw one exact, sequence-derived three-arm interface."""
+    """Draw one exact, sequence-derived three-arm interface on a shared base scale."""
 
-    junction = review.geometry.junctions[index]
-    left_fragment = review.geometry.fragments[index]
-    right_fragment = review.geometry.fragments[index + 1]
-    target = review.target.sequence_5to3
-    left_start = max(left_fragment.domain_span.start, junction.toehold_span.start - _CONTEXT_BASES)
-    right_end = min(right_fragment.domain_span.end, junction.toehold_span.end + _CONTEXT_BASES)
-    left_is_terminal = left_start == 0
-    right_is_terminal = right_end == len(target)
-    left_context = target[left_start : junction.toehold_span.start]
-    right_context = target[junction.toehold_span.end : right_end]
+    geometry = local_junction_geometry(review, index)
+    junction = geometry.junction
+    left_fragment = geometry.left_fragment
+    right_fragment = geometry.right_fragment
+    left_context = geometry.left_context
+    right_context = geometry.right_context
     toehold = junction.toehold
     toehold_bottom = junction.toehold_complement[::-1]
-    left_bottom = left_context.translate(str.maketrans("ACGT", "TGCA"))
-    right_bottom = right_context.translate(str.maketrans("ACGT", "TGCA"))
-    color = junction_color(index)
+    complement = str.maketrans("ACGT", "TGCA")
+    left_bottom = left_context.translate(complement)
+    right_bottom = right_context.translate(complement)
+    left_length = len(left_context) + len(toehold)
+    horizontal_span = max(left_length, len(right_context), 1)
+    stem_top = STEM_START_Y + len(junction.barcode)
+    base_fontsize = max(5.0, min(8.4, 180 / max(horizontal_span, len(junction.barcode), 1)))
 
     axis.set_gid(bounded_svg_gid(f"junction-three-way-assembly:{junction.junction_id}:detail"))
-    axis.set_xlim(-1, 1)
-    axis.set_ylim(-1, 1)
+    axis.set_xlim(-horizontal_span - 2.5, horizontal_span + 2.5)
+    axis.set_ylim(BOTTOM_Y - 4.2, stem_top + 5.2)
+    axis.set_aspect("equal", adjustable="box")
     axis.axis("off")
+
+    local_id = display_junction_id(junction.junction_id)
     axis.text(
-        -0.96,
-        0.93,
-        f"J{index + 1:02d} · F{index + 1:02d} → F{index + 2:02d}",
-        fontsize=7.0,
+        -horizontal_span - 2.1,
+        stem_top + 4.2,
+        (
+            f"{local_id} joins F{left_fragment.index + 1:02d} to F{right_fragment.index + 1:02d} "
+            f"at target bp {junction.toehold_span.start + 1}–{junction.toehold_span.end}"
+        ),
+        fontsize=9.5,
         fontweight="semibold",
         color=INK,
         va="top",
     )
-    axis.text(
-        0.96,
-        0.93,
-        f"target bp {junction.toehold_span.start + 1}–{junction.toehold_span.end}",
-        fontsize=5.5,
-        color=MUTED,
-        ha="right",
-        va="top",
-    )
 
-    total_left = len(left_context) + len(toehold)
-    horizontal_step = min(0.075, 0.72 / max(total_left, len(right_context), 1))
-    node_x = 0.0
-    top_y, bottom_y = 0.16, -0.12
-    left_x = node_x - total_left * horizontal_step
-    toehold_x = node_x - len(toehold) * horizontal_step
-    right_x = node_x + 0.08
+    left_x = -left_length
+    toehold_x = -len(toehold)
+    right_x = 0.0
 
-    _add_backbone(
+    draw_molecular_path(
         axis,
-        [left_x, node_x - 0.035, node_x - 0.035],
-        [top_y, top_y, 0.74],
+        [left_x, STEM_LEFT_X, STEM_LEFT_X],
+        [TOP_Y, TOP_Y, stem_top],
+        color=STRAND_EDGE,
         gid=f"junction:{junction.junction_id}:left-and-barcode-arm",
+        linewidth=STRAND_WIDTH,
+        zorder=0.2,
     )
-    _add_backbone(
+    draw_molecular_path(
         axis,
-        [node_x + 0.115, node_x + 0.115, right_x + len(right_context) * horizontal_step],
-        [0.74, top_y, top_y],
+        [STEM_RIGHT_X, STEM_RIGHT_X, len(right_context)],
+        [stem_top, TOP_Y, TOP_Y],
+        color=STRAND_EDGE,
         gid=f"junction:{junction.junction_id}:barcode-and-right-arm",
+        linewidth=STRAND_WIDTH,
+        zorder=0.2,
     )
-    _add_backbone(
+    draw_molecular_path(
         axis,
-        [left_x, toehold_x - 0.012],
-        [bottom_y, bottom_y],
+        [left_x, toehold_x - 0.34],
+        [BOTTOM_Y, BOTTOM_Y],
+        color=STRAND_EDGE,
         gid=f"junction:{junction.junction_id}:left-complement-arm",
-        color="#4B5563",
+        linewidth=STRAND_WIDTH,
+        zorder=0.2,
     )
-    _add_backbone(
+    draw_molecular_path(
         axis,
-        [toehold_x + 0.012, right_x + len(right_context) * horizontal_step],
-        [bottom_y, bottom_y],
+        [toehold_x + 0.34, len(right_context)],
+        [BOTTOM_Y, BOTTOM_Y],
+        color=STRAND_EDGE,
         gid=f"junction:{junction.junction_id}:right-complement-arm",
-        color="#4B5563",
+        linewidth=STRAND_WIDTH,
+        zorder=0.2,
     )
 
-    for y in (top_y, bottom_y):
-        axis.add_patch(
-            Rectangle(
-                (toehold_x - 0.01, y - 0.055),
-                len(toehold) * horizontal_step + 0.02,
-                0.11,
-                facecolor=color,
-                edgecolor="none",
-                alpha=0.24,
-                zorder=0,
-            )
+    if left_context:
+        draw_component_path(
+            axis,
+            [left_x, toehold_x],
+            [TOP_Y, TOP_Y],
+            color=DOMAIN,
+            gid=f"junction:{junction.junction_id}:left-target-top",
         )
-    stem_height = 0.50
-    for x in (node_x - 0.035, node_x + 0.055):
-        axis.add_patch(Rectangle((x, top_y), 0.06, stem_height, facecolor=color, edgecolor="none", alpha=0.22))
+        draw_component_path(
+            axis,
+            [left_x, toehold_x - 0.34],
+            [BOTTOM_Y, BOTTOM_Y],
+            color=DOMAIN,
+            gid=f"junction:{junction.junction_id}:left-target-bottom",
+        )
+    draw_component_path(
+        axis,
+        [toehold_x, STEM_LEFT_X],
+        [TOP_Y, TOP_Y],
+        color=TOEHOLD,
+        gid=f"junction:{junction.junction_id}:toehold-top-path",
+    )
+    draw_component_path(
+        axis,
+        [STEM_LEFT_X, STEM_LEFT_X],
+        [TOP_Y, stem_top],
+        color=BARCODE,
+        gid=f"junction:{junction.junction_id}:barcode-left-path",
+    )
+    draw_component_path(
+        axis,
+        [STEM_RIGHT_X, STEM_RIGHT_X],
+        [stem_top, TOP_Y],
+        color=BARCODE,
+        gid=f"junction:{junction.junction_id}:barcode-right-path",
+    )
+    if right_context:
+        draw_component_path(
+            axis,
+            [STEM_RIGHT_X, len(right_context)],
+            [TOP_Y, TOP_Y],
+            color=DOMAIN,
+            gid=f"junction:{junction.junction_id}:right-target-top",
+        )
+        draw_component_path(
+            axis,
+            [0.0, len(right_context)],
+            [BOTTOM_Y, BOTTOM_Y],
+            color=DOMAIN,
+            gid=f"junction:{junction.junction_id}:right-target-bottom",
+        )
+    draw_component_path(
+        axis,
+        [toehold_x + 0.34, 0.0],
+        [BOTTOM_Y, BOTTOM_Y],
+        color=TOEHOLD,
+        gid=f"junction:{junction.junction_id}:toehold-bottom-path",
+    )
 
     for sequence, start_x, y, role in (
-        (left_context, left_x, top_y, "left-top"),
-        (toehold, toehold_x, top_y, "toehold-top"),
-        (right_context, right_x, top_y, "right-top"),
-        (left_bottom, left_x, bottom_y, "left-bottom"),
-        (toehold_bottom, toehold_x, bottom_y, "toehold-bottom"),
-        (right_bottom, right_x, bottom_y, "right-bottom"),
+        (left_context, left_x, TOP_Y, "left-top"),
+        (toehold, toehold_x, TOP_Y, "toehold-top"),
+        (right_context, right_x, TOP_Y, "right-top"),
+        (left_bottom, left_x, BOTTOM_Y, "left-bottom"),
+        (toehold_bottom, toehold_x, BOTTOM_Y, "toehold-bottom"),
+        (right_bottom, right_x, BOTTOM_Y, "right-bottom"),
     ):
         draw_base_run(
             axis,
             sequence,
             start_x=start_x,
             start_y=y,
-            delta_x=horizontal_step,
-            delta_y=0,
+            delta_x=1.0,
+            delta_y=0.0,
             gid_prefix=f"junction:{junction.junction_id}:{role}",
-            fontsize=5.5,
+            fontsize=base_fontsize,
         )
 
-    barcode_y = top_y + 0.08
-    barcode_step = stem_height / max(len(junction.barcode), 1)
     draw_base_run(
         axis,
         junction.barcode,
-        start_x=node_x,
-        start_y=barcode_y,
-        delta_x=0,
-        delta_y=barcode_step,
+        start_x=STEM_LEFT_X,
+        start_y=STEM_START_Y,
+        delta_x=0.0,
+        delta_y=1.0,
         gid_prefix=f"junction:{junction.junction_id}:barcode-b",
-        fontsize=5.3,
+        fontsize=base_fontsize,
     )
     draw_base_run(
         axis,
         junction.barcode_complement,
-        start_x=node_x + 0.08,
-        start_y=barcode_y + stem_height,
-        delta_x=0,
-        delta_y=-barcode_step,
+        start_x=STEM_RIGHT_X,
+        start_y=stem_top,
+        delta_x=0.0,
+        delta_y=-1.0,
         gid_prefix=f"junction:{junction.junction_id}:barcode-b-star",
-        fontsize=5.3,
+        fontsize=base_fontsize,
     )
 
-    target_pairs = []
-    for start, length in (
-        (left_x, len(left_context)),
-        (toehold_x, len(toehold)),
-        (right_x, len(right_context)),
-    ):
-        target_pairs.extend(
-            (
-                (start + (base + 0.5) * horizontal_step, top_y - 0.035),
-                (start + (base + 0.5) * horizontal_step, bottom_y + 0.035),
-            )
-            for base in range(length)
+    target_pairs = [
+        ((start + base + 0.5, TOP_Y - 0.48), (start + base + 0.5, BOTTOM_Y + 0.48))
+        for start, length in (
+            (left_x, len(left_context)),
+            (toehold_x, len(toehold)),
+            (right_x, len(right_context)),
         )
-    _add_pairs(axis, target_pairs, gid=f"junction:{junction.junction_id}:target-pairs")
+        for base in range(length)
+    ]
+    add_pairs(axis, target_pairs, gid=f"junction:{junction.junction_id}:target-pairs")
     barcode_pairs = [
         (
-            (node_x + 0.022, barcode_y + (base + 0.5) * barcode_step),
-            (node_x + 0.058, barcode_y + (base + 0.5) * barcode_step),
+            ((STEM_LEFT_X + 0.32), STEM_START_Y + base + 0.5),
+            ((STEM_RIGHT_X - 0.32), STEM_START_Y + base + 0.5),
         )
         for base in range(len(junction.barcode))
     ]
-    _add_pairs(axis, barcode_pairs, gid=f"junction:{junction.junction_id}:barcode-pairs")
+    add_pairs(axis, barcode_pairs, gid=f"junction:{junction.junction_id}:barcode-pairs")
 
-    nick = Line2D(
-        [toehold_x - 0.012, toehold_x + 0.012],
-        [bottom_y - 0.045, bottom_y + 0.045],
-        color="#111827",
-        linewidth=1.1,
-    )
-    nick.set_gid(bounded_svg_gid(f"junction:{junction.junction_id}:nick"))
-    axis.add_line(nick)
-    axis.text(toehold_x, bottom_y - 0.14, "nick", fontsize=5.2, color=MUTED, ha="center", va="top")
-    axis.text((toehold_x + node_x) / 2, top_y + 0.09, f"t{index + 1}", fontsize=5.5, color=color, ha="center")
+    add_nick(axis, x=toehold_x, y=BOTTOM_Y, gid=f"junction:{junction.junction_id}:nick")
+    axis.text(toehold_x, BOTTOM_Y - 1.0, "nick", fontsize=7.0, color=MUTED, ha="center", va="top")
     axis.text(
-        (toehold_x + node_x) / 2,
-        bottom_y - 0.09,
+        (toehold_x + STEM_LEFT_X) / 2,
+        TOP_Y + 1.0,
+        f"t{index + 1}",
+        fontsize=7.5,
+        color=TOEHOLD_DARK,
+        ha="center",
+    )
+    axis.text(
+        toehold_x / 2,
+        BOTTOM_Y - 0.9,
         f"t{index + 1}*",
-        fontsize=5.5,
-        color=color,
+        fontsize=7.5,
+        color=TOEHOLD_DARK,
         ha="center",
         va="top",
     )
-    axis.text(node_x - 0.05, 0.67, f"b{index + 1}", fontsize=5.5, color=color, ha="right")
-    axis.text(node_x + 0.13, 0.67, f"b{index + 1}*", fontsize=5.5, color=color, ha="left")
-    axis.text(node_x, 0.77, "3′", fontsize=5.3, color=MUTED, ha="center", va="bottom")
-    axis.text(node_x + 0.08, 0.77, "5′", fontsize=5.3, color=MUTED, ha="center", va="bottom")
-    if left_is_terminal:
-        axis.text(left_x - 0.03, top_y, "5′", fontsize=5.3, color=MUTED, ha="right", va="center")
-        axis.text(left_x - 0.03, bottom_y, "3′", fontsize=5.3, color=MUTED, ha="right", va="center")
+    axis.text(
+        STEM_LEFT_X - 1.0,
+        stem_top - 0.2,
+        f"b{index + 1}",
+        fontsize=7.5,
+        color=BARCODE_DARK,
+        ha="right",
+    )
+    axis.text(
+        STEM_RIGHT_X + 1.0,
+        stem_top - 0.2,
+        f"b{index + 1}*",
+        fontsize=7.5,
+        color=BARCODE_DARK,
+        ha="left",
+    )
+    axis.text(STEM_LEFT_X, stem_top + 0.8, "3′", fontsize=7.5, color=MUTED, ha="center", va="bottom")
+    axis.text(STEM_RIGHT_X, stem_top + 0.8, "5′", fontsize=7.5, color=MUTED, ha="center", va="bottom")
+
+    if geometry.left_is_terminal:
+        axis.text(left_x - 0.8, TOP_Y, "5′", fontsize=7.5, color=MUTED, ha="right", va="center")
+        axis.text(left_x - 0.8, BOTTOM_Y, "3′", fontsize=7.5, color=MUTED, ha="right", va="center")
     else:
-        _add_break(axis, x=left_x, y=top_y, gid=f"junction:{junction.junction_id}:left-top-break")
-        _add_break(axis, x=left_x, y=bottom_y, gid=f"junction:{junction.junction_id}:left-bottom-break")
-    right_label_x = right_x + len(right_context) * horizontal_step + 0.03
-    if right_is_terminal:
-        axis.text(right_label_x, top_y, "3′", fontsize=5.3, color=MUTED, va="center")
-        axis.text(right_label_x, bottom_y, "5′", fontsize=5.3, color=MUTED, va="center")
+        add_break(axis, x=left_x, y=TOP_Y, gid=f"junction:{junction.junction_id}:left-top-break")
+        add_break(axis, x=left_x, y=BOTTOM_Y, gid=f"junction:{junction.junction_id}:left-bottom-break")
+
+    right_label_x = len(right_context) + 0.8
+    if geometry.right_is_terminal:
+        axis.text(right_label_x, TOP_Y, "3′", fontsize=7.5, color=MUTED, va="center")
+        axis.text(right_label_x, BOTTOM_Y, "5′", fontsize=7.5, color=MUTED, va="center")
     else:
-        right_boundary = right_x + len(right_context) * horizontal_step
-        _add_break(axis, x=right_boundary, y=top_y, gid=f"junction:{junction.junction_id}:right-top-break")
-        _add_break(axis, x=right_boundary, y=bottom_y, gid=f"junction:{junction.junction_id}:right-bottom-break")
-    axis.text(-0.96, -0.86, safe_identifier(junction.junction_id), fontsize=5.0, color=MUTED, va="bottom")
+        add_break(
+            axis,
+            x=float(len(right_context)),
+            y=TOP_Y,
+            gid=f"junction:{junction.junction_id}:right-top-break",
+        )
+        add_break(
+            axis,
+            x=float(len(right_context)),
+            y=BOTTOM_Y,
+            gid=f"junction:{junction.junction_id}:right-bottom-break",
+        )
 
 
 __all__ = ["draw_junction_detail", "junction_detail_base_glyph_count"]

--- a/src/dnadesign/baserender/tests/test_three_way_junction_review.py
+++ b/src/dnadesign/baserender/tests/test_three_way_junction_review.py
@@ -130,10 +130,11 @@ def test_assembly_overview_is_a_separate_target_scale_view() -> None:
         assert [axis.get_gid() for axis in figure.axes] == ["junction-three-way-assembly:overview"]
         text = "\n".join(item.get_text() for axis in figure.axes for item in axis.texts)
         assert "target-01" in text
-        assert "2 fragments · 1 junction" in text
-        assert "J1" in text
-        assert "Use view: junction_detail for exact bases" in text
-        assert "not a structure or assembly simulation" in text
+        assert "1 three-way junction links 2 fragments" in text
+        assert "junction-01" in text
+        assert "bp 11–14" in text
+        assert "opens an exact nucleotide-level view" in text
+        assert "does not establish assembly success" in text
     finally:
         plt.close(figure)
 
@@ -149,10 +150,21 @@ def test_annealed_fragment_map_draws_every_declared_domain_pair() -> None:
         )
         assert sum(len(item.get_segments()) for item in pair_collections) == paired_fragment_bases
         text = "\n".join(item.get_text() for item in figure.axes[0].texts)
-        assert "Expected fragment pairing" in text
+        assert "2 selected fragment pairs are expected to anneal" in text
         assert "F01" in text
         assert "F02" in text
-        assert "not a thermodynamic prediction or experimental result" in text
+        assert "does not establish thermodynamic or experimental success" in text
+        top_steps: set[float] = set()
+        for fragment in payload["geometry"]["fragments"]:
+            top_bases = _base_artists(
+                figure.axes[0],
+                f"junction-annealed:{fragment['fragment_id']}:top",
+            )
+            top_steps.update(
+                round(right.get_position()[0] - left.get_position()[0], 12)
+                for left, right in zip(top_bases, top_bases[1:])
+            )
+        assert len(top_steps) == 1
         complement = str.maketrans("ACGT", "TGCA")
         for fragment in payload["geometry"]["fragments"]:
             fragment_id = fragment["fragment_id"]
@@ -195,6 +207,7 @@ def test_junction_detail_draws_one_shared_three_arm_node_and_nick() -> None:
         options={"view": "junction_detail", "junction_ids": ["junction-01"]},
     )
     try:
+        assert len(figure.axes) == 1
         axis = figure.axes[0]
         gids = {artist.get_gid() for artist in (*axis.lines, *axis.collections) if artist.get_gid()}
         assert "junction:junction-01:left-and-barcode-arm" in gids
@@ -202,8 +215,8 @@ def test_junction_detail_draws_one_shared_three_arm_node_and_nick() -> None:
         assert "junction:junction-01:nick" in gids
         assert "junction:junction-01:left-top-break:0" in gids
         assert "junction:junction-01:left-bottom-break:0" in gids
-        assert "junction:junction-01:right-top-break:0" in gids
-        assert "junction:junction-01:right-bottom-break:0" in gids
+        assert "junction:junction-01:right-top-break:0" not in gids
+        assert "junction:junction-01:right-bottom-break:0" not in gids
         barcode_pairs = next(
             collection
             for collection in axis.collections
@@ -215,11 +228,11 @@ def test_junction_detail_draws_one_shared_three_arm_node_and_nick() -> None:
         assert all(segment[0][1] == segment[1][1] for segment in barcode_pairs.get_segments())
         assert all(segment[0][0] == segment[1][0] for segment in target_pairs.get_segments())
         text = "\n".join(item.get_text() for item in axis.texts)
-        assert "J01 · F01 → F02" in text
+        assert "junction-01 joins F01 to F02" in text
         assert "t1" in text and "t1*" in text
         assert "b1" in text and "b1*" in text
-        assert sum(item.get_text() == "5′" for item in axis.texts) == 1
-        assert sum(item.get_text() == "3′" for item in axis.texts) == 1
+        assert sum(item.get_text() == "5′" for item in axis.texts) == 2
+        assert sum(item.get_text() == "3′" for item in axis.texts) == 2
         left_barcode = _base_artists(axis, "junction:junction-01:barcode-b")
         right_barcode = _base_artists(axis, "junction:junction-01:barcode-b-star")
         assert "".join(item.get_text() for item in left_barcode) == junction["barcode"]
@@ -230,6 +243,11 @@ def test_junction_detail_draws_one_shared_three_arm_node_and_nick() -> None:
         assert all(
             left.get_position()[1] > right.get_position()[1] for left, right in zip(right_barcode, right_barcode[1:])
         )
+        toehold_bases = _base_artists(axis, "junction:junction-01:toehold-top")
+        horizontal_step = toehold_bases[1].get_position()[0] - toehold_bases[0].get_position()[0]
+        vertical_step = left_barcode[1].get_position()[1] - left_barcode[0].get_position()[1]
+        assert horizontal_step == pytest.approx(1.0)
+        assert vertical_step == pytest.approx(horizontal_step)
 
         complement = str.maketrans("ACGT", "TGCA")
         top_target = _base_map(

--- a/src/dnadesign/baserender/tests/three_way_junction_review/test_document_finalization.py
+++ b/src/dnadesign/baserender/tests/three_way_junction_review/test_document_finalization.py
@@ -14,9 +14,12 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import matplotlib
 import pytest
+import yaml
 
 import dnadesign.baserender as baserender
+from dnadesign.junction import build
 from dnadesign.junction.contracts import parse_request
 from dnadesign.junction.design.planner import design_junction
 from dnadesign.junction.presentation.review_contract import review_contracts
@@ -293,3 +296,26 @@ def test_adapter_accepts_real_universal_primers_across_unequal_target_lengths() 
     )
 
     assert [len(record.sequence) for record in records] == [240, 220]
+
+
+def test_checked_in_junction_figures_match_the_demo_jobs(tmp_path: Path) -> None:
+    repository_root = Path(__file__).resolve().parents[5]
+    example_root = repository_root / "src/dnadesign/junction/examples/three-fragment-review"
+    assets_root = repository_root / "src/dnadesign/junction/docs/assets"
+    request_mapping = yaml.safe_load((example_root / "request.yaml").read_text(encoding="utf-8"))
+    request = parse_request(request_mapping)
+    assert request.planning.toehold_length == 10
+    design_bundle = tmp_path / ".tmp/design-bundle"
+    build(request, destination=design_bundle)
+    plan_mapping = json.loads((design_bundle / "plan.json").read_text(encoding="utf-8"))
+    fragment_lengths = tuple(order["length"] for order in plan_mapping["orders"] if order["fragment_id"] is not None)
+    assert min(fragment_lengths) >= request.order_policy.minimum_fragment_oligo_length
+    assert max(fragment_lengths) <= request.order_policy.max_oligo_length
+    assert max(fragment_lengths) - min(fragment_lengths) <= 50
+
+    with matplotlib.rc_context(rc=matplotlib.rcParamsDefault):
+        for name in ("annealed-fragments", "assembly-overview", "junction-detail"):
+            job_mapping = yaml.safe_load((example_root / "jobs" / f"{name}.yaml").read_text(encoding="utf-8"))
+            report = baserender.run_job(job_mapping, caller_root=tmp_path)
+            [generated] = Path(report.outputs["images_dir"]).glob("*.svg")
+            assert generated.read_bytes() == (assets_root / f"{name}.svg").read_bytes()

--- a/src/dnadesign/baserender/tests/three_way_junction_review/test_module_layout.py
+++ b/src/dnadesign/baserender/tests/three_way_junction_review/test_module_layout.py
@@ -14,14 +14,22 @@ from __future__ import annotations
 import ast
 from pathlib import Path
 
-from dnadesign.baserender.src.render import junction_review_common
+from dnadesign.baserender.src.render import junction_annealed_fragments
 
-_ROOT = Path(junction_review_common.__file__).parent
+_ROOT = Path(junction_annealed_fragments.__file__).parent
 _MODULE_BUDGETS = {
-    "junction_review_common.py": 190,
-    "junction_annealed_fragments.py": 300,
-    "junction_three_way_assembly.py": 290,
-    "junction_three_way_detail.py": 260,
+    "junction_annealed_fragments.py": 100,
+    "junction_three_way_assembly.py": 230,
+    "junction_three_way_detail.py": 320,
+}
+_SUPPORT_BUDGETS = {
+    "__init__.py": 20,
+    "annealed_panel.py": 300,
+    "detail_geometry.py": 100,
+    "detail_primitives.py": 80,
+    "foundation.py": 180,
+    "overview_panel.py": 200,
+    "primitives.py": 160,
 }
 
 
@@ -29,12 +37,20 @@ def test_junction_review_modules_remain_bounded() -> None:
     for filename, line_budget in _MODULE_BUDGETS.items():
         line_count = len((_ROOT / filename).read_text(encoding="utf-8").splitlines())
         assert line_count <= line_budget, f"{filename} exceeds its {line_budget}-line architecture budget"
+    support_root = _ROOT / "junction_review"
+    for filename, line_budget in _SUPPORT_BUDGETS.items():
+        line_count = len((support_root / filename).read_text(encoding="utf-8").splitlines())
+        assert line_count <= line_budget, (
+            f"junction_review/{filename} exceeds its {line_budget}-line architecture budget"
+        )
 
 
 def test_junction_review_renderer_does_not_import_study_code() -> None:
     violations: list[str] = []
-    for filename in _MODULE_BUDGETS:
-        path = _ROOT / filename
+    paths = tuple(_ROOT / filename for filename in _MODULE_BUDGETS) + tuple(
+        _ROOT / "junction_review" / filename for filename in _SUPPORT_BUDGETS
+    )
+    for path in paths:
         tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
         for node in ast.walk(tree):
             if isinstance(node, ast.Import):

--- a/src/dnadesign/baserender/tests/three_way_junction_review/test_render_bounds.py
+++ b/src/dnadesign/baserender/tests/three_way_junction_review/test_render_bounds.py
@@ -22,7 +22,7 @@ from matplotlib.collections import LineCollection
 import dnadesign.baserender as baserender
 from dnadesign.baserender.src.outputs.names import _safe_stem
 from dnadesign.baserender.src.render import junction_three_way_assembly as assembly_renderer
-from dnadesign.baserender.src.render.junction_review_common import draw_base_run
+from dnadesign.baserender.src.render.junction_review.primitives import draw_base_run
 from dnadesign.baserender.src.render.sequence_preview import bounded_sequence_preview, bounded_svg_gid
 
 from .fixtures import (
@@ -156,7 +156,8 @@ def test_detail_preserves_every_junction_base_and_pairing_edge() -> None:
         assert _base_text(axis, f"{prefix}:barcode-b-star") == junction["barcode_complement"]
         assert _base_text(axis, f"{prefix}:toehold-top") == junction["toehold"]
         collections = [item for item in axis.collections if isinstance(item, LineCollection)]
-        expected = len(junction["barcode"]) + len(junction["toehold"]) + 12
+        context_bases = sum(len(_base_text(axis, f"{prefix}:{role}")) for role in ("left-top", "right-top"))
+        expected = len(junction["barcode"]) + len(junction["toehold"]) + context_bases
         assert sum(len(item.get_segments()) for item in collections) == expected
     finally:
         plt.close(figure)
@@ -172,7 +173,7 @@ def test_detail_rejects_excessive_base_glyphs_before_figure_allocation(
         raise AssertionError("oversized detail workload must reject before figure allocation")
 
     monkeypatch.setattr(assembly_renderer.plt, "subplots", fail_if_allocated)
-    with pytest.raises(baserender.SchemaError, match="requires 564 base glyphs; the per-junction limit is 512"):
+    with pytest.raises(baserender.SchemaError, match="requires 584 base glyphs; the per-junction limit is 512"):
         baserender.render(
             _adapt_payload(payload),
             renderer="junction_three_way_assembly",
@@ -195,7 +196,7 @@ def test_annealed_map_requires_fragment_selection_before_large_allocation() -> N
     )
     try:
         text = "\n".join(item.get_text() for item in figure.axes[0].texts)
-        assert "2 selected fragments" in text
+        assert "2 selected fragment pairs" in text
         assert "F01" in text and "F02" in text
         assert "F03" not in text
     finally:

--- a/src/dnadesign/junction/docs/README.md
+++ b/src/dnadesign/junction/docs/README.md
@@ -3,7 +3,7 @@ doc_id: junction-docs
 title: junction documentation
 owner: dnadesign-maintainers
 status: active
-last_verified: 2026-08-09
+last_verified: 2026-08-10
 ---
 
 # `junction` documentation
@@ -14,7 +14,7 @@ designed together, recovery primers, bounded search settings, and order labels.
 
 [![Base-level three-way-junction detail](assets/junction-detail.svg)](assets/junction-detail.svg)
 
-Review images are separate and opt in. The fragment-pairing map, target-scale
+Review images are separate and opt in. The fragment-annealing map, target-scale
 assembly map, and selected junction details all read the same verified review
 record. They do not predict whether the design will work in the laboratory.
 

--- a/src/dnadesign/junction/docs/assets/annealed-fragments.svg
+++ b/src/dnadesign/junction/docs/assets/annealed-fragments.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="1094.4pt" height="226.8pt" viewBox="0 0 1094.4 226.8" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="1094.4pt" height="294.48pt" viewBox="0 0 1094.4 294.48" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -20,640 +20,900 @@
  </defs>
  <g id="figure_1">
   <g id="patch_1">
-   <path d="M 0 226.8
-L 1094.4 226.8
+   <path d="M 0 294.48
+L 1094.4 294.48
 L 1094.4 0
 L 0 0
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="junction-annealed-fragments:map">
-   <g id="patch_2">
-    <path d="M 149.341824 70.011
-L 776.266338 70.011
-L 776.266338 64.044
-L 149.341824 64.044
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top-strand:body">
+    <path d="M 276.721145 78.4206
+L 950.582791 78.4206
+Q 1020.794023 78.4206 1020.794023 73.8108
+L 1020.794023 73.8108
+Q 1020.794023 69.201 950.582791 69.201
+L 276.721145 69.201
+Q 206.509913 69.201 206.509913 73.8108
+L 206.509913 73.8108
+Q 206.509913 78.4206 276.721145 78.4206
 z
-" clip-path="url(#p7877afe5bc)" style="fill: #e9edf2; opacity: 0.23"/>
+" clip-path="url(#pf6c431ed3d)" style="fill: #e8ebef; stroke: #7c8798; stroke-width: 0.7; stroke-linejoin: miter"/>
    </g>
-   <g id="patch_3">
-    <path d="M 773.048802 70.011
-L 862.892308 70.011
-L 862.892308 64.044
-L 773.048802 64.044
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:bottom-strand:body">
+    <path d="M 276.721145 96.1506
+L 684.694102 96.1506
+Q 754.905334 96.1506 754.905334 91.5408
+L 754.905334 91.5408
+Q 754.905334 86.931 684.694102 86.931
+L 276.721145 86.931
+Q 206.509913 86.931 206.509913 91.5408
+L 206.509913 91.5408
+Q 206.509913 96.1506 276.721145 96.1506
 z
-" clip-path="url(#p7877afe5bc)" style="fill: #4e79a7; opacity: 0.23"/>
+" clip-path="url(#pf6c431ed3d)" style="fill: #e8ebef; stroke: #7c8798; stroke-width: 0.7; stroke-linejoin: miter"/>
    </g>
-   <g id="patch_4">
-    <path d="M 859.674772 70.011
-L 1053.46944 70.011
-L 1053.46944 64.044
-L 859.674772 64.044
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top-strand:body">
+    <path d="M 251.79408 140.8302
+L 975.509856 140.8302
+Q 1045.721088 140.8302 1045.721088 136.2204
+L 1045.721088 136.2204
+Q 1045.721088 131.6106 975.509856 131.6106
+L 251.79408 131.6106
+Q 181.582848 131.6106 181.582848 136.2204
+L 181.582848 136.2204
+Q 181.582848 140.8302 251.79408 140.8302
 z
-" clip-path="url(#p7877afe5bc)" style="fill: #4e79a7; opacity: 0.23"/>
+" clip-path="url(#pf6c431ed3d)" style="fill: #e8ebef; stroke: #7c8798; stroke-width: 0.7; stroke-linejoin: miter"/>
    </g>
-   <g id="patch_5">
-    <path d="M 149.341824 82.647
-L 776.266338 82.647
-L 776.266338 76.68
-L 149.341824 76.68
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom-strand:body">
+    <path d="M 351.502338 158.5602
+L 709.621167 158.5602
+Q 779.832399 158.5602 779.832399 153.9504
+L 779.832399 153.9504
+Q 779.832399 149.3406 709.621167 149.3406
+L 351.502338 149.3406
+Q 281.291106 149.3406 281.291106 153.9504
+L 281.291106 153.9504
+Q 281.291106 158.5602 351.502338 158.5602
 z
-" clip-path="url(#p7877afe5bc)" style="fill: #e9edf2; opacity: 0.23"/>
+" clip-path="url(#pf6c431ed3d)" style="fill: #e8ebef; stroke: #7c8798; stroke-width: 0.7; stroke-linejoin: miter"/>
    </g>
-   <g id="patch_6">
-    <path d="M 149.341824 115.641
-L 370.361797 115.641
-L 370.361797 109.674
-L 149.341824 109.674
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top-strand:body">
+    <path d="M 326.575274 203.2398
+L 900.728662 203.2398
+Q 970.939894 203.2398 970.939894 198.63
+L 970.939894 198.63
+Q 970.939894 194.0202 900.728662 194.0202
+L 326.575274 194.0202
+Q 256.364042 194.0202 256.364042 198.63
+L 256.364042 198.63
+Q 256.364042 203.2398 326.575274 203.2398
 z
-" clip-path="url(#p7877afe5bc)" style="fill: #4e79a7; opacity: 0.23"/>
+" clip-path="url(#pf6c431ed3d)" style="fill: #e8ebef; stroke: #7c8798; stroke-width: 0.7; stroke-linejoin: miter"/>
    </g>
-   <g id="patch_7">
-    <path d="M 367.144261 115.641
-L 736.665895 115.641
-L 736.665895 109.674
-L 367.144261 109.674
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom-strand:body">
+    <path d="M 426.283532 220.9698
+L 900.728662 220.9698
+Q 970.939894 220.9698 970.939894 216.36
+L 970.939894 216.36
+Q 970.939894 211.7502 900.728662 211.7502
+L 426.283532 211.7502
+Q 356.0723 211.7502 356.0723 216.36
+L 356.0723 216.36
+Q 356.0723 220.9698 426.283532 220.9698
 z
-" clip-path="url(#p7877afe5bc)" style="fill: #e9edf2; opacity: 0.23"/>
+" clip-path="url(#pf6c431ed3d)" style="fill: #e8ebef; stroke: #7c8798; stroke-width: 0.7; stroke-linejoin: miter"/>
    </g>
-   <g id="patch_8">
-    <path d="M 733.448359 115.641
-L 835.667003 115.641
-L 835.667003 109.674
-L 733.448359 109.674
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top-strand:segment:0">
+    <path d="M 206.509913 78.4206
+L 754.905334 78.4206
+L 754.905334 69.201
+L 206.509913 69.201
 z
-" clip-path="url(#p7877afe5bc)" style="fill: #2a9d8f; opacity: 0.23"/>
+" clip-path="url(#pd8a1ada235)" style="fill: #e8ebef"/>
    </g>
-   <g id="patch_9">
-    <path d="M 832.449467 115.641
-L 1053.46944 115.641
-L 1053.46944 109.674
-L 832.449467 109.674
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top-strand:segment:1">
+    <path d="M 754.905334 78.4206
+L 837.99555 78.4206
+L 837.99555 69.201
+L 754.905334 69.201
 z
-" clip-path="url(#p7877afe5bc)" style="fill: #2a9d8f; opacity: 0.23"/>
+" clip-path="url(#p629e5de9df)" style="fill: #f3d6a1"/>
    </g>
-   <g id="patch_10">
-    <path d="M 268.143153 128.277
-L 370.361797 128.277
-L 370.361797 122.31
-L 268.143153 122.31
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top-strand:segment:2">
+    <path d="M 837.99555 78.4206
+L 1020.794023 78.4206
+L 1020.794023 69.201
+L 837.99555 69.201
 z
-" clip-path="url(#p7877afe5bc)" style="fill: #4e79a7; opacity: 0.23"/>
+" clip-path="url(#p1d5d9186c3)" style="fill: #a9d8d5"/>
    </g>
-   <g id="patch_11">
-    <path d="M 367.144261 128.277
-L 736.665895 128.277
-L 736.665895 122.31
-L 367.144261 122.31
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:bottom-strand:segment:0">
+    <path d="M 206.509913 96.1506
+L 754.905334 96.1506
+L 754.905334 86.931
+L 206.509913 86.931
 z
-" clip-path="url(#p7877afe5bc)" style="fill: #e9edf2; opacity: 0.23"/>
+" clip-path="url(#p1cada285ad)" style="fill: #e8ebef"/>
    </g>
-   <g id="patch_12">
-    <path d="M 149.341824 161.271
-L 467.16288 161.271
-L 467.16288 155.304
-L 149.341824 155.304
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top-strand:segment:0">
+    <path d="M 181.582848 140.8302
+L 364.381322 140.8302
+L 364.381322 131.6106
+L 181.582848 131.6106
 z
-" clip-path="url(#p7877afe5bc)" style="fill: #2a9d8f; opacity: 0.23"/>
+" clip-path="url(#p19ee901b5b)" style="fill: #a9d8d5"/>
    </g>
-   <g id="patch_13">
-    <path d="M 463.945344 161.271
-L 1053.46944 161.271
-L 1053.46944 155.304
-L 463.945344 155.304
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top-strand:segment:1">
+    <path d="M 364.381322 140.8302
+L 779.832399 140.8302
+L 779.832399 131.6106
+L 364.381322 131.6106
 z
-" clip-path="url(#p7877afe5bc)" style="fill: #e9edf2; opacity: 0.23"/>
+" clip-path="url(#p4a7f553509)" style="fill: #e8ebef"/>
    </g>
-   <g id="patch_14">
-    <path d="M 320.943744 173.907
-L 467.16288 173.907
-L 467.16288 167.94
-L 320.943744 167.94
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top-strand:segment:2">
+    <path d="M 779.832399 140.8302
+L 862.922614 140.8302
+L 862.922614 131.6106
+L 779.832399 131.6106
 z
-" clip-path="url(#p7877afe5bc)" style="fill: #2a9d8f; opacity: 0.23"/>
+" clip-path="url(#pbc837e291f)" style="fill: #f3d6a1"/>
    </g>
-   <g id="patch_15">
-    <path d="M 463.945344 173.907
-L 1053.46944 173.907
-L 1053.46944 167.94
-L 463.945344 167.94
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top-strand:segment:3">
+    <path d="M 862.922614 140.8302
+L 1045.721088 140.8302
+L 1045.721088 131.6106
+L 862.922614 131.6106
 z
-" clip-path="url(#p7877afe5bc)" style="fill: #e9edf2; opacity: 0.23"/>
+" clip-path="url(#p9a115cdbd8)" style="fill: #a9d8d5"/>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom-strand:segment:0">
+    <path d="M 281.291106 158.5602
+L 364.381322 158.5602
+L 364.381322 149.3406
+L 281.291106 149.3406
+z
+" clip-path="url(#pb20e9e7f38)" style="fill: #f3d6a1"/>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom-strand:segment:1">
+    <path d="M 364.381322 158.5602
+L 779.832399 158.5602
+L 779.832399 149.3406
+L 364.381322 149.3406
+z
+" clip-path="url(#p4f6db620b5)" style="fill: #e8ebef"/>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top-strand:segment:0">
+    <path d="M 256.364042 203.2398
+L 439.162516 203.2398
+L 439.162516 194.0202
+L 256.364042 194.0202
+z
+" clip-path="url(#pe2245db88e)" style="fill: #a9d8d5"/>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top-strand:segment:1">
+    <path d="M 439.162516 203.2398
+L 970.939894 203.2398
+L 970.939894 194.0202
+L 439.162516 194.0202
+z
+" clip-path="url(#p76b0274912)" style="fill: #e8ebef"/>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom-strand:segment:0">
+    <path d="M 356.0723 220.9698
+L 439.162516 220.9698
+L 439.162516 211.7502
+L 356.0723 211.7502
+z
+" clip-path="url(#p2a8ba0e3ce)" style="fill: #f3d6a1"/>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom-strand:segment:1">
+    <path d="M 439.162516 220.9698
+L 970.939894 220.9698
+L 970.939894 211.7502
+L 439.162516 211.7502
+z
+" clip-path="url(#p743fcea6e1)" style="fill: #e8ebef"/>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top-strand:outline">
+    <path d="M 276.721145 78.4206
+L 950.582791 78.4206
+Q 1020.794023 78.4206 1020.794023 73.8108
+L 1020.794023 73.8108
+Q 1020.794023 69.201 950.582791 69.201
+L 276.721145 69.201
+Q 206.509913 69.201 206.509913 73.8108
+L 206.509913 73.8108
+Q 206.509913 78.4206 276.721145 78.4206
+L 276.721145 78.4206
+z
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #7c8798; stroke-width: 0.7; stroke-linejoin: miter"/>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:bottom-strand:outline">
+    <path d="M 276.721145 96.1506
+L 684.694102 96.1506
+Q 754.905334 96.1506 754.905334 91.5408
+L 754.905334 91.5408
+Q 754.905334 86.931 684.694102 86.931
+L 276.721145 86.931
+Q 206.509913 86.931 206.509913 91.5408
+L 206.509913 91.5408
+Q 206.509913 96.1506 276.721145 96.1506
+L 276.721145 96.1506
+z
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #7c8798; stroke-width: 0.7; stroke-linejoin: miter"/>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top-strand:outline">
+    <path d="M 251.79408 140.8302
+L 975.509856 140.8302
+Q 1045.721088 140.8302 1045.721088 136.2204
+L 1045.721088 136.2204
+Q 1045.721088 131.6106 975.509856 131.6106
+L 251.79408 131.6106
+Q 181.582848 131.6106 181.582848 136.2204
+L 181.582848 136.2204
+Q 181.582848 140.8302 251.79408 140.8302
+L 251.79408 140.8302
+z
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #7c8798; stroke-width: 0.7; stroke-linejoin: miter"/>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom-strand:outline">
+    <path d="M 351.502338 158.5602
+L 709.621167 158.5602
+Q 779.832399 158.5602 779.832399 153.9504
+L 779.832399 153.9504
+Q 779.832399 149.3406 709.621167 149.3406
+L 351.502338 149.3406
+Q 281.291106 149.3406 281.291106 153.9504
+L 281.291106 153.9504
+Q 281.291106 158.5602 351.502338 158.5602
+L 351.502338 158.5602
+z
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #7c8798; stroke-width: 0.7; stroke-linejoin: miter"/>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top-strand:outline">
+    <path d="M 326.575274 203.2398
+L 900.728662 203.2398
+Q 970.939894 203.2398 970.939894 198.63
+L 970.939894 198.63
+Q 970.939894 194.0202 900.728662 194.0202
+L 326.575274 194.0202
+Q 256.364042 194.0202 256.364042 198.63
+L 256.364042 198.63
+Q 256.364042 203.2398 326.575274 203.2398
+L 326.575274 203.2398
+z
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #7c8798; stroke-width: 0.7; stroke-linejoin: miter"/>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom-strand:outline">
+    <path d="M 426.283532 220.9698
+L 900.728662 220.9698
+Q 970.939894 220.9698 970.939894 216.36
+L 970.939894 216.36
+Q 970.939894 211.7502 900.728662 211.7502
+L 426.283532 211.7502
+Q 356.0723 211.7502 356.0723 216.36
+L 356.0723 216.36
+Q 356.0723 220.9698 426.283532 220.9698
+L 426.283532 220.9698
+z
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #7c8798; stroke-width: 0.7; stroke-linejoin: miter"/>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:watson-crick">
-    <path d="M 156.890658 70.713
-L 156.890658 75.627
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 165.553255 70.713
-L 165.553255 75.627
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 174.215852 70.713
-L 174.215852 75.627
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 182.878449 70.713
-L 182.878449 75.627
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 191.541046 70.713
-L 191.541046 75.627
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 200.203643 70.713
-L 200.203643 75.627
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 208.86624 70.713
-L 208.86624 75.627
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 217.528837 70.713
-L 217.528837 75.627
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 226.191434 70.713
-L 226.191434 75.627
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 234.854031 70.713
-L 234.854031 75.627
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 243.516628 70.713
-L 243.516628 75.627
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 252.179225 70.713
-L 252.179225 75.627
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 260.841822 70.713
-L 260.841822 75.627
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 269.504418 70.713
-L 269.504418 75.627
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 278.167015 70.713
-L 278.167015 75.627
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 286.829612 70.713
-L 286.829612 75.627
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 295.492209 70.713
-L 295.492209 75.627
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 304.154806 70.713
-L 304.154806 75.627
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 312.817403 70.713
-L 312.817403 75.627
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 321.48 70.713
-L 321.48 75.627
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 330.142597 70.713
-L 330.142597 75.627
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 338.805194 70.713
-L 338.805194 75.627
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 347.467791 70.713
-L 347.467791 75.627
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 356.130388 70.713
-L 356.130388 75.627
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 364.792985 70.713
-L 364.792985 75.627
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 373.455582 70.713
-L 373.455582 75.627
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 382.118178 70.713
-L 382.118178 75.627
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 390.780775 70.713
-L 390.780775 75.627
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 399.443372 70.713
-L 399.443372 75.627
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 408.105969 70.713
-L 408.105969 75.627
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 416.768566 70.713
-L 416.768566 75.627
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 425.431163 70.713
-L 425.431163 75.627
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 434.09376 70.713
-L 434.09376 75.627
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 442.756357 70.713
-L 442.756357 75.627
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 451.418954 70.713
-L 451.418954 75.627
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 460.081551 70.713
-L 460.081551 75.627
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 468.744148 70.713
-L 468.744148 75.627
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 477.406745 70.713
-L 477.406745 75.627
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 486.069342 70.713
-L 486.069342 75.627
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 494.731938 70.713
-L 494.731938 75.627
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 503.394535 70.713
-L 503.394535 75.627
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 512.057132 70.713
-L 512.057132 75.627
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 520.719729 70.713
-L 520.719729 75.627
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 529.382326 70.713
-L 529.382326 75.627
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 538.044923 70.713
-L 538.044923 75.627
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 546.70752 70.713
-L 546.70752 75.627
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 555.370117 70.713
-L 555.370117 75.627
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 564.032714 70.713
-L 564.032714 75.627
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 572.695311 70.713
-L 572.695311 75.627
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 581.357908 70.713
-L 581.357908 75.627
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 590.020505 70.713
-L 590.020505 75.627
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 598.683102 70.713
-L 598.683102 75.627
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 607.345698 70.713
-L 607.345698 75.627
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 616.008295 70.713
-L 616.008295 75.627
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 624.670892 70.713
-L 624.670892 75.627
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 633.333489 70.713
-L 633.333489 75.627
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 641.996086 70.713
-L 641.996086 75.627
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 650.658683 70.713
-L 650.658683 75.627
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 659.32128 70.713
-L 659.32128 75.627
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 667.983877 70.713
-L 667.983877 75.627
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 676.646474 70.713
-L 676.646474 75.627
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 685.309071 70.713
-L 685.309071 75.627
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 693.971668 70.713
-L 693.971668 75.627
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 702.634265 70.713
-L 702.634265 75.627
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 711.296862 70.713
-L 711.296862 75.627
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 719.959458 70.713
-L 719.959458 75.627
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 728.622055 70.713
-L 728.622055 75.627
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 737.284652 70.713
-L 737.284652 75.627
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 745.947249 70.713
-L 745.947249 75.627
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 754.609846 70.713
-L 754.609846 75.627
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 763.272443 70.713
-L 763.272443 75.627
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 771.93504 70.713
-L 771.93504 75.627
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
+    <path d="M 210.664423 78.7752
+L 210.664423 86.5764
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 218.973445 78.7752
+L 218.973445 86.5764
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 227.282466 78.7752
+L 227.282466 86.5764
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 235.591488 78.7752
+L 235.591488 86.5764
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 243.90051 78.7752
+L 243.90051 86.5764
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 252.209531 78.7752
+L 252.209531 86.5764
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 260.518553 78.7752
+L 260.518553 86.5764
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 268.827574 78.7752
+L 268.827574 86.5764
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 277.136596 78.7752
+L 277.136596 86.5764
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 285.445617 78.7752
+L 285.445617 86.5764
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 293.754639 78.7752
+L 293.754639 86.5764
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 302.06366 78.7752
+L 302.06366 86.5764
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 310.372682 78.7752
+L 310.372682 86.5764
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 318.681703 78.7752
+L 318.681703 86.5764
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 326.990725 78.7752
+L 326.990725 86.5764
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 335.299746 78.7752
+L 335.299746 86.5764
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 343.608768 78.7752
+L 343.608768 86.5764
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 351.91779 78.7752
+L 351.91779 86.5764
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 360.226811 78.7752
+L 360.226811 86.5764
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 368.535833 78.7752
+L 368.535833 86.5764
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 376.844854 78.7752
+L 376.844854 86.5764
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 385.153876 78.7752
+L 385.153876 86.5764
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 393.462897 78.7752
+L 393.462897 86.5764
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 401.771919 78.7752
+L 401.771919 86.5764
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 410.08094 78.7752
+L 410.08094 86.5764
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 418.389962 78.7752
+L 418.389962 86.5764
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 426.698983 78.7752
+L 426.698983 86.5764
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 435.008005 78.7752
+L 435.008005 86.5764
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 443.317026 78.7752
+L 443.317026 86.5764
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 451.626048 78.7752
+L 451.626048 86.5764
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 459.93507 78.7752
+L 459.93507 86.5764
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 468.244091 78.7752
+L 468.244091 86.5764
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 476.553113 78.7752
+L 476.553113 86.5764
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 484.862134 78.7752
+L 484.862134 86.5764
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 493.171156 78.7752
+L 493.171156 86.5764
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 501.480177 78.7752
+L 501.480177 86.5764
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 509.789199 78.7752
+L 509.789199 86.5764
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 518.09822 78.7752
+L 518.09822 86.5764
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 526.407242 78.7752
+L 526.407242 86.5764
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 534.716263 78.7752
+L 534.716263 86.5764
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 543.025285 78.7752
+L 543.025285 86.5764
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 551.334306 78.7752
+L 551.334306 86.5764
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 559.643328 78.7752
+L 559.643328 86.5764
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 567.95235 78.7752
+L 567.95235 86.5764
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 576.261371 78.7752
+L 576.261371 86.5764
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 584.570393 78.7752
+L 584.570393 86.5764
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 592.879414 78.7752
+L 592.879414 86.5764
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 601.188436 78.7752
+L 601.188436 86.5764
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 609.497457 78.7752
+L 609.497457 86.5764
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 617.806479 78.7752
+L 617.806479 86.5764
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 626.1155 78.7752
+L 626.1155 86.5764
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 634.424522 78.7752
+L 634.424522 86.5764
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 642.733543 78.7752
+L 642.733543 86.5764
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 651.042565 78.7752
+L 651.042565 86.5764
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 659.351586 78.7752
+L 659.351586 86.5764
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 667.660608 78.7752
+L 667.660608 86.5764
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 675.96963 78.7752
+L 675.96963 86.5764
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 684.278651 78.7752
+L 684.278651 86.5764
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 692.587673 78.7752
+L 692.587673 86.5764
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 700.896694 78.7752
+L 700.896694 86.5764
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 709.205716 78.7752
+L 709.205716 86.5764
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 717.514737 78.7752
+L 717.514737 86.5764
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 725.823759 78.7752
+L 725.823759 86.5764
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 734.13278 78.7752
+L 734.13278 86.5764
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 742.441802 78.7752
+L 742.441802 86.5764
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 750.750823 78.7752
+L 750.750823 86.5764
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:watson-crick">
-    <path d="M 375.311852 116.343
-L 375.311852 121.257
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 385.211963 116.343
-L 385.211963 121.257
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 395.112074 116.343
-L 395.112074 121.257
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 405.012185 116.343
-L 405.012185 121.257
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 414.912295 116.343
-L 414.912295 121.257
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 424.812406 116.343
-L 424.812406 121.257
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 434.712517 116.343
-L 434.712517 121.257
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 444.612628 116.343
-L 444.612628 121.257
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 454.512738 116.343
-L 454.512738 121.257
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 464.412849 116.343
-L 464.412849 121.257
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 474.31296 116.343
-L 474.31296 121.257
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 484.213071 116.343
-L 484.213071 121.257
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 494.113182 116.343
-L 494.113182 121.257
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 504.013292 116.343
-L 504.013292 121.257
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 513.913403 116.343
-L 513.913403 121.257
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 523.813514 116.343
-L 523.813514 121.257
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 533.713625 116.343
-L 533.713625 121.257
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 543.613735 116.343
-L 543.613735 121.257
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 553.513846 116.343
-L 553.513846 121.257
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 563.413957 116.343
-L 563.413957 121.257
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 573.314068 116.343
-L 573.314068 121.257
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 583.214178 116.343
-L 583.214178 121.257
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 593.114289 116.343
-L 593.114289 121.257
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 603.0144 116.343
-L 603.0144 121.257
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 612.914511 116.343
-L 612.914511 121.257
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 622.814622 116.343
-L 622.814622 121.257
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 632.714732 116.343
-L 632.714732 121.257
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 642.614843 116.343
-L 642.614843 121.257
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 652.514954 116.343
-L 652.514954 121.257
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 662.415065 116.343
-L 662.415065 121.257
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 672.315175 116.343
-L 672.315175 121.257
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 682.215286 116.343
-L 682.215286 121.257
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 692.115397 116.343
-L 692.115397 121.257
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 702.015508 116.343
-L 702.015508 121.257
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 711.915618 116.343
-L 711.915618 121.257
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 721.815729 116.343
-L 721.815729 121.257
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 731.71584 116.343
-L 731.71584 121.257
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
+    <path d="M 368.535833 141.1848
+L 368.535833 148.986
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 376.844854 141.1848
+L 376.844854 148.986
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 385.153876 141.1848
+L 385.153876 148.986
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 393.462897 141.1848
+L 393.462897 148.986
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 401.771919 141.1848
+L 401.771919 148.986
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 410.08094 141.1848
+L 410.08094 148.986
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 418.389962 141.1848
+L 418.389962 148.986
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 426.698983 141.1848
+L 426.698983 148.986
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 435.008005 141.1848
+L 435.008005 148.986
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 443.317026 141.1848
+L 443.317026 148.986
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 451.626048 141.1848
+L 451.626048 148.986
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 459.93507 141.1848
+L 459.93507 148.986
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 468.244091 141.1848
+L 468.244091 148.986
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 476.553113 141.1848
+L 476.553113 148.986
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 484.862134 141.1848
+L 484.862134 148.986
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 493.171156 141.1848
+L 493.171156 148.986
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 501.480177 141.1848
+L 501.480177 148.986
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 509.789199 141.1848
+L 509.789199 148.986
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 518.09822 141.1848
+L 518.09822 148.986
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 526.407242 141.1848
+L 526.407242 148.986
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 534.716263 141.1848
+L 534.716263 148.986
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 543.025285 141.1848
+L 543.025285 148.986
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 551.334306 141.1848
+L 551.334306 148.986
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 559.643328 141.1848
+L 559.643328 148.986
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 567.95235 141.1848
+L 567.95235 148.986
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 576.261371 141.1848
+L 576.261371 148.986
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 584.570393 141.1848
+L 584.570393 148.986
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 592.879414 141.1848
+L 592.879414 148.986
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 601.188436 141.1848
+L 601.188436 148.986
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 609.497457 141.1848
+L 609.497457 148.986
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 617.806479 141.1848
+L 617.806479 148.986
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 626.1155 141.1848
+L 626.1155 148.986
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 634.424522 141.1848
+L 634.424522 148.986
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 642.733543 141.1848
+L 642.733543 148.986
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 651.042565 141.1848
+L 651.042565 148.986
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 659.351586 141.1848
+L 659.351586 148.986
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 667.660608 141.1848
+L 667.660608 148.986
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 675.96963 141.1848
+L 675.96963 148.986
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 684.278651 141.1848
+L 684.278651 148.986
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 692.587673 141.1848
+L 692.587673 148.986
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 700.896694 141.1848
+L 700.896694 148.986
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 709.205716 141.1848
+L 709.205716 148.986
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 717.514737 141.1848
+L 717.514737 148.986
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 725.823759 141.1848
+L 725.823759 148.986
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 734.13278 141.1848
+L 734.13278 148.986
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 742.441802 141.1848
+L 742.441802 148.986
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 750.750823 141.1848
+L 750.750823 148.986
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 759.059845 141.1848
+L 759.059845 148.986
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 767.368866 141.1848
+L 767.368866 148.986
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 775.677888 141.1848
+L 775.677888 148.986
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:watson-crick">
-    <path d="M 474.31296 161.973
-L 474.31296 166.887
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 488.61312 161.973
-L 488.61312 166.887
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 502.91328 161.973
-L 502.91328 166.887
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 517.21344 161.973
-L 517.21344 166.887
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 531.5136 161.973
-L 531.5136 166.887
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 545.81376 161.973
-L 545.81376 166.887
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 560.11392 161.973
-L 560.11392 166.887
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 574.41408 161.973
-L 574.41408 166.887
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 588.71424 161.973
-L 588.71424 166.887
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 603.0144 161.973
-L 603.0144 166.887
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 617.31456 161.973
-L 617.31456 166.887
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 631.61472 161.973
-L 631.61472 166.887
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 645.91488 161.973
-L 645.91488 166.887
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 660.21504 161.973
-L 660.21504 166.887
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 674.5152 161.973
-L 674.5152 166.887
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 688.81536 161.973
-L 688.81536 166.887
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 703.11552 161.973
-L 703.11552 166.887
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 717.41568 161.973
-L 717.41568 166.887
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 731.71584 161.973
-L 731.71584 166.887
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 746.016 161.973
-L 746.016 166.887
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 760.31616 161.973
-L 760.31616 166.887
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 774.61632 161.973
-L 774.61632 166.887
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 788.91648 161.973
-L 788.91648 166.887
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 803.21664 161.973
-L 803.21664 166.887
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 817.5168 161.973
-L 817.5168 166.887
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 831.81696 161.973
-L 831.81696 166.887
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 846.11712 161.973
-L 846.11712 166.887
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 860.41728 161.973
-L 860.41728 166.887
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 874.71744 161.973
-L 874.71744 166.887
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 889.0176 161.973
-L 889.0176 166.887
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 903.31776 161.973
-L 903.31776 166.887
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 917.61792 161.973
-L 917.61792 166.887
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 931.91808 161.973
-L 931.91808 166.887
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 946.21824 161.973
-L 946.21824 166.887
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 960.5184 161.973
-L 960.5184 166.887
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 974.81856 161.973
-L 974.81856 166.887
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 989.11872 161.973
-L 989.11872 166.887
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 1003.41888 161.973
-L 1003.41888 166.887
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 1017.71904 161.973
-L 1017.71904 166.887
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 1032.0192 161.973
-L 1032.0192 166.887
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
-    <path d="M 1046.31936 161.973
-L 1046.31936 166.887
-" clip-path="url(#p7877afe5bc)" style="fill: none; stroke: #cdd3db; stroke-width: 0.42"/>
+    <path d="M 443.317026 203.5944
+L 443.317026 211.3956
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 451.626048 203.5944
+L 451.626048 211.3956
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 459.93507 203.5944
+L 459.93507 211.3956
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 468.244091 203.5944
+L 468.244091 211.3956
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 476.553113 203.5944
+L 476.553113 211.3956
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 484.862134 203.5944
+L 484.862134 211.3956
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 493.171156 203.5944
+L 493.171156 211.3956
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 501.480177 203.5944
+L 501.480177 211.3956
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 509.789199 203.5944
+L 509.789199 211.3956
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 518.09822 203.5944
+L 518.09822 211.3956
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 526.407242 203.5944
+L 526.407242 211.3956
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 534.716263 203.5944
+L 534.716263 211.3956
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 543.025285 203.5944
+L 543.025285 211.3956
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 551.334306 203.5944
+L 551.334306 211.3956
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 559.643328 203.5944
+L 559.643328 211.3956
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 567.95235 203.5944
+L 567.95235 211.3956
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 576.261371 203.5944
+L 576.261371 211.3956
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 584.570393 203.5944
+L 584.570393 211.3956
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 592.879414 203.5944
+L 592.879414 211.3956
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 601.188436 203.5944
+L 601.188436 211.3956
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 609.497457 203.5944
+L 609.497457 211.3956
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 617.806479 203.5944
+L 617.806479 211.3956
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 626.1155 203.5944
+L 626.1155 211.3956
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 634.424522 203.5944
+L 634.424522 211.3956
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 642.733543 203.5944
+L 642.733543 211.3956
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 651.042565 203.5944
+L 651.042565 211.3956
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 659.351586 203.5944
+L 659.351586 211.3956
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 667.660608 203.5944
+L 667.660608 211.3956
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 675.96963 203.5944
+L 675.96963 211.3956
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 684.278651 203.5944
+L 684.278651 211.3956
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 692.587673 203.5944
+L 692.587673 211.3956
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 700.896694 203.5944
+L 700.896694 211.3956
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 709.205716 203.5944
+L 709.205716 211.3956
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 717.514737 203.5944
+L 717.514737 211.3956
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 725.823759 203.5944
+L 725.823759 211.3956
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 734.13278 203.5944
+L 734.13278 211.3956
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 742.441802 203.5944
+L 742.441802 211.3956
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 750.750823 203.5944
+L 750.750823 211.3956
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 759.059845 203.5944
+L 759.059845 211.3956
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 767.368866 203.5944
+L 767.368866 211.3956
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 775.677888 203.5944
+L 775.677888 211.3956
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 783.98691 203.5944
+L 783.98691 211.3956
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 792.295931 203.5944
+L 792.295931 211.3956
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 800.604953 203.5944
+L 800.604953 211.3956
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 808.913974 203.5944
+L 808.913974 211.3956
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 817.222996 203.5944
+L 817.222996 211.3956
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 825.532017 203.5944
+L 825.532017 211.3956
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 833.841039 203.5944
+L 833.841039 211.3956
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 842.15006 203.5944
+L 842.15006 211.3956
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 850.459082 203.5944
+L 850.459082 211.3956
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 858.768103 203.5944
+L 858.768103 211.3956
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 867.077125 203.5944
+L 867.077125 211.3956
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 875.386146 203.5944
+L 875.386146 211.3956
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 883.695168 203.5944
+L 883.695168 211.3956
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 892.00419 203.5944
+L 892.00419 211.3956
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 900.313211 203.5944
+L 900.313211 211.3956
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 908.622233 203.5944
+L 908.622233 211.3956
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 916.931254 203.5944
+L 916.931254 211.3956
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 925.240276 203.5944
+L 925.240276 211.3956
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 933.549297 203.5944
+L 933.549297 211.3956
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 941.858319 203.5944
+L 941.858319 211.3956
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 950.16734 203.5944
+L 950.16734 211.3956
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 958.476362 203.5944
+L 958.476362 211.3956
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
+    <path d="M 966.785383 203.5944
+L 966.785383 211.3956
+" clip-path="url(#pf6c431ed3d)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.6"/>
    </g>
    <g id="text_1">
-    <!-- Expected fragment pairing -->
-    <g style="fill: #172033" transform="translate(29.22048 20.190047) scale(0.125 -0.125)">
+    <!-- 3 selected fragment pairs are expected to anneal for synthetic-three-fragment-target -->
+    <g style="fill: #172033" transform="translate(24.957792 19.962056) scale(0.15 -0.15)">
      <defs>
-      <path id="DejaVuSans-Bold-45" d="M 588 4666
-L 3834 4666
-L 3834 3756
-L 1791 3756
-L 1791 2888
-L 3713 2888
-L 3713 1978
-L 1791 1978
-L 1791 909
-L 3903 909
-L 3903 0
-L 588 0
-L 588 4666
+      <path id="DejaVuSans-Bold-33" d="M 2981 2516
+Q 3453 2394 3698 2092
+Q 3944 1791 3944 1325
+Q 3944 631 3412 270
+Q 2881 -91 1863 -91
+Q 1503 -91 1142 -33
+Q 781 25 428 141
+L 428 1069
+Q 766 900 1098 814
+Q 1431 728 1753 728
+Q 2231 728 2486 893
+Q 2741 1059 2741 1369
+Q 2741 1688 2480 1852
+Q 2219 2016 1709 2016
+L 1228 2016
+L 1228 2791
+L 1734 2791
+Q 2188 2791 2409 2933
+Q 2631 3075 2631 3366
+Q 2631 3634 2415 3781
+Q 2200 3928 1806 3928
+Q 1516 3928 1219 3862
+Q 922 3797 628 3669
+L 628 4550
+Q 984 4650 1334 4700
+Q 1684 4750 2022 4750
+Q 2931 4750 3382 4451
+Q 3834 4153 3834 3553
+Q 3834 3144 3618 2883
+Q 3403 2622 2981 2516
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-78" d="M 1422 1791
-L 159 3500
-L 1344 3500
-L 2059 2463
-L 2784 3500
-L 3969 3500
-L 2706 1797
-L 4031 0
-L 2847 0
-L 2059 1106
-L 1281 0
-L 97 0
-L 1422 1791
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-70" d="M 1656 506
-L 1656 -1331
-L 538 -1331
-L 538 3500
-L 1656 3500
-L 1656 2988
-Q 1888 3294 2169 3439
-Q 2450 3584 2816 3584
-Q 3463 3584 3878 3070
-Q 4294 2556 4294 1747
-Q 4294 938 3878 423
-Q 3463 -91 2816 -91
-Q 2450 -91 2169 54
-Q 1888 200 1656 506
-z
-M 2400 2772
-Q 2041 2772 1848 2508
-Q 1656 2244 1656 1747
-Q 1656 1250 1848 986
-Q 2041 722 2400 722
-Q 2759 722 2948 984
-Q 3138 1247 3138 1747
-Q 3138 2247 2948 2509
-Q 2759 2772 2400 2772
+      <path id="DejaVuSans-Bold-20" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-73" d="M 3272 3391
+L 3272 2541
+Q 2913 2691 2578 2766
+Q 2244 2841 1947 2841
+Q 1628 2841 1473 2761
+Q 1319 2681 1319 2516
+Q 1319 2381 1436 2309
+Q 1553 2238 1856 2203
+L 2053 2175
+Q 2913 2066 3209 1816
+Q 3506 1566 3506 1031
+Q 3506 472 3093 190
+Q 2681 -91 1863 -91
+Q 1516 -91 1145 -36
+Q 775 19 384 128
+L 384 978
+Q 719 816 1070 734
+Q 1422 653 1784 653
+Q 2113 653 2278 743
+Q 2444 834 2444 1013
+Q 2444 1163 2330 1236
+Q 2216 1309 1875 1350
+L 1678 1375
+Q 931 1469 631 1722
+Q 331 1975 331 2491
+Q 331 3047 712 3315
+Q 1094 3584 1881 3584
+Q 2191 3584 2531 3537
+Q 2872 3491 3272 3391
 z
 " transform="scale(0.015625)"/>
       <path id="DejaVuSans-Bold-65" d="M 4031 1759
@@ -679,6 +939,13 @@ Q 2509 2841 2209 2841
 Q 1884 2841 1681 2658
 Q 1478 2475 1428 2131
 L 2881 2131
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-6c" d="M 538 4863
+L 1656 4863
+L 1656 0
+L 538 0
+L 538 4863
 z
 " transform="scale(0.015625)"/>
       <path id="DejaVuSans-Bold-63" d="M 3366 3391
@@ -749,7 +1016,6 @@ Q 1447 1247 1636 984
 Q 1825 722 2181 722
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-20" transform="scale(0.015625)"/>
       <path id="DejaVuSans-Bold-66" d="M 2841 4863
 L 2841 4128
 L 2222 4128
@@ -909,6 +1175,32 @@ Q 3428 3584 3742 3212
 Q 4056 2841 4056 2131
 z
 " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-70" d="M 1656 506
+L 1656 -1331
+L 538 -1331
+L 538 3500
+L 1656 3500
+L 1656 2988
+Q 1888 3294 2169 3439
+Q 2450 3584 2816 3584
+Q 3463 3584 3878 3070
+Q 4294 2556 4294 1747
+Q 4294 938 3878 423
+Q 3463 -91 2816 -91
+Q 2450 -91 2169 54
+Q 1888 200 1656 506
+z
+M 2400 2772
+Q 2041 2772 1848 2508
+Q 1656 2244 1656 1747
+Q 1656 1250 1848 986
+Q 2041 722 2400 722
+Q 2759 722 2948 984
+Q 3138 1247 3138 1747
+Q 3138 2247 2948 2509
+Q 2759 2772 2400 2772
+z
+" transform="scale(0.015625)"/>
       <path id="DejaVuSans-Bold-69" d="M 538 3500
 L 1656 3500
 L 1656 0
@@ -922,124 +1214,188 @@ L 538 3950
 L 538 4863
 z
 " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-78" d="M 1422 1791
+L 159 3500
+L 1344 3500
+L 2059 2463
+L 2784 3500
+L 3969 3500
+L 2706 1797
+L 4031 0
+L 2847 0
+L 2059 1106
+L 1281 0
+L 97 0
+L 1422 1791
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-6f" d="M 2203 2784
+Q 1831 2784 1636 2517
+Q 1441 2250 1441 1747
+Q 1441 1244 1636 976
+Q 1831 709 2203 709
+Q 2569 709 2762 976
+Q 2956 1244 2956 1747
+Q 2956 2250 2762 2517
+Q 2569 2784 2203 2784
+z
+M 2203 3584
+Q 3106 3584 3614 3096
+Q 4122 2609 4122 1747
+Q 4122 884 3614 396
+Q 3106 -91 2203 -91
+Q 1297 -91 786 396
+Q 275 884 275 1747
+Q 275 2609 786 3096
+Q 1297 3584 2203 3584
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-79" d="M 78 3500
+L 1197 3500
+L 2138 1125
+L 2938 3500
+L 4056 3500
+L 2584 -331
+Q 2363 -916 2067 -1148
+Q 1772 -1381 1288 -1381
+L 641 -1381
+L 641 -647
+L 991 -647
+Q 1275 -647 1404 -556
+Q 1534 -466 1606 -231
+L 1638 -134
+L 78 3500
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-68" d="M 4056 2131
+L 4056 0
+L 2931 0
+L 2931 347
+L 2931 1625
+Q 2931 2084 2911 2256
+Q 2891 2428 2841 2509
+Q 2775 2619 2662 2680
+Q 2550 2741 2406 2741
+Q 2056 2741 1856 2470
+Q 1656 2200 1656 1722
+L 1656 0
+L 538 0
+L 538 4863
+L 1656 4863
+L 1656 2988
+Q 1909 3294 2193 3439
+Q 2478 3584 2822 3584
+Q 3428 3584 3742 3212
+Q 4056 2841 4056 2131
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-2d" d="M 347 2297
+L 2309 2297
+L 2309 1388
+L 347 1388
+L 347 2297
+z
+" transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-Bold-45"/>
-     <use xlink:href="#DejaVuSans-Bold-78" transform="translate(68.310547 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-70" transform="translate(132.8125 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-65" transform="translate(204.394531 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-63" transform="translate(272.216797 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-74" transform="translate(331.494141 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-65" transform="translate(379.296875 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-64" transform="translate(447.119141 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(518.701172 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-66" transform="translate(553.515625 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-72" transform="translate(597.021484 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-61" transform="translate(646.337891 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-67" transform="translate(713.818359 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-6d" transform="translate(785.400391 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-65" transform="translate(889.599609 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(957.421875 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-74" transform="translate(1028.613281 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(1076.416016 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-70" transform="translate(1111.230469 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-61" transform="translate(1182.8125 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-69" transform="translate(1250.292969 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-72" transform="translate(1284.570312 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-69" transform="translate(1333.886719 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(1368.164062 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-67" transform="translate(1439.355469 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-33"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-73" transform="translate(104.394531 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-65" transform="translate(163.916016 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6c" transform="translate(231.738281 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-65" transform="translate(266.015625 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-63" transform="translate(333.837891 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-74" transform="translate(393.115234 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-65" transform="translate(440.917969 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-64" transform="translate(508.740234 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(580.322266 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-66" transform="translate(615.136719 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-72" transform="translate(658.642578 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-61" transform="translate(707.958984 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-67" transform="translate(775.439453 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6d" transform="translate(847.021484 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-65" transform="translate(951.220703 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(1019.042969 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-74" transform="translate(1090.234375 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(1138.037109 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-70" transform="translate(1172.851562 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-61" transform="translate(1244.433594 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-69" transform="translate(1311.914062 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-72" transform="translate(1346.191406 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-73" transform="translate(1395.507812 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(1455.029297 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-61" transform="translate(1489.84375 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-72" transform="translate(1557.324219 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-65" transform="translate(1606.640625 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(1674.462891 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-65" transform="translate(1709.277344 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-78" transform="translate(1777.099609 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-70" transform="translate(1841.601562 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-65" transform="translate(1913.183594 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-63" transform="translate(1981.005859 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-74" transform="translate(2040.283203 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-65" transform="translate(2088.085938 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-64" transform="translate(2155.908203 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(2227.490234 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-74" transform="translate(2262.304688 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6f" transform="translate(2310.107422 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(2378.808594 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-61" transform="translate(2413.623047 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(2481.103516 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(2552.294922 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-65" transform="translate(2623.486328 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-61" transform="translate(2691.308594 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6c" transform="translate(2758.789062 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(2793.066406 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-66" transform="translate(2827.880859 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6f" transform="translate(2871.386719 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-72" transform="translate(2940.087891 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(2989.404297 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-73" transform="translate(3024.21875 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-79" transform="translate(3083.740234 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(3148.925781 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-74" transform="translate(3220.117188 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-68" transform="translate(3267.919922 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-65" transform="translate(3339.111328 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-74" transform="translate(3406.933594 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-69" transform="translate(3454.736328 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-63" transform="translate(3489.013672 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-2d" transform="translate(3548.291016 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-74" transform="translate(3589.794922 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-68" transform="translate(3637.597656 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-72" transform="translate(3708.789062 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-65" transform="translate(3758.105469 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-65" transform="translate(3825.927734 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-2d" transform="translate(3893.75 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-66" transform="translate(3935.253906 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-72" transform="translate(3978.759766 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-61" transform="translate(4028.076172 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-67" transform="translate(4095.556641 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6d" transform="translate(4167.138672 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-65" transform="translate(4271.337891 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(4339.160156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-74" transform="translate(4410.351562 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-2d" transform="translate(4458.154297 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-74" transform="translate(4499.658203 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-61" transform="translate(4547.460938 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-72" transform="translate(4614.941406 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-67" transform="translate(4664.257812 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-65" transform="translate(4735.839844 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-74" transform="translate(4803.662109 0)"/>
     </g>
    </g>
    <g id="text_2">
-    <!-- synthetic-three-fragment-target · 170 bp target · 3 selected fragments -->
-    <g style="fill: #667085" transform="translate(29.22048 36.842953) scale(0.067 -0.067)">
+    <!-- The 200 bp target contributes 6 fragment oligos spanning 60–104 nt with median 80 nt -->
+    <g style="fill: #667085" transform="translate(24.957792 38.806594) scale(0.09 -0.09)">
      <defs>
-      <path id="DejaVuSans-73" d="M 2834 3397
-L 2834 2853
-Q 2591 2978 2328 3040
-Q 2066 3103 1784 3103
-Q 1356 3103 1142 2972
-Q 928 2841 928 2578
-Q 928 2378 1081 2264
-Q 1234 2150 1697 2047
-L 1894 2003
-Q 2506 1872 2764 1633
-Q 3022 1394 3022 966
-Q 3022 478 2636 193
-Q 2250 -91 1575 -91
-Q 1294 -91 989 -36
-Q 684 19 347 128
-L 347 722
-Q 666 556 975 473
-Q 1284 391 1588 391
-Q 1994 391 2212 530
-Q 2431 669 2431 922
-Q 2431 1156 2273 1281
-Q 2116 1406 1581 1522
-L 1381 1569
-Q 847 1681 609 1914
-Q 372 2147 372 2553
-Q 372 3047 722 3315
-Q 1072 3584 1716 3584
-Q 2034 3584 2315 3537
-Q 2597 3491 2834 3397
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-79" d="M 2059 -325
-Q 1816 -950 1584 -1140
-Q 1353 -1331 966 -1331
-L 506 -1331
-L 506 -850
-L 844 -850
-Q 1081 -850 1212 -737
-Q 1344 -625 1503 -206
-L 1606 56
-L 191 3500
-L 800 3500
-L 1894 763
-L 2988 3500
-L 3597 3500
-L 2059 -325
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-6e" d="M 3513 2113
-L 3513 0
-L 2938 0
-L 2938 2094
-Q 2938 2591 2744 2837
-Q 2550 3084 2163 3084
-Q 1697 3084 1428 2787
-Q 1159 2491 1159 1978
-L 1159 0
-L 581 0
-L 581 3500
-L 1159 3500
-L 1159 2956
-Q 1366 3272 1645 3428
-Q 1925 3584 2291 3584
-Q 2894 3584 3203 3211
-Q 3513 2838 3513 2113
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-74" d="M 1172 4494
-L 1172 3500
-L 2356 3500
-L 2356 3053
-L 1172 3053
-L 1172 1153
-Q 1172 725 1289 603
-Q 1406 481 1766 481
-L 2356 481
-L 2356 0
-L 1766 0
-Q 1100 0 847 248
-Q 594 497 594 1153
-L 594 3053
-L 172 3053
-L 172 3500
-L 594 3500
-L 594 4494
-L 1172 4494
+      <path id="DejaVuSans-54" d="M -19 4666
+L 3928 4666
+L 3928 4134
+L 2272 4134
+L 2272 0
+L 1638 0
+L 1638 4134
+L -19 4134
+L -19 4666
 z
 " transform="scale(0.015625)"/>
       <path id="DejaVuSans-68" d="M 3513 2113
@@ -1086,212 +1442,29 @@ Q 1016 2553 972 2059
 L 3022 2063
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-69" d="M 603 3500
-L 1178 3500
-L 1178 0
-L 603 0
-L 603 3500
-z
-M 603 4863
-L 1178 4863
-L 1178 4134
-L 603 4134
-L 603 4863
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-63" d="M 3122 3366
-L 3122 2828
-Q 2878 2963 2633 3030
-Q 2388 3097 2138 3097
-Q 1578 3097 1268 2742
-Q 959 2388 959 1747
-Q 959 1106 1268 751
-Q 1578 397 2138 397
-Q 2388 397 2633 464
-Q 2878 531 3122 666
-L 3122 134
-Q 2881 22 2623 -34
-Q 2366 -91 2075 -91
-Q 1284 -91 818 406
-Q 353 903 353 1747
-Q 353 2603 823 3093
-Q 1294 3584 2113 3584
-Q 2378 3584 2631 3529
-Q 2884 3475 3122 3366
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-2d" d="M 313 2009
-L 1997 2009
-L 1997 1497
-L 313 1497
-L 313 2009
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-72" d="M 2631 2963
-Q 2534 3019 2420 3045
-Q 2306 3072 2169 3072
-Q 1681 3072 1420 2755
-Q 1159 2438 1159 1844
-L 1159 0
-L 581 0
-L 581 3500
-L 1159 3500
-L 1159 2956
-Q 1341 3275 1631 3429
-Q 1922 3584 2338 3584
-Q 2397 3584 2469 3576
-Q 2541 3569 2628 3553
-L 2631 2963
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-66" d="M 2375 4863
-L 2375 4384
-L 1825 4384
-Q 1516 4384 1395 4259
-Q 1275 4134 1275 3809
-L 1275 3500
-L 2222 3500
-L 2222 3053
-L 1275 3053
-L 1275 0
-L 697 0
-L 697 3053
-L 147 3053
-L 147 3500
-L 697 3500
-L 697 3744
-Q 697 4328 969 4595
-Q 1241 4863 1831 4863
-L 2375 4863
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-61" d="M 2194 1759
-Q 1497 1759 1228 1600
-Q 959 1441 959 1056
-Q 959 750 1161 570
-Q 1363 391 1709 391
-Q 2188 391 2477 730
-Q 2766 1069 2766 1631
-L 2766 1759
-L 2194 1759
-z
-M 3341 1997
-L 3341 0
-L 2766 0
-L 2766 531
-Q 2569 213 2275 61
-Q 1981 -91 1556 -91
-Q 1019 -91 701 211
-Q 384 513 384 1019
-Q 384 1609 779 1909
-Q 1175 2209 1959 2209
-L 2766 2209
-L 2766 2266
-Q 2766 2663 2505 2880
-Q 2244 3097 1772 3097
-Q 1472 3097 1187 3025
-Q 903 2953 641 2809
-L 641 3341
-Q 956 3463 1253 3523
-Q 1550 3584 1831 3584
-Q 2591 3584 2966 3190
-Q 3341 2797 3341 1997
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-67" d="M 2906 1791
-Q 2906 2416 2648 2759
-Q 2391 3103 1925 3103
-Q 1463 3103 1205 2759
-Q 947 2416 947 1791
-Q 947 1169 1205 825
-Q 1463 481 1925 481
-Q 2391 481 2648 825
-Q 2906 1169 2906 1791
-z
-M 3481 434
-Q 3481 -459 3084 -895
-Q 2688 -1331 1869 -1331
-Q 1566 -1331 1297 -1286
-Q 1028 -1241 775 -1147
-L 775 -588
-Q 1028 -725 1275 -790
-Q 1522 -856 1778 -856
-Q 2344 -856 2625 -561
-Q 2906 -266 2906 331
-L 2906 616
-Q 2728 306 2450 153
-Q 2172 0 1784 0
-Q 1141 0 747 490
-Q 353 981 353 1791
-Q 353 2603 747 3093
-Q 1141 3584 1784 3584
-Q 2172 3584 2450 3431
-Q 2728 3278 2906 2969
-L 2906 3500
-L 3481 3500
-L 3481 434
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-6d" d="M 3328 2828
-Q 3544 3216 3844 3400
-Q 4144 3584 4550 3584
-Q 5097 3584 5394 3201
-Q 5691 2819 5691 2113
-L 5691 0
-L 5113 0
-L 5113 2094
-Q 5113 2597 4934 2840
-Q 4756 3084 4391 3084
-Q 3944 3084 3684 2787
-Q 3425 2491 3425 1978
-L 3425 0
-L 2847 0
-L 2847 2094
-Q 2847 2600 2669 2842
-Q 2491 3084 2119 3084
-Q 1678 3084 1418 2786
-Q 1159 2488 1159 1978
-L 1159 0
-L 581 0
-L 581 3500
-L 1159 3500
-L 1159 2956
-Q 1356 3278 1631 3431
-Q 1906 3584 2284 3584
-Q 2666 3584 2933 3390
-Q 3200 3197 3328 2828
-z
-" transform="scale(0.015625)"/>
       <path id="DejaVuSans-20" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-b7" d="M 684 2619
-L 1344 2619
-L 1344 1825
-L 684 1825
-L 684 2619
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-31" d="M 794 531
-L 1825 531
-L 1825 4091
-L 703 3866
-L 703 4441
-L 1819 4666
-L 2450 4666
-L 2450 531
-L 3481 531
-L 3481 0
-L 794 0
-L 794 531
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-37" d="M 525 4666
-L 3525 4666
-L 3525 4397
-L 1831 0
-L 1172 0
-L 2766 4134
-L 525 4134
-L 525 4666
+      <path id="DejaVuSans-32" d="M 1228 531
+L 3431 531
+L 3431 0
+L 469 0
+L 469 531
+Q 828 903 1448 1529
+Q 2069 2156 2228 2338
+Q 2531 2678 2651 2914
+Q 2772 3150 2772 3378
+Q 2772 3750 2511 3984
+Q 2250 4219 1831 4219
+Q 1534 4219 1204 4116
+Q 875 4013 500 3803
+L 500 4441
+Q 881 4594 1212 4672
+Q 1544 4750 1819 4750
+Q 2544 4750 2975 4387
+Q 3406 4025 3406 3419
+Q 3406 3131 3298 2873
+Q 3191 2616 2906 2266
+Q 2828 2175 2409 1742
+Q 1991 1309 1228 531
 z
 " transform="scale(0.015625)"/>
       <path id="DejaVuSans-30" d="M 2034 4250
@@ -1367,36 +1540,317 @@ Q 2594 391 2855 752
 Q 3116 1113 3116 1747
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-33" d="M 2597 2516
-Q 3050 2419 3304 2112
-Q 3559 1806 3559 1356
-Q 3559 666 3084 287
-Q 2609 -91 1734 -91
-Q 1441 -91 1130 -33
-Q 819 25 488 141
-L 488 750
-Q 750 597 1062 519
-Q 1375 441 1716 441
-Q 2309 441 2620 675
-Q 2931 909 2931 1356
-Q 2931 1769 2642 2001
-Q 2353 2234 1838 2234
-L 1294 2234
-L 1294 2753
-L 1863 2753
-Q 2328 2753 2575 2939
-Q 2822 3125 2822 3475
-Q 2822 3834 2567 4026
-Q 2313 4219 1838 4219
-Q 1578 4219 1281 4162
-Q 984 4106 628 3988
-L 628 4550
-Q 988 4650 1302 4700
-Q 1616 4750 1894 4750
-Q 2613 4750 3031 4423
-Q 3450 4097 3450 3541
-Q 3450 3153 3228 2886
-Q 3006 2619 2597 2516
+      <path id="DejaVuSans-74" d="M 1172 4494
+L 1172 3500
+L 2356 3500
+L 2356 3053
+L 1172 3053
+L 1172 1153
+Q 1172 725 1289 603
+Q 1406 481 1766 481
+L 2356 481
+L 2356 0
+L 1766 0
+Q 1100 0 847 248
+Q 594 497 594 1153
+L 594 3053
+L 172 3053
+L 172 3500
+L 594 3500
+L 594 4494
+L 1172 4494
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-61" d="M 2194 1759
+Q 1497 1759 1228 1600
+Q 959 1441 959 1056
+Q 959 750 1161 570
+Q 1363 391 1709 391
+Q 2188 391 2477 730
+Q 2766 1069 2766 1631
+L 2766 1759
+L 2194 1759
+z
+M 3341 1997
+L 3341 0
+L 2766 0
+L 2766 531
+Q 2569 213 2275 61
+Q 1981 -91 1556 -91
+Q 1019 -91 701 211
+Q 384 513 384 1019
+Q 384 1609 779 1909
+Q 1175 2209 1959 2209
+L 2766 2209
+L 2766 2266
+Q 2766 2663 2505 2880
+Q 2244 3097 1772 3097
+Q 1472 3097 1187 3025
+Q 903 2953 641 2809
+L 641 3341
+Q 956 3463 1253 3523
+Q 1550 3584 1831 3584
+Q 2591 3584 2966 3190
+Q 3341 2797 3341 1997
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-72" d="M 2631 2963
+Q 2534 3019 2420 3045
+Q 2306 3072 2169 3072
+Q 1681 3072 1420 2755
+Q 1159 2438 1159 1844
+L 1159 0
+L 581 0
+L 581 3500
+L 1159 3500
+L 1159 2956
+Q 1341 3275 1631 3429
+Q 1922 3584 2338 3584
+Q 2397 3584 2469 3576
+Q 2541 3569 2628 3553
+L 2631 2963
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-67" d="M 2906 1791
+Q 2906 2416 2648 2759
+Q 2391 3103 1925 3103
+Q 1463 3103 1205 2759
+Q 947 2416 947 1791
+Q 947 1169 1205 825
+Q 1463 481 1925 481
+Q 2391 481 2648 825
+Q 2906 1169 2906 1791
+z
+M 3481 434
+Q 3481 -459 3084 -895
+Q 2688 -1331 1869 -1331
+Q 1566 -1331 1297 -1286
+Q 1028 -1241 775 -1147
+L 775 -588
+Q 1028 -725 1275 -790
+Q 1522 -856 1778 -856
+Q 2344 -856 2625 -561
+Q 2906 -266 2906 331
+L 2906 616
+Q 2728 306 2450 153
+Q 2172 0 1784 0
+Q 1141 0 747 490
+Q 353 981 353 1791
+Q 353 2603 747 3093
+Q 1141 3584 1784 3584
+Q 2172 3584 2450 3431
+Q 2728 3278 2906 2969
+L 2906 3500
+L 3481 3500
+L 3481 434
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-63" d="M 3122 3366
+L 3122 2828
+Q 2878 2963 2633 3030
+Q 2388 3097 2138 3097
+Q 1578 3097 1268 2742
+Q 959 2388 959 1747
+Q 959 1106 1268 751
+Q 1578 397 2138 397
+Q 2388 397 2633 464
+Q 2878 531 3122 666
+L 3122 134
+Q 2881 22 2623 -34
+Q 2366 -91 2075 -91
+Q 1284 -91 818 406
+Q 353 903 353 1747
+Q 353 2603 823 3093
+Q 1294 3584 2113 3584
+Q 2378 3584 2631 3529
+Q 2884 3475 3122 3366
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-6f" d="M 1959 3097
+Q 1497 3097 1228 2736
+Q 959 2375 959 1747
+Q 959 1119 1226 758
+Q 1494 397 1959 397
+Q 2419 397 2687 759
+Q 2956 1122 2956 1747
+Q 2956 2369 2687 2733
+Q 2419 3097 1959 3097
+z
+M 1959 3584
+Q 2709 3584 3137 3096
+Q 3566 2609 3566 1747
+Q 3566 888 3137 398
+Q 2709 -91 1959 -91
+Q 1206 -91 779 398
+Q 353 888 353 1747
+Q 353 2609 779 3096
+Q 1206 3584 1959 3584
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-6e" d="M 3513 2113
+L 3513 0
+L 2938 0
+L 2938 2094
+Q 2938 2591 2744 2837
+Q 2550 3084 2163 3084
+Q 1697 3084 1428 2787
+Q 1159 2491 1159 1978
+L 1159 0
+L 581 0
+L 581 3500
+L 1159 3500
+L 1159 2956
+Q 1366 3272 1645 3428
+Q 1925 3584 2291 3584
+Q 2894 3584 3203 3211
+Q 3513 2838 3513 2113
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-69" d="M 603 3500
+L 1178 3500
+L 1178 0
+L 603 0
+L 603 3500
+z
+M 603 4863
+L 1178 4863
+L 1178 4134
+L 603 4134
+L 603 4863
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-75" d="M 544 1381
+L 544 3500
+L 1119 3500
+L 1119 1403
+Q 1119 906 1312 657
+Q 1506 409 1894 409
+Q 2359 409 2629 706
+Q 2900 1003 2900 1516
+L 2900 3500
+L 3475 3500
+L 3475 0
+L 2900 0
+L 2900 538
+Q 2691 219 2414 64
+Q 2138 -91 1772 -91
+Q 1169 -91 856 284
+Q 544 659 544 1381
+z
+M 1991 3584
+L 1991 3584
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-73" d="M 2834 3397
+L 2834 2853
+Q 2591 2978 2328 3040
+Q 2066 3103 1784 3103
+Q 1356 3103 1142 2972
+Q 928 2841 928 2578
+Q 928 2378 1081 2264
+Q 1234 2150 1697 2047
+L 1894 2003
+Q 2506 1872 2764 1633
+Q 3022 1394 3022 966
+Q 3022 478 2636 193
+Q 2250 -91 1575 -91
+Q 1294 -91 989 -36
+Q 684 19 347 128
+L 347 722
+Q 666 556 975 473
+Q 1284 391 1588 391
+Q 1994 391 2212 530
+Q 2431 669 2431 922
+Q 2431 1156 2273 1281
+Q 2116 1406 1581 1522
+L 1381 1569
+Q 847 1681 609 1914
+Q 372 2147 372 2553
+Q 372 3047 722 3315
+Q 1072 3584 1716 3584
+Q 2034 3584 2315 3537
+Q 2597 3491 2834 3397
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-36" d="M 2113 2584
+Q 1688 2584 1439 2293
+Q 1191 2003 1191 1497
+Q 1191 994 1439 701
+Q 1688 409 2113 409
+Q 2538 409 2786 701
+Q 3034 994 3034 1497
+Q 3034 2003 2786 2293
+Q 2538 2584 2113 2584
+z
+M 3366 4563
+L 3366 3988
+Q 3128 4100 2886 4159
+Q 2644 4219 2406 4219
+Q 1781 4219 1451 3797
+Q 1122 3375 1075 2522
+Q 1259 2794 1537 2939
+Q 1816 3084 2150 3084
+Q 2853 3084 3261 2657
+Q 3669 2231 3669 1497
+Q 3669 778 3244 343
+Q 2819 -91 2113 -91
+Q 1303 -91 875 529
+Q 447 1150 447 2328
+Q 447 3434 972 4092
+Q 1497 4750 2381 4750
+Q 2619 4750 2861 4703
+Q 3103 4656 3366 4563
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-66" d="M 2375 4863
+L 2375 4384
+L 1825 4384
+Q 1516 4384 1395 4259
+Q 1275 4134 1275 3809
+L 1275 3500
+L 2222 3500
+L 2222 3053
+L 1275 3053
+L 1275 0
+L 697 0
+L 697 3053
+L 147 3053
+L 147 3500
+L 697 3500
+L 697 3744
+Q 697 4328 969 4595
+Q 1241 4863 1831 4863
+L 2375 4863
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-6d" d="M 3328 2828
+Q 3544 3216 3844 3400
+Q 4144 3584 4550 3584
+Q 5097 3584 5394 3201
+Q 5691 2819 5691 2113
+L 5691 0
+L 5113 0
+L 5113 2094
+Q 5113 2597 4934 2840
+Q 4756 3084 4391 3084
+Q 3944 3084 3684 2787
+Q 3425 2491 3425 1978
+L 3425 0
+L 2847 0
+L 2847 2094
+Q 2847 2600 2669 2842
+Q 2491 3084 2119 3084
+Q 1678 3084 1418 2786
+Q 1159 2488 1159 1978
+L 1159 0
+L 581 0
+L 581 3500
+L 1159 3500
+L 1159 2956
+Q 1356 3278 1631 3431
+Q 1906 3584 2284 3584
+Q 2666 3584 2933 3390
+Q 3200 3197 3328 2828
 z
 " transform="scale(0.015625)"/>
       <path id="DejaVuSans-6c" d="M 603 4863
@@ -1404,6 +1858,62 @@ L 1178 4863
 L 1178 0
 L 603 0
 L 603 4863
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-2013" d="M 313 1978
+L 2888 1978
+L 2888 1528
+L 313 1528
+L 313 1978
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-31" d="M 794 531
+L 1825 531
+L 1825 4091
+L 703 3866
+L 703 4441
+L 1819 4666
+L 2450 4666
+L 2450 531
+L 3481 531
+L 3481 0
+L 794 0
+L 794 531
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-34" d="M 2419 4116
+L 825 1625
+L 2419 1625
+L 2419 4116
+z
+M 2253 4666
+L 3047 4666
+L 3047 1625
+L 3713 1625
+L 3713 1100
+L 3047 1100
+L 3047 0
+L 2419 0
+L 2419 1100
+L 313 1100
+L 313 1709
+L 2253 4666
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-77" d="M 269 3500
+L 844 3500
+L 1563 769
+L 2278 3500
+L 2956 3500
+L 3675 769
+L 4391 3500
+L 4966 3500
+L 4050 0
+L 3372 0
+L 2619 2869
+L 1863 0
+L 1184 0
+L 269 3500
 z
 " transform="scale(0.015625)"/>
       <path id="DejaVuSans-64" d="M 2906 2969
@@ -1432,283 +1942,135 @@ Q 1469 3103 1208 2742
 Q 947 2381 947 1747
 z
 " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-38" d="M 2034 2216
+Q 1584 2216 1326 1975
+Q 1069 1734 1069 1313
+Q 1069 891 1326 650
+Q 1584 409 2034 409
+Q 2484 409 2743 651
+Q 3003 894 3003 1313
+Q 3003 1734 2745 1975
+Q 2488 2216 2034 2216
+z
+M 1403 2484
+Q 997 2584 770 2862
+Q 544 3141 544 3541
+Q 544 4100 942 4425
+Q 1341 4750 2034 4750
+Q 2731 4750 3128 4425
+Q 3525 4100 3525 3541
+Q 3525 3141 3298 2862
+Q 3072 2584 2669 2484
+Q 3125 2378 3379 2068
+Q 3634 1759 3634 1313
+Q 3634 634 3220 271
+Q 2806 -91 2034 -91
+Q 1263 -91 848 271
+Q 434 634 434 1313
+Q 434 1759 690 2068
+Q 947 2378 1403 2484
+z
+M 1172 3481
+Q 1172 3119 1398 2916
+Q 1625 2713 2034 2713
+Q 2441 2713 2670 2916
+Q 2900 3119 2900 3481
+Q 2900 3844 2670 4047
+Q 2441 4250 2034 4250
+Q 1625 4250 1398 4047
+Q 1172 3844 1172 3481
+z
+" transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-73"/>
-     <use xlink:href="#DejaVuSans-79" transform="translate(52.099609 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(111.279297 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(174.658203 0)"/>
-     <use xlink:href="#DejaVuSans-68" transform="translate(213.867188 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(277.246094 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(338.769531 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(377.978516 0)"/>
-     <use xlink:href="#DejaVuSans-63" transform="translate(405.761719 0)"/>
-     <use xlink:href="#DejaVuSans-2d" transform="translate(460.742188 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(496.826172 0)"/>
-     <use xlink:href="#DejaVuSans-68" transform="translate(536.035156 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(599.414062 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(638.277344 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(699.800781 0)"/>
-     <use xlink:href="#DejaVuSans-2d" transform="translate(761.324219 0)"/>
-     <use xlink:href="#DejaVuSans-66" transform="translate(797.408203 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(832.613281 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(873.726562 0)"/>
-     <use xlink:href="#DejaVuSans-67" transform="translate(935.005859 0)"/>
-     <use xlink:href="#DejaVuSans-6d" transform="translate(998.482422 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(1095.894531 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(1157.417969 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(1220.796875 0)"/>
-     <use xlink:href="#DejaVuSans-2d" transform="translate(1260.005859 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(1296.089844 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(1335.298828 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(1396.578125 0)"/>
-     <use xlink:href="#DejaVuSans-67" transform="translate(1435.941406 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(1499.417969 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(1560.941406 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(1600.150391 0)"/>
-     <use xlink:href="#DejaVuSans-b7" transform="translate(1631.9375 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(1663.724609 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(1695.511719 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(1759.134766 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(1822.757812 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(1886.380859 0)"/>
-     <use xlink:href="#DejaVuSans-62" transform="translate(1918.167969 0)"/>
-     <use xlink:href="#DejaVuSans-70" transform="translate(1981.644531 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(2045.121094 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(2076.908203 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(2116.117188 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(2177.396484 0)"/>
-     <use xlink:href="#DejaVuSans-67" transform="translate(2216.759766 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(2280.236328 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(2341.759766 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(2380.96875 0)"/>
-     <use xlink:href="#DejaVuSans-b7" transform="translate(2412.755859 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(2444.542969 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(2476.330078 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(2539.953125 0)"/>
-     <use xlink:href="#DejaVuSans-73" transform="translate(2571.740234 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(2623.839844 0)"/>
-     <use xlink:href="#DejaVuSans-6c" transform="translate(2685.363281 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(2713.146484 0)"/>
-     <use xlink:href="#DejaVuSans-63" transform="translate(2774.669922 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(2829.650391 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(2868.859375 0)"/>
-     <use xlink:href="#DejaVuSans-64" transform="translate(2930.382812 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(2993.859375 0)"/>
-     <use xlink:href="#DejaVuSans-66" transform="translate(3025.646484 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(3060.851562 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(3101.964844 0)"/>
-     <use xlink:href="#DejaVuSans-67" transform="translate(3163.244141 0)"/>
-     <use xlink:href="#DejaVuSans-6d" transform="translate(3226.720703 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(3324.132812 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(3385.65625 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(3449.035156 0)"/>
-     <use xlink:href="#DejaVuSans-73" transform="translate(3488.244141 0)"/>
+     <use xlink:href="#DejaVuSans-54"/>
+     <use xlink:href="#DejaVuSans-68" transform="translate(61.083984 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(124.462891 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(185.986328 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(217.773438 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(281.396484 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(345.019531 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(408.642578 0)"/>
+     <use xlink:href="#DejaVuSans-62" transform="translate(440.429688 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(503.90625 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(567.382812 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(599.169922 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(638.378906 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(699.658203 0)"/>
+     <use xlink:href="#DejaVuSans-67" transform="translate(739.021484 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(802.498047 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(864.021484 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(903.230469 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(935.017578 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(989.998047 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(1051.179688 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(1114.558594 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(1153.767578 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(1194.880859 0)"/>
+     <use xlink:href="#DejaVuSans-62" transform="translate(1222.664062 0)"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(1286.140625 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(1349.519531 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(1388.728516 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(1450.251953 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1502.351562 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(1534.138672 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1597.761719 0)"/>
+     <use xlink:href="#DejaVuSans-66" transform="translate(1629.548828 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(1664.753906 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(1705.867188 0)"/>
+     <use xlink:href="#DejaVuSans-67" transform="translate(1767.146484 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(1830.623047 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(1928.035156 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(1989.558594 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(2052.9375 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2092.146484 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(2123.933594 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(2185.115234 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(2212.898438 0)"/>
+     <use xlink:href="#DejaVuSans-67" transform="translate(2240.681641 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(2304.158203 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(2365.339844 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2417.439453 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(2449.226562 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(2501.326172 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(2564.802734 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(2626.082031 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(2689.460938 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(2752.839844 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(2780.623047 0)"/>
+     <use xlink:href="#DejaVuSans-67" transform="translate(2844.001953 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2907.478516 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(2939.265625 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(3002.888672 0)"/>
+     <use xlink:href="#DejaVuSans-2013" transform="translate(3066.511719 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(3116.511719 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(3180.134766 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(3243.757812 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3307.380859 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(3339.167969 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(3402.546875 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3441.755859 0)"/>
+     <use xlink:href="#DejaVuSans-77" transform="translate(3473.542969 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(3555.330078 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(3583.113281 0)"/>
+     <use xlink:href="#DejaVuSans-68" transform="translate(3622.322266 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3685.701172 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(3717.488281 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(3814.900391 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(3876.423828 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(3939.900391 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(3967.683594 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(4028.962891 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(4092.341797 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(4124.128906 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(4187.751953 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(4251.375 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(4283.162109 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(4346.541016 0)"/>
     </g>
    </g>
    <g id="text_3">
-    <!-- Bases and Watson–Crick edges come from the verified design record. -->
-    <g style="fill: #667085" transform="translate(861.022432 15.251063) scale(0.06 -0.06)">
-     <defs>
-      <path id="DejaVuSans-42" d="M 1259 2228
-L 1259 519
-L 2272 519
-Q 2781 519 3026 730
-Q 3272 941 3272 1375
-Q 3272 1813 3026 2020
-Q 2781 2228 2272 2228
-L 1259 2228
-z
-M 1259 4147
-L 1259 2741
-L 2194 2741
-Q 2656 2741 2882 2914
-Q 3109 3088 3109 3444
-Q 3109 3797 2882 3972
-Q 2656 4147 2194 4147
-L 1259 4147
-z
-M 628 4666
-L 2241 4666
-Q 2963 4666 3353 4366
-Q 3744 4066 3744 3513
-Q 3744 3084 3544 2831
-Q 3344 2578 2956 2516
-Q 3422 2416 3680 2098
-Q 3938 1781 3938 1306
-Q 3938 681 3513 340
-Q 3088 0 2303 0
-L 628 0
-L 628 4666
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-57" d="M 213 4666
-L 850 4666
-L 1831 722
-L 2809 4666
-L 3519 4666
-L 4500 722
-L 5478 4666
-L 6119 4666
-L 4947 0
-L 4153 0
-L 3169 4050
-L 2175 0
-L 1381 0
-L 213 4666
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-6f" d="M 1959 3097
-Q 1497 3097 1228 2736
-Q 959 2375 959 1747
-Q 959 1119 1226 758
-Q 1494 397 1959 397
-Q 2419 397 2687 759
-Q 2956 1122 2956 1747
-Q 2956 2369 2687 2733
-Q 2419 3097 1959 3097
-z
-M 1959 3584
-Q 2709 3584 3137 3096
-Q 3566 2609 3566 1747
-Q 3566 888 3137 398
-Q 2709 -91 1959 -91
-Q 1206 -91 779 398
-Q 353 888 353 1747
-Q 353 2609 779 3096
-Q 1206 3584 1959 3584
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-2013" d="M 313 1978
-L 2888 1978
-L 2888 1528
-L 313 1528
-L 313 1978
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-43" d="M 4122 4306
-L 4122 3641
-Q 3803 3938 3442 4084
-Q 3081 4231 2675 4231
-Q 1875 4231 1450 3742
-Q 1025 3253 1025 2328
-Q 1025 1406 1450 917
-Q 1875 428 2675 428
-Q 3081 428 3442 575
-Q 3803 722 4122 1019
-L 4122 359
-Q 3791 134 3420 21
-Q 3050 -91 2638 -91
-Q 1578 -91 968 557
-Q 359 1206 359 2328
-Q 359 3453 968 4101
-Q 1578 4750 2638 4750
-Q 3056 4750 3426 4639
-Q 3797 4528 4122 4306
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-6b" d="M 581 4863
-L 1159 4863
-L 1159 1991
-L 2875 3500
-L 3609 3500
-L 1753 1863
-L 3688 0
-L 2938 0
-L 1159 1709
-L 1159 0
-L 581 0
-L 581 4863
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-76" d="M 191 3500
-L 800 3500
-L 1894 563
-L 2988 3500
-L 3597 3500
-L 2284 0
-L 1503 0
-L 191 3500
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-2e" d="M 684 794
-L 1344 794
-L 1344 0
-L 684 0
-L 684 794
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-42"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(68.603516 0)"/>
-     <use xlink:href="#DejaVuSans-73" transform="translate(129.882812 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(181.982422 0)"/>
-     <use xlink:href="#DejaVuSans-73" transform="translate(243.505859 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(295.605469 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(327.392578 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(388.671875 0)"/>
-     <use xlink:href="#DejaVuSans-64" transform="translate(452.050781 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(515.527344 0)"/>
-     <use xlink:href="#DejaVuSans-57" transform="translate(547.314453 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(639.816406 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(701.095703 0)"/>
-     <use xlink:href="#DejaVuSans-73" transform="translate(740.304688 0)"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(792.404297 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(853.585938 0)"/>
-     <use xlink:href="#DejaVuSans-2013" transform="translate(916.964844 0)"/>
-     <use xlink:href="#DejaVuSans-43" transform="translate(966.964844 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(1036.789062 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(1077.902344 0)"/>
-     <use xlink:href="#DejaVuSans-63" transform="translate(1105.685547 0)"/>
-     <use xlink:href="#DejaVuSans-6b" transform="translate(1160.666016 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(1218.576172 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(1250.363281 0)"/>
-     <use xlink:href="#DejaVuSans-64" transform="translate(1311.886719 0)"/>
-     <use xlink:href="#DejaVuSans-67" transform="translate(1375.363281 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(1438.839844 0)"/>
-     <use xlink:href="#DejaVuSans-73" transform="translate(1500.363281 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(1552.462891 0)"/>
-     <use xlink:href="#DejaVuSans-63" transform="translate(1584.25 0)"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(1639.230469 0)"/>
-     <use xlink:href="#DejaVuSans-6d" transform="translate(1700.412109 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(1797.824219 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(1859.347656 0)"/>
-     <use xlink:href="#DejaVuSans-66" transform="translate(1891.134766 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(1926.339844 0)"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(1965.203125 0)"/>
-     <use xlink:href="#DejaVuSans-6d" transform="translate(2026.384766 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(2123.796875 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(2155.583984 0)"/>
-     <use xlink:href="#DejaVuSans-68" transform="translate(2194.792969 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(2258.171875 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(2319.695312 0)"/>
-     <use xlink:href="#DejaVuSans-76" transform="translate(2351.482422 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(2410.662109 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(2472.185547 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(2513.298828 0)"/>
-     <use xlink:href="#DejaVuSans-66" transform="translate(2541.082031 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(2576.287109 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(2604.070312 0)"/>
-     <use xlink:href="#DejaVuSans-64" transform="translate(2665.59375 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(2729.070312 0)"/>
-     <use xlink:href="#DejaVuSans-64" transform="translate(2760.857422 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(2824.333984 0)"/>
-     <use xlink:href="#DejaVuSans-73" transform="translate(2885.857422 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(2937.957031 0)"/>
-     <use xlink:href="#DejaVuSans-67" transform="translate(2965.740234 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(3029.216797 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(3092.595703 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(3124.382812 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(3163.246094 0)"/>
-     <use xlink:href="#DejaVuSans-63" transform="translate(3224.769531 0)"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(3279.75 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(3340.931641 0)"/>
-     <use xlink:href="#DejaVuSans-64" transform="translate(3380.294922 0)"/>
-     <use xlink:href="#DejaVuSans-2e" transform="translate(3443.771484 0)"/>
-    </g>
-   </g>
-   <g id="text_4">
     <!-- target -->
-    <g style="fill: #667085" transform="translate(455.202519 61.951156) scale(0.05 -0.05)">
+    <g style="fill: #667085" transform="translate(470.369498 65.659212) scale(0.068 -0.068)">
      <use xlink:href="#DejaVuSans-74"/>
      <use xlink:href="#DejaVuSans-61" transform="translate(39.208984 0)"/>
      <use xlink:href="#DejaVuSans-72" transform="translate(100.488281 0)"/>
@@ -1717,23 +2079,23 @@ z
      <use xlink:href="#DejaVuSans-74" transform="translate(264.851562 0)"/>
     </g>
    </g>
-   <g id="text_5">
+   <g id="text_4">
     <!-- t1 -->
-    <g style="fill: #4e79a7" transform="translate(815.399852 61.951156) scale(0.05 -0.05)">
+    <g style="fill: #8a5a00" transform="translate(792.954286 65.659212) scale(0.068 -0.068)">
      <use xlink:href="#DejaVuSans-74"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(39.208984 0)"/>
     </g>
    </g>
-   <g id="text_6">
+   <g id="text_5">
     <!-- b1 -->
-    <g style="fill: #4e79a7" transform="translate(953.394371 61.951156) scale(0.05 -0.05)">
+    <g style="fill: #1f6f70" transform="translate(925.073068 65.659212) scale(0.068 -0.068)">
      <use xlink:href="#DejaVuSans-62"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.476562 0)"/>
     </g>
    </g>
-   <g id="text_7">
+   <g id="text_6">
     <!-- target -->
-    <g style="fill: #667085" transform="translate(455.202519 74.587156) scale(0.05 -0.05)">
+    <g style="fill: #667085" transform="translate(470.369498 103.445137) scale(0.068 -0.068)">
      <use xlink:href="#DejaVuSans-74"/>
      <use xlink:href="#DejaVuSans-61" transform="translate(39.208984 0)"/>
      <use xlink:href="#DejaVuSans-72" transform="translate(100.488281 0)"/>
@@ -1744,7 +2106,7 @@ z
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:0:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(155.265174 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(208.316502 75.983831) scale(0.078 -0.078)">
      <defs>
       <path id="DejaVuSansMono-54" d="M 147 4666
 L 3706 4666
@@ -1763,7 +2125,7 @@ z
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:1:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(163.927771 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(216.625523 75.983831) scale(0.078 -0.078)">
      <defs>
       <path id="DejaVuSansMono-43" d="M 3353 166
 Q 3113 38 2859 -26
@@ -1792,7 +2154,7 @@ z
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:2:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(172.590368 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(224.934545 75.983831) scale(0.078 -0.078)">
      <defs>
       <path id="DejaVuSansMono-41" d="M 1925 4109
 L 1259 1722
@@ -1816,37 +2178,37 @@ z
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:3:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(181.252965 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(233.243566 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:4:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(189.915562 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(241.552588 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:5:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(198.578159 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(249.861609 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:6:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(207.240756 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(258.170631 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:7:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(215.903353 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(266.479652 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:8:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(224.565949 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(274.788674 75.983831) scale(0.078 -0.078)">
      <defs>
       <path id="DejaVuSansMono-47" d="M 3450 384
 Q 3197 150 2880 29
@@ -1879,1009 +2241,937 @@ z
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:9:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(233.228546 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(283.097695 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:10:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(241.891143 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(291.406717 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:11:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(250.55374 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(299.715738 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:12:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(259.216337 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(308.02476 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:13:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(267.878934 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(316.333782 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:14:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(276.541531 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(324.642803 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:15:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(285.204128 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(332.951825 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:16:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(293.866725 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(341.260846 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:17:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(302.529322 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(349.569868 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:18:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(311.191919 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(357.878889 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:19:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(319.854516 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(366.187911 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:20:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(328.517113 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(374.496932 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:21:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(337.179709 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(382.805954 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:22:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(345.842306 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(391.114975 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:23:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(354.504903 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(399.423997 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:24:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(363.1675 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(407.733018 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:25:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(371.830097 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(416.04204 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:26:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(380.492694 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(424.351062 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:27:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(389.155291 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(432.660083 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:28:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(397.817888 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(440.969105 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:29:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(406.480485 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(449.278126 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:30:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(415.143082 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(457.587148 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:31:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(423.805679 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(465.896169 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:32:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(432.468276 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(474.205191 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:33:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(441.130873 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(482.514212 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:34:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(449.793469 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(490.823234 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:35:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(458.456066 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(499.132255 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:36:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(467.118663 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(507.441277 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:37:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(475.78126 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(515.750298 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:38:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(484.443857 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(524.05932 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:39:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(493.106454 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(532.368342 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:40:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(501.769051 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(540.677363 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:41:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(510.431648 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(548.986385 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:42:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(519.094245 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(557.295406 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:43:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(527.756842 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(565.604428 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:44:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(536.419439 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(573.913449 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:45:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(545.082036 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(582.222471 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:46:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(553.744633 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(590.531492 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:47:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(562.407229 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(598.840514 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:48:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(571.069826 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(607.149535 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:49:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(579.732423 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(615.458557 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:50:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(588.39502 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(623.767578 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:51:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(597.057617 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(632.0766 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:52:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(605.720214 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(640.385622 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:53:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(614.382811 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(648.694643 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:54:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(623.045408 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(657.003665 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:55:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(631.708005 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(665.312686 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:56:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(640.370602 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(673.621708 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:57:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(649.033199 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(681.930729 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:58:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(657.695796 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(690.239751 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:59:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(666.358393 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(698.548772 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:60:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(675.020989 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(706.857794 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:61:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(683.683586 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(715.166815 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:62:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(692.346183 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(723.475837 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:63:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(701.00878 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(731.784858 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:64:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(709.671377 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(740.09388 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:65:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(718.333974 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(748.402902 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:66:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(726.996571 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(756.711923 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:67:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(735.659168 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(765.020945 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:68:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(744.321765 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(773.329966 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:69:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(752.984362 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(781.638988 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:70:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(761.646959 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(789.948009 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:71:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(770.309556 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(798.257031 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:72:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(778.972153 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(806.566052 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:73:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(787.634749 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(814.875074 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:74:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(796.297346 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(823.184095 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:75:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(804.959943 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(831.493117 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:76:C">
-    <!-- C -->
-    <g style="fill: #172033" transform="translate(813.62254 68.356406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-43"/>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:76:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(839.802138 75.983831) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:77:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(822.285137 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(848.11116 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:78:A">
-    <!-- A -->
-    <g style="fill: #172033" transform="translate(830.947734 68.356406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-41"/>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:78:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(856.420182 75.983831) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:79:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(839.610331 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(864.729203 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:80:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(848.272928 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(873.038225 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:81:G">
-    <!-- G -->
-    <g style="fill: #172033" transform="translate(856.935525 68.356406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-47"/>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:81:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(881.347246 75.983831) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:82:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(865.598122 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(889.656268 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:83:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(874.260719 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(897.965289 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:84:A">
-    <!-- A -->
-    <g style="fill: #172033" transform="translate(882.923316 68.356406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-41"/>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:84:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(906.274311 75.983831) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:85:A">
-    <!-- A -->
-    <g style="fill: #172033" transform="translate(891.585913 68.356406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-41"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:86:C">
-    <!-- C -->
-    <g style="fill: #172033" transform="translate(900.248509 68.356406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-43"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:87:A">
-    <!-- A -->
-    <g style="fill: #172033" transform="translate(908.911106 68.356406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-41"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:88:G">
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:85:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(917.573703 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(914.583332 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:89:T">
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:86:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(922.892354 75.983831) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-47"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:87:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(926.2363 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(931.201375 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-54"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:88:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(939.510397 75.983831) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-43"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:89:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(947.819418 75.983831) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:90:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(934.898897 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(956.12844 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:91:C">
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:91:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(964.437462 75.983831) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-54"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:92:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(943.561494 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(972.746483 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:92:T">
-    <!-- T -->
-    <g style="fill: #172033" transform="translate(952.224091 68.356406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-54"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:93:G">
-    <!-- G -->
-    <g style="fill: #172033" transform="translate(960.886688 68.356406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-47"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:94:T">
-    <!-- T -->
-    <g style="fill: #172033" transform="translate(969.549285 68.356406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-54"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:95:T">
-    <!-- T -->
-    <g style="fill: #172033" transform="translate(978.211882 68.356406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-54"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:96:A">
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:93:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(986.874479 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(981.055505 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:97:T">
-    <!-- T -->
-    <g style="fill: #172033" transform="translate(995.537076 68.356406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-54"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:98:G">
-    <!-- G -->
-    <g style="fill: #172033" transform="translate(1004.199673 68.356406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-47"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:99:A">
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:94:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(1012.862269 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(989.364526 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:100:C">
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:95:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(1021.524866 68.356406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(997.673548 75.983831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:101:G">
-    <!-- G -->
-    <g style="fill: #172033" transform="translate(1030.187463 68.356406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-47"/>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:96:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(1005.982569 75.983831) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:102:G">
-    <!-- G -->
-    <g style="fill: #172033" transform="translate(1038.85006 68.356406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-47"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:103:G">
-    <!-- G -->
-    <g style="fill: #172033" transform="translate(1047.512657 68.356406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-47"/>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:top:base:97:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(1014.291591 75.983831) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:bottom:base:0:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(155.265174 80.992406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(208.316502 93.713831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:bottom:base:1:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(163.927771 80.992406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(216.625523 93.713831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:bottom:base:2:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(172.590368 80.992406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(224.934545 93.713831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:bottom:base:3:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(181.252965 80.992406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(233.243566 93.713831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:bottom:base:4:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(189.915562 80.992406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(241.552588 93.713831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:bottom:base:5:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(198.578159 80.992406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(249.861609 93.713831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:bottom:base:6:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(207.240756 80.992406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(258.170631 93.713831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:bottom:base:7:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(215.903353 80.992406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(266.479652 93.713831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:bottom:base:8:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(224.565949 80.992406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(274.788674 93.713831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:bottom:base:9:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(233.228546 80.992406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(283.097695 93.713831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:bottom:base:10:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(241.891143 80.992406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(291.406717 93.713831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:bottom:base:11:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(250.55374 80.992406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(299.715738 93.713831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:bottom:base:12:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(259.216337 80.992406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(308.02476 93.713831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:bottom:base:13:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(267.878934 80.992406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(316.333782 93.713831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:bottom:base:14:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(276.541531 80.992406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(324.642803 93.713831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:bottom:base:15:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(285.204128 80.992406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(332.951825 93.713831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:bottom:base:16:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(293.866725 80.992406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(341.260846 93.713831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:bottom:base:17:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(302.529322 80.992406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(349.569868 93.713831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:bottom:base:18:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(311.191919 80.992406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(357.878889 93.713831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:bottom:base:19:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(319.854516 80.992406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(366.187911 93.713831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:bottom:base:20:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(328.517113 80.992406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(374.496932 93.713831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:bottom:base:21:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(337.179709 80.992406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(382.805954 93.713831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:bottom:base:22:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(345.842306 80.992406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(391.114975 93.713831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:bottom:base:23:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(354.504903 80.992406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(399.423997 93.713831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:bottom:base:24:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(363.1675 80.992406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(407.733018 93.713831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:bottom:base:25:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(371.830097 80.992406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(416.04204 93.713831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:bottom:base:26:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(380.492694 80.992406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(424.351062 93.713831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:bottom:base:27:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(389.155291 80.992406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(432.660083 93.713831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:bottom:base:28:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(397.817888 80.992406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(440.969105 93.713831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:bottom:base:29:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(406.480485 80.992406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(449.278126 93.713831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:bottom:base:30:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(415.143082 80.992406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(457.587148 93.713831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:bottom:base:31:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(423.805679 80.992406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(465.896169 93.713831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:bottom:base:32:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(432.468276 80.992406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(474.205191 93.713831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:bottom:base:33:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(441.130873 80.992406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(482.514212 93.713831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:bottom:base:34:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(449.793469 80.992406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(490.823234 93.713831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:bottom:base:35:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(458.456066 80.992406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(499.132255 93.713831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:bottom:base:36:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(467.118663 80.992406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(507.441277 93.713831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:bottom:base:37:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(475.78126 80.992406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(515.750298 93.713831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:bottom:base:38:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(484.443857 80.992406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(524.05932 93.713831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:bottom:base:39:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(493.106454 80.992406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(532.368342 93.713831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:bottom:base:40:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(501.769051 80.992406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(540.677363 93.713831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:bottom:base:41:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(510.431648 80.992406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(548.986385 93.713831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:bottom:base:42:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(519.094245 80.992406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(557.295406 93.713831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:bottom:base:43:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(527.756842 80.992406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(565.604428 93.713831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:bottom:base:44:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(536.419439 80.992406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(573.913449 93.713831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:bottom:base:45:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(545.082036 80.992406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(582.222471 93.713831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:bottom:base:46:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(553.744633 80.992406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(590.531492 93.713831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:bottom:base:47:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(562.407229 80.992406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(598.840514 93.713831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:bottom:base:48:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(571.069826 80.992406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(607.149535 93.713831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:bottom:base:49:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(579.732423 80.992406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(615.458557 93.713831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:bottom:base:50:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(588.39502 80.992406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(623.767578 93.713831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:bottom:base:51:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(597.057617 80.992406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(632.0766 93.713831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:bottom:base:52:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(605.720214 80.992406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(640.385622 93.713831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:bottom:base:53:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(614.382811 80.992406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(648.694643 93.713831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:bottom:base:54:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(623.045408 80.992406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(657.003665 93.713831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:bottom:base:55:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(631.708005 80.992406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(665.312686 93.713831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:bottom:base:56:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(640.370602 80.992406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(673.621708 93.713831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:bottom:base:57:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(649.033199 80.992406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(681.930729 93.713831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:bottom:base:58:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(657.695796 80.992406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(690.239751 93.713831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:bottom:base:59:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(666.358393 80.992406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(698.548772 93.713831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:bottom:base:60:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(675.020989 80.992406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(706.857794 93.713831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:bottom:base:61:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(683.683586 80.992406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(715.166815 93.713831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:bottom:base:62:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(692.346183 80.992406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(723.475837 93.713831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:bottom:base:63:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(701.00878 80.992406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(731.784858 93.713831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:bottom:base:64:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(709.671377 80.992406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(740.09388 93.713831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:bottom:base:65:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(718.333974 80.992406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(748.402902 93.713831) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:bottom:base:66:G">
-    <!-- G -->
-    <g style="fill: #172033" transform="translate(726.996571 80.992406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-47"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:bottom:base:67:C">
-    <!-- C -->
-    <g style="fill: #172033" transform="translate(735.659168 80.992406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-43"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:bottom:base:68:A">
-    <!-- A -->
-    <g style="fill: #172033" transform="translate(744.321765 80.992406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-41"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:bottom:base:69:T">
-    <!-- T -->
-    <g style="fill: #172033" transform="translate(752.984362 80.992406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-54"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:bottom:base:70:C">
-    <!-- C -->
-    <g style="fill: #172033" transform="translate(761.646959 80.992406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-43"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0001:bottom:base:71:T">
-    <!-- T -->
-    <g style="fill: #172033" transform="translate(770.309556 80.992406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-54"/>
-    </g>
-   </g>
-   <g id="text_8">
+   <g id="text_7">
     <!-- 5′ -->
-    <g style="fill: #667085" transform="translate(139.317545 68.342062) scale(0.054 -0.054)">
+    <g style="fill: #667085" transform="translate(191.652905 75.79755) scale(0.072 -0.072)">
      <defs>
       <path id="DejaVuSans-35" d="M 691 4666
 L 3169 4666
@@ -2920,30 +3210,64 @@ z
      <use xlink:href="#DejaVuSans-2032" transform="translate(63.623047 0)"/>
     </g>
    </g>
+   <g id="text_8">
+    <!-- 3′ -->
+    <g style="fill: #667085" transform="translate(1025.114715 75.79755) scale(0.072 -0.072)">
+     <defs>
+      <path id="DejaVuSans-33" d="M 2597 2516
+Q 3050 2419 3304 2112
+Q 3559 1806 3559 1356
+Q 3559 666 3084 287
+Q 2609 -91 1734 -91
+Q 1441 -91 1130 -33
+Q 819 25 488 141
+L 488 750
+Q 750 597 1062 519
+Q 1375 441 1716 441
+Q 2309 441 2620 675
+Q 2931 909 2931 1356
+Q 2931 1769 2642 2001
+Q 2353 2234 1838 2234
+L 1294 2234
+L 1294 2753
+L 1863 2753
+Q 2328 2753 2575 2939
+Q 2822 3125 2822 3475
+Q 2822 3834 2567 4026
+Q 2313 4219 1838 4219
+Q 1578 4219 1281 4162
+Q 984 4106 628 3988
+L 628 4550
+Q 988 4650 1302 4700
+Q 1616 4750 1894 4750
+Q 2613 4750 3031 4423
+Q 3450 4097 3450 3541
+Q 3450 3153 3228 2886
+Q 3006 2619 2597 2516
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-33"/>
+     <use xlink:href="#DejaVuSans-2032" transform="translate(63.623047 0)"/>
+    </g>
+   </g>
    <g id="text_9">
     <!-- 3′ -->
-    <g style="fill: #667085" transform="translate(1057.759488 68.342062) scale(0.054 -0.054)">
+    <g style="fill: #667085" transform="translate(191.652905 93.52755) scale(0.072 -0.072)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-2032" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_10">
-    <!-- 3′ -->
-    <g style="fill: #667085" transform="translate(139.317545 80.978062) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSans-33"/>
-     <use xlink:href="#DejaVuSans-2032" transform="translate(63.623047 0)"/>
-    </g>
-   </g>
-   <g id="text_11">
     <!-- 5′ -->
-    <g style="fill: #667085" transform="translate(780.556386 80.978062) scale(0.054 -0.054)">
+    <g style="fill: #667085" transform="translate(759.226025 93.52755) scale(0.072 -0.072)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-2032" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_12">
-    <!-- F01 -->
-    <g style="fill: #172033" transform="translate(29.22048 63.744281) scale(0.06 -0.06)">
+   <g id="text_11">
+    <!-- F01 · first -->
+    <g style="fill: #172033" transform="translate(24.957792 73.184737) scale(0.072 -0.072)">
      <defs>
       <path id="DejaVuSans-Bold-46" d="M 588 4666
 L 3834 4666
@@ -2993,56 +3317,154 @@ L 750 0
 L 750 831
 z
 " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-b7" d="M 653 2828
+L 1778 2828
+L 1778 1619
+L 653 1619
+L 653 2828
+z
+" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-Bold-46"/>
      <use xlink:href="#DejaVuSans-Bold-30" transform="translate(68.310547 0)"/>
      <use xlink:href="#DejaVuSans-Bold-31" transform="translate(137.890625 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(207.470703 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-b7" transform="translate(242.285156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(280.273438 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-66" transform="translate(315.087891 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-69" transform="translate(358.59375 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-72" transform="translate(392.871094 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-73" transform="translate(442.1875 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-74" transform="translate(501.708984 0)"/>
     </g>
-    <!-- first -->
-    <g style="fill: #172033" transform="translate(29.22048 70.462969) scale(0.06 -0.06)">
+    <!-- 98 nt / 66 nt -->
+    <g style="fill: #172033" transform="translate(24.957792 81.247162) scale(0.072 -0.072)">
      <defs>
-      <path id="DejaVuSans-Bold-73" d="M 3272 3391
-L 3272 2541
-Q 2913 2691 2578 2766
-Q 2244 2841 1947 2841
-Q 1628 2841 1473 2761
-Q 1319 2681 1319 2516
-Q 1319 2381 1436 2309
-Q 1553 2238 1856 2203
-L 2053 2175
-Q 2913 2066 3209 1816
-Q 3506 1566 3506 1031
-Q 3506 472 3093 190
-Q 2681 -91 1863 -91
-Q 1516 -91 1145 -36
-Q 775 19 384 128
-L 384 978
-Q 719 816 1070 734
-Q 1422 653 1784 653
-Q 2113 653 2278 743
-Q 2444 834 2444 1013
-Q 2444 1163 2330 1236
-Q 2216 1309 1875 1350
-L 1678 1375
-Q 931 1469 631 1722
-Q 331 1975 331 2491
-Q 331 3047 712 3315
-Q 1094 3584 1881 3584
-Q 2191 3584 2531 3537
-Q 2872 3491 3272 3391
+      <path id="DejaVuSans-Bold-39" d="M 641 103
+L 641 966
+Q 928 831 1190 764
+Q 1453 697 1709 697
+Q 2247 697 2547 995
+Q 2847 1294 2900 1881
+Q 2688 1725 2447 1647
+Q 2206 1569 1925 1569
+Q 1209 1569 770 1986
+Q 331 2403 331 3084
+Q 331 3838 820 4291
+Q 1309 4744 2131 4744
+Q 3044 4744 3544 4128
+Q 4044 3513 4044 2388
+Q 4044 1231 3459 570
+Q 2875 -91 1856 -91
+Q 1528 -91 1228 -42
+Q 928 6 641 103
+z
+M 2125 2350
+Q 2441 2350 2600 2554
+Q 2759 2759 2759 3169
+Q 2759 3575 2600 3781
+Q 2441 3988 2125 3988
+Q 1809 3988 1650 3781
+Q 1491 3575 1491 3169
+Q 1491 2759 1650 2554
+Q 1809 2350 2125 2350
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-38" d="M 2228 2088
+Q 1891 2088 1709 1903
+Q 1528 1719 1528 1375
+Q 1528 1031 1709 848
+Q 1891 666 2228 666
+Q 2563 666 2741 848
+Q 2919 1031 2919 1375
+Q 2919 1722 2741 1905
+Q 2563 2088 2228 2088
+z
+M 1350 2484
+Q 925 2613 709 2878
+Q 494 3144 494 3541
+Q 494 4131 934 4440
+Q 1375 4750 2228 4750
+Q 3075 4750 3515 4442
+Q 3956 4134 3956 3541
+Q 3956 3144 3739 2878
+Q 3522 2613 3097 2484
+Q 3572 2353 3814 2058
+Q 4056 1763 4056 1313
+Q 4056 619 3595 264
+Q 3134 -91 2228 -91
+Q 1319 -91 855 264
+Q 391 619 391 1313
+Q 391 1763 633 2058
+Q 875 2353 1350 2484
+z
+M 1631 3419
+Q 1631 3141 1786 2991
+Q 1941 2841 2228 2841
+Q 2509 2841 2662 2991
+Q 2816 3141 2816 3419
+Q 2816 3697 2662 3845
+Q 2509 3994 2228 3994
+Q 1941 3994 1786 3844
+Q 1631 3694 1631 3419
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-2f" d="M 1644 4666
+L 2338 4666
+L 691 -594
+L 0 -594
+L 1644 4666
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-36" d="M 2316 2303
+Q 2000 2303 1842 2098
+Q 1684 1894 1684 1484
+Q 1684 1075 1842 870
+Q 2000 666 2316 666
+Q 2634 666 2792 870
+Q 2950 1075 2950 1484
+Q 2950 1894 2792 2098
+Q 2634 2303 2316 2303
+z
+M 3803 4544
+L 3803 3681
+Q 3506 3822 3243 3889
+Q 2981 3956 2731 3956
+Q 2194 3956 1894 3657
+Q 1594 3359 1544 2772
+Q 1750 2925 1990 3001
+Q 2231 3078 2516 3078
+Q 3231 3078 3670 2659
+Q 4109 2241 4109 1563
+Q 4109 813 3618 361
+Q 3128 -91 2303 -91
+Q 1394 -91 895 523
+Q 397 1138 397 2266
+Q 397 3422 980 4083
+Q 1563 4744 2578 4744
+Q 2900 4744 3203 4694
+Q 3506 4644 3803 4544
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-Bold-66"/>
-     <use xlink:href="#DejaVuSans-Bold-69" transform="translate(43.505859 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-72" transform="translate(77.783203 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-73" transform="translate(127.099609 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-74" transform="translate(186.621094 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-39"/>
+     <use xlink:href="#DejaVuSans-Bold-38" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(139.160156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(173.974609 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-74" transform="translate(245.166016 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(292.96875 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-2f" transform="translate(327.783203 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(364.306641 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-36" transform="translate(399.121094 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-36" transform="translate(468.701172 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(538.28125 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(573.095703 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-74" transform="translate(644.287109 0)"/>
     </g>
    </g>
-   <g id="text_13">
+   <g id="text_12">
     <!-- b1* -->
-    <g style="fill: #4e79a7" transform="translate(255.424076 107.581156) scale(0.05 -0.05)">
+    <g style="fill: #1f6f70" transform="translate(266.960366 128.068812) scale(0.068 -0.068)">
      <defs>
       <path id="DejaVuSans-2a" d="M 3009 3897
 L 1888 3291
@@ -3071,9 +3493,9 @@ z
      <use xlink:href="#DejaVuSans-2a" transform="translate(127.099609 0)"/>
     </g>
    </g>
-   <g id="text_14">
+   <g id="text_13">
     <!-- target -->
-    <g style="fill: #667085" transform="translate(544.303516 107.581156) scale(0.05 -0.05)">
+    <g style="fill: #667085" transform="translate(561.768735 128.068812) scale(0.068 -0.068)">
      <use xlink:href="#DejaVuSans-74"/>
      <use xlink:href="#DejaVuSans-61" transform="translate(39.208984 0)"/>
      <use xlink:href="#DejaVuSans-72" transform="translate(100.488281 0)"/>
@@ -3082,57 +3504,31 @@ z
      <use xlink:href="#DejaVuSans-74" transform="translate(264.851562 0)"/>
     </g>
    </g>
-   <g id="text_15">
+   <g id="text_14">
     <!-- t2 -->
-    <g style="fill: #2a9d8f" transform="translate(781.986978 107.581156) scale(0.05 -0.05)">
-     <defs>
-      <path id="DejaVuSans-32" d="M 1228 531
-L 3431 531
-L 3431 0
-L 469 0
-L 469 531
-Q 828 903 1448 1529
-Q 2069 2156 2228 2338
-Q 2531 2678 2651 2914
-Q 2772 3150 2772 3378
-Q 2772 3750 2511 3984
-Q 2250 4219 1831 4219
-Q 1534 4219 1204 4116
-Q 875 4013 500 3803
-L 500 4441
-Q 881 4594 1212 4672
-Q 1544 4750 1819 4750
-Q 2544 4750 2975 4387
-Q 3406 4025 3406 3419
-Q 3406 3131 3298 2873
-Q 3191 2616 2906 2266
-Q 2828 2175 2409 1742
-Q 1991 1309 1228 531
-z
-" transform="scale(0.015625)"/>
-     </defs>
+    <g style="fill: #8a5a00" transform="translate(817.88135 128.068812) scale(0.068 -0.068)">
      <use xlink:href="#DejaVuSans-74"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(39.208984 0)"/>
     </g>
    </g>
-   <g id="text_16">
+   <g id="text_15">
     <!-- b2 -->
-    <g style="fill: #2a9d8f" transform="translate(939.781719 107.581156) scale(0.05 -0.05)">
+    <g style="fill: #1f6f70" transform="translate(950.000132 128.068812) scale(0.068 -0.068)">
      <use xlink:href="#DejaVuSans-62"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.476562 0)"/>
     </g>
    </g>
-   <g id="text_17">
+   <g id="text_16">
     <!-- t1* -->
-    <g style="fill: #4e79a7" transform="translate(315.431772 120.217156) scale(0.05 -0.05)">
+    <g style="fill: #8a5a00" transform="translate(317.640058 165.854737) scale(0.068 -0.068)">
      <use xlink:href="#DejaVuSans-74"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(39.208984 0)"/>
      <use xlink:href="#DejaVuSans-2a" transform="translate(102.832031 0)"/>
     </g>
    </g>
-   <g id="text_18">
+   <g id="text_17">
     <!-- target -->
-    <g style="fill: #667085" transform="translate(544.303516 120.217156) scale(0.05 -0.05)">
+    <g style="fill: #667085" transform="translate(561.768735 165.854737) scale(0.068 -0.068)">
      <use xlink:href="#DejaVuSans-74"/>
      <use xlink:href="#DejaVuSans-61" transform="translate(39.208984 0)"/>
      <use xlink:href="#DejaVuSans-72" transform="translate(100.488281 0)"/>
@@ -3141,865 +3537,1021 @@ z
      <use xlink:href="#DejaVuSans-74" transform="translate(264.851562 0)"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:0:C">
-    <!-- C -->
-    <g style="fill: #172033" transform="translate(155.883931 113.986406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-43"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:1:C">
-    <!-- C -->
-    <g style="fill: #172033" transform="translate(165.784042 113.986406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-43"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:2:C">
-    <!-- C -->
-    <g style="fill: #172033" transform="translate(175.684153 113.986406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-43"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:3:G">
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:0:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(185.584263 113.986406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(183.389437 138.393431) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-47"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:1:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(191.698458 138.393431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-47"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:2:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(200.00748 138.393431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-47"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:3:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(208.316502 138.393431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:4:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(195.484374 113.986406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(216.625523 138.393431) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:5:C">
-    <!-- C -->
-    <g style="fill: #172033" transform="translate(205.384485 113.986406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-43"/>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:5:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(224.934545 138.393431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:6:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(215.284596 113.986406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(233.243566 138.393431) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:7:T">
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:7:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(241.552588 138.393431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-43"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:8:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(225.184706 113.986406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(249.861609 138.393431) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:8:A">
-    <!-- A -->
-    <g style="fill: #172033" transform="translate(235.084817 113.986406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-41"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:9:A">
-    <!-- A -->
-    <g style="fill: #172033" transform="translate(244.984928 113.986406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-41"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:10:C">
-    <!-- C -->
-    <g style="fill: #172033" transform="translate(254.885039 113.986406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-43"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:11:A">
-    <!-- A -->
-    <g style="fill: #172033" transform="translate(264.785149 113.986406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-41"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:12:G">
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:9:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(274.68526 113.986406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(258.170631 138.393431) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:13:C">
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:10:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(266.479652 138.393431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-41"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:11:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(284.585371 113.986406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(274.788674 138.393431) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-43"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:12:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(283.097695 138.393431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-43"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:13:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(291.406717 138.393431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:14:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(294.485482 113.986406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(299.715738 138.393431) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:15:C">
-    <!-- C -->
-    <g style="fill: #172033" transform="translate(304.385593 113.986406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-43"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:16:T">
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:15:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(314.285703 113.986406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(308.02476 138.393431) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:17:G">
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:16:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(324.185814 113.986406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(316.333782 138.393431) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:18:T">
-    <!-- T -->
-    <g style="fill: #172033" transform="translate(334.085925 113.986406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-54"/>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:17:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(324.642803 138.393431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:19:T">
-    <!-- T -->
-    <g style="fill: #172033" transform="translate(343.986036 113.986406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-54"/>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:18:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(332.951825 138.393431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-43"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:19:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(341.260846 138.393431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:20:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(353.886146 113.986406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(349.569868 138.393431) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:21:T">
-    <!-- T -->
-    <g style="fill: #172033" transform="translate(363.786257 113.986406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-54"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:22:T">
-    <!-- T -->
-    <g style="fill: #172033" transform="translate(373.686368 113.986406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-54"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:23:C">
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:21:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(383.586479 113.986406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(357.878889 138.393431) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:24:T">
-    <!-- T -->
-    <g style="fill: #172033" transform="translate(393.486589 113.986406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-54"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:25:A">
-    <!-- A -->
-    <g style="fill: #172033" transform="translate(403.3867 113.986406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-41"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:26:T">
-    <!-- T -->
-    <g style="fill: #172033" transform="translate(413.286811 113.986406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-54"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:27:C">
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:22:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(423.186922 113.986406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(366.187911 138.393431) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:28:A">
-    <!-- A -->
-    <g style="fill: #172033" transform="translate(433.087033 113.986406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-41"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:29:G">
-    <!-- G -->
-    <g style="fill: #172033" transform="translate(442.987143 113.986406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-47"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:30:A">
-    <!-- A -->
-    <g style="fill: #172033" transform="translate(452.887254 113.986406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-41"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:31:T">
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:23:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(462.787365 113.986406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(374.496932 138.393431) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:32:G">
-    <!-- G -->
-    <g style="fill: #172033" transform="translate(472.687476 113.986406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-47"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:33:A">
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:24:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(482.587586 113.986406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(382.805954 138.393431) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:34:T">
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:25:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(391.114975 138.393431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-47"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:26:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(399.423997 138.393431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-47"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:27:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(407.733018 138.393431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-47"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:28:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(492.487697 113.986406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(416.04204 138.393431) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-54"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:29:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(424.351062 138.393431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-43"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:30:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(432.660083 138.393431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-54"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:31:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(440.969105 138.393431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-41"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:32:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(449.278126 138.393431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-54"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:33:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(457.587148 138.393431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-43"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:34:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(465.896169 138.393431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:35:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(502.387808 113.986406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(474.205191 138.393431) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:36:C">
-    <!-- C -->
-    <g style="fill: #172033" transform="translate(512.287919 113.986406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-43"/>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:36:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(482.514212 138.393431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:37:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(522.188029 113.986406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(490.823234 138.393431) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:38:T">
-    <!-- T -->
-    <g style="fill: #172033" transform="translate(532.08814 113.986406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-54"/>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:38:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(499.132255 138.393431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:39:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(541.988251 113.986406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(507.441277 138.393431) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:40:G">
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:40:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(515.750298 138.393431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-54"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:41:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(551.888362 113.986406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(524.05932 138.393431) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:41:C">
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:42:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(561.788473 113.986406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(532.368342 138.393431) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:42:G">
-    <!-- G -->
-    <g style="fill: #172033" transform="translate(571.688583 113.986406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-47"/>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:43:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(540.677363 138.393431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:43:G">
-    <!-- G -->
-    <g style="fill: #172033" transform="translate(581.588694 113.986406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-47"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:44:A">
-    <!-- A -->
-    <g style="fill: #172033" transform="translate(591.488805 113.986406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-41"/>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:44:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(548.986385 138.393431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:45:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(601.388916 113.986406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(557.295406 138.393431) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:46:T">
-    <!-- T -->
-    <g style="fill: #172033" transform="translate(611.289026 113.986406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-54"/>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:46:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(565.604428 138.393431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:47:A">
-    <!-- A -->
-    <g style="fill: #172033" transform="translate(621.189137 113.986406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-41"/>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:47:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(573.913449 138.393431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:48:A">
-    <!-- A -->
-    <g style="fill: #172033" transform="translate(631.089248 113.986406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-41"/>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:48:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(582.222471 138.393431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:49:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(640.989359 113.986406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(590.531492 138.393431) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:50:G">
-    <!-- G -->
-    <g style="fill: #172033" transform="translate(650.889469 113.986406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-47"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:51:T">
-    <!-- T -->
-    <g style="fill: #172033" transform="translate(660.78958 113.986406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-54"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:52:A">
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:50:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(670.689691 113.986406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(598.840514 138.393431) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:53:C">
-    <!-- C -->
-    <g style="fill: #172033" transform="translate(680.589802 113.986406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-43"/>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:51:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(607.149535 138.393431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-41"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:52:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(615.458557 138.393431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-54"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:53:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(623.767578 138.393431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:54:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(690.489913 113.986406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(632.0766 138.393431) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:55:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(700.390023 113.986406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(640.385622 138.393431) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:56:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(710.290134 113.986406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(648.694643 138.393431) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:57:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(720.190245 113.986406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(657.003665 138.393431) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:58:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(730.090356 113.986406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(665.312686 138.393431) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:59:T">
-    <!-- T -->
-    <g style="fill: #172033" transform="translate(739.990466 113.986406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-54"/>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:59:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(673.621708 138.393431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:60:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(749.890577 113.986406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(681.930729 138.393431) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:61:A">
-    <!-- A -->
-    <g style="fill: #172033" transform="translate(759.790688 113.986406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-41"/>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:61:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(690.239751 138.393431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:62:T">
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:62:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(698.548772 138.393431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-47"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:63:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(769.690799 113.986406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(706.857794 138.393431) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:63:C">
-    <!-- C -->
-    <g style="fill: #172033" transform="translate(779.590909 113.986406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-43"/>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:64:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(715.166815 138.393431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:64:C">
-    <!-- C -->
-    <g style="fill: #172033" transform="translate(789.49102 113.986406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-43"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:65:G">
-    <!-- G -->
-    <g style="fill: #172033" transform="translate(799.391131 113.986406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-47"/>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:65:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(723.475837 138.393431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:66:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(809.291242 113.986406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(731.784858 138.393431) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:67:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(819.191353 113.986406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(740.09388 138.393431) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:68:A">
-    <!-- A -->
-    <g style="fill: #172033" transform="translate(829.091463 113.986406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-41"/>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:68:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(748.402902 138.393431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:69:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(838.991574 113.986406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(756.711923 138.393431) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:70:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(848.891685 113.986406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(765.020945 138.393431) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:71:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(858.791796 113.986406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(773.329966 138.393431) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:72:G">
-    <!-- G -->
-    <g style="fill: #172033" transform="translate(868.691906 113.986406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-47"/>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:72:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(781.638988 138.393431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:73:C">
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:73:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(789.948009 138.393431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-41"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:74:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(798.257031 138.393431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-41"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:75:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(878.592017 113.986406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(806.566052 138.393431) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:74:G">
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:76:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(888.492128 113.986406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(814.875074 138.393431) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:75:A">
-    <!-- A -->
-    <g style="fill: #172033" transform="translate(898.392239 113.986406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-41"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:76:A">
-    <!-- A -->
-    <g style="fill: #172033" transform="translate(908.292349 113.986406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-41"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:77:T">
-    <!-- T -->
-    <g style="fill: #172033" transform="translate(918.19246 113.986406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-54"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:78:A">
-    <!-- A -->
-    <g style="fill: #172033" transform="translate(928.092571 113.986406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-41"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:79:G">
-    <!-- G -->
-    <g style="fill: #172033" transform="translate(937.992682 113.986406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-47"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:80:A">
-    <!-- A -->
-    <g style="fill: #172033" transform="translate(947.892793 113.986406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-41"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:81:T">
-    <!-- T -->
-    <g style="fill: #172033" transform="translate(957.792903 113.986406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-54"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:82:C">
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:77:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(967.693014 113.986406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(823.184095 138.393431) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:83:G">
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:78:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(831.493117 138.393431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-54"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:79:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(839.802138 138.393431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-54"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:80:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(848.11116 138.393431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-54"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:81:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(977.593125 113.986406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(856.420182 138.393431) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-47"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:82:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(864.729203 138.393431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-54"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:83:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(873.038225 138.393431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:84:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(987.493236 113.986406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(881.347246 138.393431) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:85:G">
-    <!-- G -->
-    <g style="fill: #172033" transform="translate(997.393346 113.986406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-47"/>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:85:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(889.656268 138.393431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:86:C">
-    <!-- C -->
-    <g style="fill: #172033" transform="translate(1007.293457 113.986406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-43"/>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:86:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(897.965289 138.393431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:87:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(1017.193568 113.986406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(906.274311 138.393431) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:88:T">
-    <!-- T -->
-    <g style="fill: #172033" transform="translate(1027.093679 113.986406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-54"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:89:A">
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:88:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(1036.993789 113.986406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(914.583332 138.393431) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:90:T">
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:89:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(1046.8939 113.986406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(922.892354 138.393431) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:0:C">
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:90:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(931.201375 138.393431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-41"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:91:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(274.68526 126.622406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(939.510397 138.393431) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-43"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:92:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(947.819418 138.393431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-43"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:93:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(956.12844 138.393431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-41"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:94:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(964.437462 138.393431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-43"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:95:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(972.746483 138.393431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-43"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:96:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(981.055505 138.393431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-41"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:97:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(989.364526 138.393431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-47"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:98:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(997.673548 138.393431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-43"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:99:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(1005.982569 138.393431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-41"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:100:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(1014.291591 138.393431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-43"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:101:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(1022.600612 138.393431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-43"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:102:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(1030.909634 138.393431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-47"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:top:base:103:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(1039.218655 138.393431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-47"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:0:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(283.097695 156.123431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:1:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(284.585371 126.622406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(291.406717 156.123431) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:2:C">
-    <!-- C -->
-    <g style="fill: #172033" transform="translate(294.485482 126.622406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-43"/>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:2:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(299.715738 156.123431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:3:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(304.385593 126.622406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(308.02476 156.123431) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:4:G">
-    <!-- G -->
-    <g style="fill: #172033" transform="translate(314.285703 126.622406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-47"/>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:4:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(316.333782 156.123431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:5:A">
-    <!-- A -->
-    <g style="fill: #172033" transform="translate(324.185814 126.622406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-41"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:6:T">
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:5:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(334.085925 126.622406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(324.642803 156.123431) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-54"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:6:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(332.951825 156.123431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:7:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(343.986036 126.622406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(341.260846 156.123431) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:8:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(353.886146 126.622406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(349.569868 156.123431) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:9:C">
-    <!-- C -->
-    <g style="fill: #172033" transform="translate(363.786257 126.622406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-43"/>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:9:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(357.878889 156.123431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:10:A">
-    <!-- A -->
-    <g style="fill: #172033" transform="translate(373.686368 126.622406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-41"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:11:G">
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:10:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(383.586479 126.622406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(366.187911 156.123431) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:12:A">
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:11:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(393.486589 126.622406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(374.496932 156.123431) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:13:T">
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:12:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(403.3867 126.622406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(382.805954 156.123431) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:14:A">
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:13:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(391.114975 156.123431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-43"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:14:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(399.423997 156.123431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-43"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:15:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(407.733018 156.123431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-43"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:16:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(413.286811 126.622406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(416.04204 156.123431) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:15:G">
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:17:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(423.186922 126.622406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(424.351062 156.123431) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:16:T">
-    <!-- T -->
-    <g style="fill: #172033" transform="translate(433.087033 126.622406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-54"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:17:C">
-    <!-- C -->
-    <g style="fill: #172033" transform="translate(442.987143 126.622406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-43"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:18:T">
-    <!-- T -->
-    <g style="fill: #172033" transform="translate(452.887254 126.622406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-54"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:19:A">
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:18:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(462.787365 126.622406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(432.660083 156.123431) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:20:C">
-    <!-- C -->
-    <g style="fill: #172033" transform="translate(472.687476 126.622406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-43"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:21:T">
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:19:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(482.587586 126.622406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(440.969105 156.123431) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:22:A">
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:20:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(492.487697 126.622406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(449.278126 156.123431) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-41"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:21:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(457.587148 156.123431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-47"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:22:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(465.896169 156.123431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:23:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(502.387808 126.622406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(474.205191 156.123431) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:24:G">
-    <!-- G -->
-    <g style="fill: #172033" transform="translate(512.287919 126.622406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-47"/>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:24:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(482.514212 156.123431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:25:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(522.188029 126.622406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(490.823234 156.123431) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:26:A">
-    <!-- A -->
-    <g style="fill: #172033" transform="translate(532.08814 126.622406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-41"/>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:26:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(499.132255 156.123431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:27:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(541.988251 126.622406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(507.441277 156.123431) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:28:C">
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:28:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(515.750298 156.123431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-41"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:29:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(551.888362 126.622406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(524.05932 156.123431) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:29:G">
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:30:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(561.788473 126.622406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(532.368342 156.123431) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:30:C">
-    <!-- C -->
-    <g style="fill: #172033" transform="translate(571.688583 126.622406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-43"/>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:31:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(540.677363 156.123431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:31:C">
-    <!-- C -->
-    <g style="fill: #172033" transform="translate(581.588694 126.622406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-43"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:32:T">
-    <!-- T -->
-    <g style="fill: #172033" transform="translate(591.488805 126.622406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-54"/>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:32:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(548.986385 156.123431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:33:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(601.388916 126.622406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(557.295406 156.123431) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:34:A">
-    <!-- A -->
-    <g style="fill: #172033" transform="translate(611.289026 126.622406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-41"/>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:34:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(565.604428 156.123431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:35:T">
-    <!-- T -->
-    <g style="fill: #172033" transform="translate(621.189137 126.622406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-54"/>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:35:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(573.913449 156.123431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:36:T">
-    <!-- T -->
-    <g style="fill: #172033" transform="translate(631.089248 126.622406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-54"/>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:36:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(582.222471 156.123431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:37:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(640.989359 126.622406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(590.531492 156.123431) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:38:C">
-    <!-- C -->
-    <g style="fill: #172033" transform="translate(650.889469 126.622406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-43"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:39:A">
-    <!-- A -->
-    <g style="fill: #172033" transform="translate(660.78958 126.622406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-41"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:40:T">
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:38:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(670.689691 126.622406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(598.840514 156.123431) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:41:G">
-    <!-- G -->
-    <g style="fill: #172033" transform="translate(680.589802 126.622406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-47"/>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:39:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(607.149535 156.123431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-54"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:40:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(615.458557 156.123431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-41"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:41:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(623.767578 156.123431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:42:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(690.489913 126.622406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(632.0766 156.123431) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:43:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(700.390023 126.622406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(640.385622 156.123431) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:44:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(710.290134 126.622406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(648.694643 156.123431) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:45:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(720.190245 126.622406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(657.003665 156.123431) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:46:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(730.090356 126.622406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(665.312686 156.123431) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
-   <g id="text_19">
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:47:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(673.621708 156.123431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-47"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:48:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(681.930729 156.123431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-54"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:49:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(690.239751 156.123431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-43"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:50:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(698.548772 156.123431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-43"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:51:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(706.857794 156.123431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-41"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:52:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(715.166815 156.123431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-54"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:53:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(723.475837 156.123431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-41"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:54:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(731.784858 156.123431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-54"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:55:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(740.09388 156.123431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-54"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:56:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(748.402902 156.123431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-41"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:57:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(756.711923 156.123431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-47"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:58:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(765.020945 156.123431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-47"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0002:bottom:base:59:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(773.329966 156.123431) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-43"/>
+    </g>
+   </g>
+   <g id="text_18">
     <!-- 5′ -->
-    <g style="fill: #667085" transform="translate(139.317545 113.972062) scale(0.054 -0.054)">
+    <g style="fill: #667085" transform="translate(166.725841 138.20715) scale(0.072 -0.072)">
      <use xlink:href="#DejaVuSans-35"/>
+     <use xlink:href="#DejaVuSans-2032" transform="translate(63.623047 0)"/>
+    </g>
+   </g>
+   <g id="text_19">
+    <!-- 3′ -->
+    <g style="fill: #667085" transform="translate(1050.041779 138.20715) scale(0.072 -0.072)">
+     <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-2032" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_20">
     <!-- 3′ -->
-    <g style="fill: #667085" transform="translate(1057.759488 113.972062) scale(0.054 -0.054)">
+    <g style="fill: #667085" transform="translate(266.434099 155.93715) scale(0.072 -0.072)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-2032" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_21">
-    <!-- 3′ -->
-    <g style="fill: #667085" transform="translate(258.118874 126.608062) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSans-33"/>
-     <use xlink:href="#DejaVuSans-2032" transform="translate(63.623047 0)"/>
-    </g>
-   </g>
-   <g id="text_22">
     <!-- 5′ -->
-    <g style="fill: #667085" transform="translate(740.955943 126.608062) scale(0.054 -0.054)">
+    <g style="fill: #667085" transform="translate(784.15309 155.93715) scale(0.072 -0.072)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-2032" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_23">
-    <!-- F02 -->
-    <g style="fill: #172033" transform="translate(29.22048 109.374281) scale(0.06 -0.06)">
+   <g id="text_22">
+    <!-- F02 · internal -->
+    <g style="fill: #172033" transform="translate(24.957792 135.594337) scale(0.072 -0.072)">
      <defs>
       <path id="DejaVuSans-Bold-32" d="M 1844 884
 L 3897 884
@@ -4027,39 +4579,68 @@ z
      <use xlink:href="#DejaVuSans-Bold-46"/>
      <use xlink:href="#DejaVuSans-Bold-30" transform="translate(68.310547 0)"/>
      <use xlink:href="#DejaVuSans-Bold-32" transform="translate(137.890625 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(207.470703 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-b7" transform="translate(242.285156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(280.273438 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-69" transform="translate(315.087891 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(349.365234 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-74" transform="translate(420.556641 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-65" transform="translate(468.359375 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-72" transform="translate(536.181641 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(585.498047 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-61" transform="translate(656.689453 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6c" transform="translate(724.169922 0)"/>
     </g>
-    <!-- internal -->
-    <g style="fill: #172033" transform="translate(29.22048 116.092969) scale(0.06 -0.06)">
+    <!-- 104 nt / 60 nt -->
+    <g style="fill: #172033" transform="translate(24.957792 143.656762) scale(0.072 -0.072)">
      <defs>
-      <path id="DejaVuSans-Bold-6c" d="M 538 4863
-L 1656 4863
-L 1656 0
-L 538 0
-L 538 4863
+      <path id="DejaVuSans-Bold-34" d="M 2356 3675
+L 1038 1722
+L 2356 1722
+L 2356 3675
+z
+M 2156 4666
+L 3494 4666
+L 3494 1722
+L 4159 1722
+L 4159 850
+L 3494 850
+L 3494 0
+L 2356 0
+L 2356 850
+L 288 850
+L 288 1881
+L 2156 4666
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-Bold-69"/>
-     <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(34.277344 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-74" transform="translate(105.46875 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-65" transform="translate(153.271484 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-72" transform="translate(221.09375 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(270.410156 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-61" transform="translate(341.601562 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-6c" transform="translate(409.082031 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-31"/>
+     <use xlink:href="#DejaVuSans-Bold-30" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-34" transform="translate(139.160156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(208.740234 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(243.554688 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-74" transform="translate(314.746094 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(362.548828 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-2f" transform="translate(397.363281 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(433.886719 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-36" transform="translate(468.701172 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-30" transform="translate(538.28125 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(607.861328 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(642.675781 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-74" transform="translate(713.867188 0)"/>
     </g>
    </g>
-   <g id="text_24">
+   <g id="text_23">
     <!-- b2* -->
-    <g style="fill: #2a9d8f" transform="translate(303.824618 153.211156) scale(0.05 -0.05)">
+    <g style="fill: #1f6f70" transform="translate(341.74156 190.478412) scale(0.068 -0.068)">
      <use xlink:href="#DejaVuSans-62"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.476562 0)"/>
      <use xlink:href="#DejaVuSans-2a" transform="translate(127.099609 0)"/>
     </g>
    </g>
-   <g id="text_25">
+   <g id="text_24">
     <!-- target -->
-    <g style="fill: #667085" transform="translate(751.105829 153.211156) scale(0.05 -0.05)">
+    <g style="fill: #667085" transform="translate(694.71308 190.478412) scale(0.068 -0.068)">
      <use xlink:href="#DejaVuSans-74"/>
      <use xlink:href="#DejaVuSans-61" transform="translate(39.208984 0)"/>
      <use xlink:href="#DejaVuSans-72" transform="translate(100.488281 0)"/>
@@ -4068,17 +4649,17 @@ z
      <use xlink:href="#DejaVuSans-74" transform="translate(264.851562 0)"/>
     </g>
    </g>
-   <g id="text_26">
+   <g id="text_25">
     <!-- t2* -->
-    <g style="fill: #2a9d8f" transform="translate(390.232609 165.847156) scale(0.05 -0.05)">
+    <g style="fill: #8a5a00" transform="translate(392.421252 228.264338) scale(0.068 -0.068)">
      <use xlink:href="#DejaVuSans-74"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(39.208984 0)"/>
      <use xlink:href="#DejaVuSans-2a" transform="translate(102.832031 0)"/>
     </g>
    </g>
-   <g id="text_27">
+   <g id="text_26">
     <!-- target -->
-    <g style="fill: #667085" transform="translate(751.105829 165.847156) scale(0.05 -0.05)">
+    <g style="fill: #667085" transform="translate(694.71308 228.264338) scale(0.068 -0.068)">
      <use xlink:href="#DejaVuSans-74"/>
      <use xlink:href="#DejaVuSans-61" transform="translate(39.208984 0)"/>
      <use xlink:href="#DejaVuSans-72" transform="translate(100.488281 0)"/>
@@ -4087,800 +4668,1071 @@ z
      <use xlink:href="#DejaVuSans-74" transform="translate(264.851562 0)"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:0:A">
-    <!-- A -->
-    <g style="fill: #172033" transform="translate(158.083956 159.616406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-41"/>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:0:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(258.170631 200.803031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:1:T">
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:1:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(266.479652 200.803031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-43"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:2:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(274.788674 200.803031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-47"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:3:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(283.097695 200.803031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-47"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:4:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(172.384116 159.616406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(291.406717 200.803031) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:2:A">
-    <!-- A -->
-    <g style="fill: #172033" transform="translate(186.684276 159.616406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-41"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:3:A">
-    <!-- A -->
-    <g style="fill: #172033" transform="translate(200.984436 159.616406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-41"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:4:G">
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:5:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(215.284596 159.616406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(299.715738 200.803031) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:5:C">
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:6:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(229.584756 159.616406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(308.02476 200.803031) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:6:G">
-    <!-- G -->
-    <g style="fill: #172033" transform="translate(243.884916 159.616406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-47"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:7:C">
-    <!-- C -->
-    <g style="fill: #172033" transform="translate(258.185076 159.616406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-43"/>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:7:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(316.333782 200.803031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:8:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(272.485236 159.616406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(324.642803 200.803031) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:9:A">
-    <!-- A -->
-    <g style="fill: #172033" transform="translate(286.785396 159.616406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-41"/>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:9:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(332.951825 200.803031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:10:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(301.085556 159.616406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(341.260846 200.803031) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:11:C">
-    <!-- C -->
-    <g style="fill: #172033" transform="translate(315.385716 159.616406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-43"/>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:11:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(349.569868 200.803031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:12:T">
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:12:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(357.878889 200.803031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-47"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:13:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(329.685876 159.616406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(366.187911 200.803031) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:13:A">
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:14:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(343.986036 159.616406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(374.496932 200.803031) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-41"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:14:T">
-    <!-- T -->
-    <g style="fill: #172033" transform="translate(358.286196 159.616406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:15:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(372.586356 159.616406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(382.805954 200.803031) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:16:C">
-    <!-- C -->
-    <g style="fill: #172033" transform="translate(386.886516 159.616406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-43"/>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:16:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(391.114975 200.803031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:17:G">
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:17:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(399.423997 200.803031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-54"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:18:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(407.733018 200.803031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-54"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:19:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(401.186676 159.616406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(416.04204 200.803031) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:18:C">
-    <!-- C -->
-    <g style="fill: #172033" transform="translate(415.486836 159.616406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-43"/>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:20:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(424.351062 200.803031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:19:C">
-    <!-- C -->
-    <g style="fill: #172033" transform="translate(429.786996 159.616406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-43"/>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:21:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(432.660083 200.803031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:20:G">
-    <!-- G -->
-    <g style="fill: #172033" transform="translate(444.087156 159.616406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-47"/>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:22:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(440.969105 200.803031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:21:G">
-    <!-- G -->
-    <g style="fill: #172033" transform="translate(458.387316 159.616406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-47"/>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:23:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(449.278126 200.803031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:22:C">
-    <!-- C -->
-    <g style="fill: #172033" transform="translate(472.687476 159.616406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-43"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:23:G">
-    <!-- G -->
-    <g style="fill: #172033" transform="translate(486.987636 159.616406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-47"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:24:C">
-    <!-- C -->
-    <g style="fill: #172033" transform="translate(501.287796 159.616406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-43"/>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:24:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(457.587148 200.803031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:25:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(515.587956 159.616406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(465.896169 200.803031) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:26:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(529.888116 159.616406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(474.205191 200.803031) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:27:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(544.188276 159.616406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(482.514212 200.803031) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:28:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(558.488436 159.616406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(490.823234 200.803031) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:29:A">
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:29:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(499.132255 200.803031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-47"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:30:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(507.441277 200.803031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-47"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:31:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(515.750298 200.803031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-47"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:32:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(572.788596 159.616406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(524.05932 200.803031) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:30:A">
-    <!-- A -->
-    <g style="fill: #172033" transform="translate(587.088756 159.616406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-41"/>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:33:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(532.368342 200.803031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:31:T">
-    <!-- T -->
-    <g style="fill: #172033" transform="translate(601.388916 159.616406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-54"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:32:T">
-    <!-- T -->
-    <g style="fill: #172033" transform="translate(615.689076 159.616406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-54"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:33:T">
-    <!-- T -->
-    <g style="fill: #172033" transform="translate(629.989236 159.616406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-54"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:34:T">
-    <!-- T -->
-    <g style="fill: #172033" transform="translate(644.289396 159.616406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-54"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:35:G">
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:34:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(658.589556 159.616406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(540.677363 200.803031) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:36:G">
-    <!-- G -->
-    <g style="fill: #172033" transform="translate(672.889716 159.616406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-47"/>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:35:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(548.986385 200.803031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:37:G">
-    <!-- G -->
-    <g style="fill: #172033" transform="translate(687.189876 159.616406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-47"/>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:36:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(557.295406 200.803031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-43"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:37:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(565.604428 200.803031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:38:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(701.490036 159.616406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(573.913449 200.803031) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:39:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(715.790196 159.616406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(582.222471 200.803031) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:40:C">
-    <!-- C -->
-    <g style="fill: #172033" transform="translate(730.090356 159.616406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-43"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:41:G">
-    <!-- G -->
-    <g style="fill: #172033" transform="translate(744.390516 159.616406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-47"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:42:C">
-    <!-- C -->
-    <g style="fill: #172033" transform="translate(758.690676 159.616406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-43"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:43:C">
-    <!-- C -->
-    <g style="fill: #172033" transform="translate(772.990836 159.616406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-43"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:44:T">
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:40:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(787.290996 159.616406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(590.531492 200.803031) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-54"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:41:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(598.840514 200.803031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-54"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:42:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(607.149535 200.803031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-41"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:43:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(615.458557 200.803031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-41"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:44:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(623.767578 200.803031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:45:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(801.591156 159.616406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(632.0766 200.803031) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:46:A">
-    <!-- A -->
-    <g style="fill: #172033" transform="translate(815.891316 159.616406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-41"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:47:T">
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:46:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(830.191476 159.616406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(640.385622 200.803031) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:48:T">
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:47:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(648.694643 200.803031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-41"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:48:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(657.003665 200.803031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-47"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:49:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(844.491636 159.616406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(665.312686 200.803031) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:49:A">
-    <!-- A -->
-    <g style="fill: #172033" transform="translate(858.791796 159.616406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-41"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:50:A">
-    <!-- A -->
-    <g style="fill: #172033" transform="translate(873.091956 159.616406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-41"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:51:C">
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:50:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(887.392116 159.616406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(673.621708 200.803031) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-43"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:51:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(681.930729 200.803031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:52:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(901.692276 159.616406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(690.239751 200.803031) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:53:T">
-    <!-- T -->
-    <g style="fill: #172033" transform="translate(915.992436 159.616406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-54"/>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:53:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(698.548772 200.803031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:54:A">
-    <!-- A -->
-    <g style="fill: #172033" transform="translate(930.292596 159.616406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-41"/>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:54:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(706.857794 200.803031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:55:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(944.592756 159.616406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(715.166815 200.803031) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:56:T">
-    <!-- T -->
-    <g style="fill: #172033" transform="translate(958.892916 159.616406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-54"/>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:56:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(723.475837 200.803031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:57:C">
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:57:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(731.784858 200.803031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-41"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:58:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(973.193076 159.616406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(740.09388 200.803031) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-43"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:58:T">
-    <!-- T -->
-    <g style="fill: #172033" transform="translate(987.493236 159.616406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:59:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(1001.793396 159.616406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(748.402902 200.803031) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:60:A">
-    <!-- A -->
-    <g style="fill: #172033" transform="translate(1016.093556 159.616406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-41"/>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:60:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(756.711923 200.803031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:61:T">
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:61:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(765.020945 200.803031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-43"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:62:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(1030.393716 159.616406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(773.329966 200.803031) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:62:G">
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:63:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(781.638988 200.803031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-43"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:64:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(789.948009 200.803031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-54"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:65:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(798.257031 200.803031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-41"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:66:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(1044.693876 159.616406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(806.566052 200.803031) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:0:A">
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:67:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(814.875074 200.803031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-43"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:68:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(823.184095 200.803031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-54"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:69:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(831.493117 200.803031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-43"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:70:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(329.685876 172.252406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(839.802138 200.803031) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-41"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:71:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(848.11116 200.803031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-43"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:72:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(856.420182 200.803031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-43"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:73:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(864.729203 200.803031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-54"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:74:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(873.038225 200.803031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-54"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:75:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(881.347246 200.803031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-47"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:76:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(889.656268 200.803031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-47"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:77:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(897.965289 200.803031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-41"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:78:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(906.274311 200.803031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-54"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:79:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(914.583332 200.803031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-54"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:80:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(922.892354 200.803031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-47"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:81:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(931.201375 200.803031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-41"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:82:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(939.510397 200.803031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-43"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:83:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(947.819418 200.803031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-41"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:84:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(956.12844 200.803031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-47"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:top:base:85:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(964.437462 200.803031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-47"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:0:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(357.878889 218.533031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:1:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(343.986036 172.252406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(366.187911 218.533031) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:2:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(358.286196 172.252406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(374.496932 218.533031) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:3:A">
-    <!-- A -->
-    <g style="fill: #172033" transform="translate(372.586356 172.252406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-41"/>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:3:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(382.805954 218.533031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:4:G">
-    <!-- G -->
-    <g style="fill: #172033" transform="translate(386.886516 172.252406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-47"/>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:4:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(391.114975 218.533031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:5:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(401.186676 172.252406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(399.423997 218.533031) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:6:C">
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:6:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(407.733018 218.533031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-41"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:7:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(416.04204 218.533031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-41"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:8:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(424.351062 218.533031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-41"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:9:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(415.486836 172.252406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(432.660083 218.533031) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:7:T">
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:10:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(429.786996 172.252406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(440.969105 218.533031) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:8:T">
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:11:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(444.087156 172.252406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(449.278126 218.533031) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:9:T">
-    <!-- T -->
-    <g style="fill: #172033" transform="translate(458.387316 172.252406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-54"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:10:G">
-    <!-- G -->
-    <g style="fill: #172033" transform="translate(472.687476 172.252406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-47"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:11:C">
-    <!-- C -->
-    <g style="fill: #172033" transform="translate(486.987636 172.252406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-43"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:12:G">
-    <!-- G -->
-    <g style="fill: #172033" transform="translate(501.287796 172.252406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-47"/>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:12:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(457.587148 218.533031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:13:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(515.587956 172.252406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(465.896169 218.533031) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:14:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(529.888116 172.252406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(474.205191 218.533031) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:15:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(544.188276 172.252406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(482.514212 218.533031) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:16:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(558.488436 172.252406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(490.823234 218.533031) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:17:T">
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:17:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(499.132255 218.533031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-43"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:18:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(507.441277 218.533031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-43"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:19:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(515.750298 218.533031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-43"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:20:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(572.788596 172.252406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(524.05932 218.533031) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:18:T">
-    <!-- T -->
-    <g style="fill: #172033" transform="translate(587.088756 172.252406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-54"/>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:21:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(532.368342 218.533031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:19:A">
-    <!-- A -->
-    <g style="fill: #172033" transform="translate(601.388916 172.252406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-41"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:20:A">
-    <!-- A -->
-    <g style="fill: #172033" transform="translate(615.689076 172.252406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-41"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:21:A">
-    <!-- A -->
-    <g style="fill: #172033" transform="translate(629.989236 172.252406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-41"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:22:A">
-    <!-- A -->
-    <g style="fill: #172033" transform="translate(644.289396 172.252406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-41"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:23:C">
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:22:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(658.589556 172.252406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(540.677363 218.533031) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:24:C">
-    <!-- C -->
-    <g style="fill: #172033" transform="translate(672.889716 172.252406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-43"/>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:23:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(548.986385 218.533031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:25:C">
-    <!-- C -->
-    <g style="fill: #172033" transform="translate(687.189876 172.252406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-43"/>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:24:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(557.295406 218.533031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-47"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:25:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(565.604428 218.533031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:26:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(701.490036 172.252406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(573.913449 218.533031) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:27:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(715.790196 172.252406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(582.222471 218.533031) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:28:G">
-    <!-- G -->
-    <g style="fill: #172033" transform="translate(730.090356 172.252406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-47"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:29:C">
-    <!-- C -->
-    <g style="fill: #172033" transform="translate(744.390516 172.252406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-43"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:30:G">
-    <!-- G -->
-    <g style="fill: #172033" transform="translate(758.690676 172.252406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-47"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:31:G">
-    <!-- G -->
-    <g style="fill: #172033" transform="translate(772.990836 172.252406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-47"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:32:A">
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:28:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(787.290996 172.252406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(590.531492 218.533031) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-41"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:29:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(598.840514 218.533031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-41"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:30:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(607.149535 218.533031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-54"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:31:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(615.458557 218.533031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-54"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:32:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(623.767578 218.533031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:33:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(801.591156 172.252406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(632.0766 218.533031) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:34:T">
-    <!-- T -->
-    <g style="fill: #172033" transform="translate(815.891316 172.252406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-54"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:35:A">
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:34:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(830.191476 172.252406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(640.385622 218.533031) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:36:A">
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:35:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(648.694643 218.533031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-54"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:36:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(657.003665 218.533031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-43"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:37:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(844.491636 172.252406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(665.312686 218.533031) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:37:T">
-    <!-- T -->
-    <g style="fill: #172033" transform="translate(858.791796 172.252406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-54"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:38:T">
-    <!-- T -->
-    <g style="fill: #172033" transform="translate(873.091956 172.252406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-54"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:39:G">
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:38:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(887.392116 172.252406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(673.621708 218.533031) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-47"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:39:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(681.930729 218.533031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:40:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(901.692276 172.252406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(690.239751 218.533031) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:41:A">
-    <!-- A -->
-    <g style="fill: #172033" transform="translate(915.992436 172.252406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-41"/>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:41:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(698.548772 218.533031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:42:T">
-    <!-- T -->
-    <g style="fill: #172033" transform="translate(930.292596 172.252406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-54"/>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:42:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(706.857794 218.533031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:43:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(944.592756 172.252406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(715.166815 218.533031) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:44:A">
-    <!-- A -->
-    <g style="fill: #172033" transform="translate(958.892916 172.252406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-41"/>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:44:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(723.475837 218.533031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:45:G">
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:45:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(731.784858 218.533031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-54"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:46:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(973.193076 172.252406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(740.09388 218.533031) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-47"/>
-    </g>
-   </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:46:A">
-    <!-- A -->
-    <g style="fill: #172033" transform="translate(987.493236 172.252406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
    <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:47:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(1001.793396 172.252406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(748.402902 218.533031) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:48:T">
-    <!-- T -->
-    <g style="fill: #172033" transform="translate(1016.093556 172.252406) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSansMono-54"/>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:48:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(756.711923 218.533031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:49:A">
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:49:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(765.020945 218.533031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-47"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:50:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(1030.393716 172.252406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(773.329966 218.533031) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
-   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:50:C">
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:51:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(781.638988 218.533031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-47"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:52:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(789.948009 218.533031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-41"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:53:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(798.257031 218.533031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-54"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:54:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(1044.693876 172.252406) scale(0.054 -0.054)">
+    <g style="fill: #172033" transform="translate(806.566052 218.533031) scale(0.078 -0.078)">
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
-   <g id="text_28">
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:55:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(814.875074 218.533031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-47"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:56:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(823.184095 218.533031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-41"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:57:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(831.493117 218.533031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-47"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:58:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(839.802138 218.533031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-54"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:59:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(848.11116 218.533031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-47"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:60:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(856.420182 218.533031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-47"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:61:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(864.729203 218.533031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-41"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:62:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(873.038225 218.533031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-41"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:63:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(881.347246 218.533031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-43"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:64:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(889.656268 218.533031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-43"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:65:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(897.965289 218.533031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-54"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:66:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(906.274311 218.533031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-41"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:67:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(914.583332 218.533031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-41"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:68:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(922.892354 218.533031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-43"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:69:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(931.201375 218.533031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-54"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:70:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(939.510397 218.533031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-47"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:71:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(947.819418 218.533031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-54"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:72:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(956.12844 218.533031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-43"/>
+    </g>
+   </g>
+   <g id="junction-annealed:synthetic-three-fragment-target:fragment-0003:bottom:base:73:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(964.437462 218.533031) scale(0.078 -0.078)">
+     <use xlink:href="#DejaVuSansMono-43"/>
+    </g>
+   </g>
+   <g id="text_27">
     <!-- 5′ -->
-    <g style="fill: #667085" transform="translate(139.317545 159.602062) scale(0.054 -0.054)">
+    <g style="fill: #667085" transform="translate(241.507034 200.61675) scale(0.072 -0.072)">
      <use xlink:href="#DejaVuSans-35"/>
+     <use xlink:href="#DejaVuSans-2032" transform="translate(63.623047 0)"/>
+    </g>
+   </g>
+   <g id="text_28">
+    <!-- 3′ -->
+    <g style="fill: #667085" transform="translate(975.260585 200.61675) scale(0.072 -0.072)">
+     <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-2032" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_29">
     <!-- 3′ -->
-    <g style="fill: #667085" transform="translate(1057.759488 159.602062) scale(0.054 -0.054)">
+    <g style="fill: #667085" transform="translate(341.215293 218.34675) scale(0.072 -0.072)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-2032" transform="translate(63.623047 0)"/>
     </g>
    </g>
    <g id="text_30">
-    <!-- 3′ -->
-    <g style="fill: #667085" transform="translate(310.919465 172.238062) scale(0.054 -0.054)">
-     <use xlink:href="#DejaVuSans-33"/>
-     <use xlink:href="#DejaVuSans-2032" transform="translate(63.623047 0)"/>
-    </g>
-   </g>
-   <g id="text_31">
     <!-- 5′ -->
-    <g style="fill: #667085" transform="translate(1057.759488 172.238062) scale(0.054 -0.054)">
+    <g style="fill: #667085" transform="translate(975.260585 218.34675) scale(0.072 -0.072)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-2032" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_32">
-    <!-- F03 -->
-    <g style="fill: #172033" transform="translate(29.22048 155.004281) scale(0.06 -0.06)">
-     <defs>
-      <path id="DejaVuSans-Bold-33" d="M 2981 2516
-Q 3453 2394 3698 2092
-Q 3944 1791 3944 1325
-Q 3944 631 3412 270
-Q 2881 -91 1863 -91
-Q 1503 -91 1142 -33
-Q 781 25 428 141
-L 428 1069
-Q 766 900 1098 814
-Q 1431 728 1753 728
-Q 2231 728 2486 893
-Q 2741 1059 2741 1369
-Q 2741 1688 2480 1852
-Q 2219 2016 1709 2016
-L 1228 2016
-L 1228 2791
-L 1734 2791
-Q 2188 2791 2409 2933
-Q 2631 3075 2631 3366
-Q 2631 3634 2415 3781
-Q 2200 3928 1806 3928
-Q 1516 3928 1219 3862
-Q 922 3797 628 3669
-L 628 4550
-Q 984 4650 1334 4700
-Q 1684 4750 2022 4750
-Q 2931 4750 3382 4451
-Q 3834 4153 3834 3553
-Q 3834 3144 3618 2883
-Q 3403 2622 2981 2516
-z
-" transform="scale(0.015625)"/>
-     </defs>
+   <g id="text_31">
+    <!-- F03 · last -->
+    <g style="fill: #172033" transform="translate(24.957792 198.003938) scale(0.072 -0.072)">
      <use xlink:href="#DejaVuSans-Bold-46"/>
      <use xlink:href="#DejaVuSans-Bold-30" transform="translate(68.310547 0)"/>
      <use xlink:href="#DejaVuSans-Bold-33" transform="translate(137.890625 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(207.470703 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-b7" transform="translate(242.285156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(280.273438 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6c" transform="translate(315.087891 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-61" transform="translate(349.365234 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-73" transform="translate(416.845703 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-74" transform="translate(476.367188 0)"/>
     </g>
-    <!-- last -->
-    <g style="fill: #172033" transform="translate(29.22048 161.722969) scale(0.06 -0.06)">
-     <use xlink:href="#DejaVuSans-Bold-6c"/>
-     <use xlink:href="#DejaVuSans-Bold-61" transform="translate(34.277344 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-73" transform="translate(101.757812 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-74" transform="translate(161.279297 0)"/>
+    <!-- 86 nt / 74 nt -->
+    <g style="fill: #172033" transform="translate(24.957792 206.066362) scale(0.072 -0.072)">
+     <defs>
+      <path id="DejaVuSans-Bold-37" d="M 428 4666
+L 3944 4666
+L 3944 3988
+L 2125 0
+L 953 0
+L 2675 3781
+L 428 3781
+L 428 4666
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-Bold-38"/>
+     <use xlink:href="#DejaVuSans-Bold-36" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(139.160156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(173.974609 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-74" transform="translate(245.166016 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(292.96875 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-2f" transform="translate(327.783203 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(364.306641 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-37" transform="translate(399.121094 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-34" transform="translate(468.701172 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(538.28125 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(573.095703 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-74" transform="translate(644.287109 0)"/>
     </g>
    </g>
-   <g id="text_33">
-    <!-- Sequence-derived pairing schematic; not a thermodynamic prediction or experimental result. -->
-    <g style="fill: #667085" transform="translate(29.22048 216.534188) scale(0.06 -0.06)">
+   <g id="text_32">
+    <!-- Base pairing is sequence-derived and does not establish thermodynamic or experimental success -->
+    <g style="fill: #667085" transform="translate(24.957792 284.90705) scale(0.08 -0.08)">
      <defs>
-      <path id="DejaVuSans-53" d="M 3425 4513
-L 3425 3897
-Q 3066 4069 2747 4153
-Q 2428 4238 2131 4238
-Q 1616 4238 1336 4038
-Q 1056 3838 1056 3469
-Q 1056 3159 1242 3001
-Q 1428 2844 1947 2747
-L 2328 2669
-Q 3034 2534 3370 2195
-Q 3706 1856 3706 1288
-Q 3706 609 3251 259
-Q 2797 -91 1919 -91
-Q 1588 -91 1214 -16
-Q 841 59 441 206
-L 441 856
-Q 825 641 1194 531
-Q 1563 422 1919 422
-Q 2459 422 2753 634
-Q 3047 847 3047 1241
-Q 3047 1584 2836 1778
-Q 2625 1972 2144 2069
-L 1759 2144
-Q 1053 2284 737 2584
-Q 422 2884 422 3419
-Q 422 4038 858 4394
-Q 1294 4750 2059 4750
-Q 2388 4750 2728 4690
-Q 3069 4631 3425 4513
+      <path id="DejaVuSans-42" d="M 1259 2228
+L 1259 519
+L 2272 519
+Q 2781 519 3026 730
+Q 3272 941 3272 1375
+Q 3272 1813 3026 2020
+Q 2781 2228 2272 2228
+L 1259 2228
+z
+M 1259 4147
+L 1259 2741
+L 2194 2741
+Q 2656 2741 2882 2914
+Q 3109 3088 3109 3444
+Q 3109 3797 2882 3972
+Q 2656 4147 2194 4147
+L 1259 4147
+z
+M 628 4666
+L 2241 4666
+Q 2963 4666 3353 4366
+Q 3744 4066 3744 3513
+Q 3744 3084 3544 2831
+Q 3344 2578 2956 2516
+Q 3422 2416 3680 2098
+Q 3938 1781 3938 1306
+Q 3938 681 3513 340
+Q 3088 0 2303 0
+L 628 0
+L 628 4666
 z
 " transform="scale(0.015625)"/>
       <path id="DejaVuSans-71" d="M 947 1747
@@ -4909,41 +5761,38 @@ L 2906 -1331
 L 2906 525
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-75" d="M 544 1381
-L 544 3500
-L 1119 3500
-L 1119 1403
-Q 1119 906 1312 657
-Q 1506 409 1894 409
-Q 2359 409 2629 706
-Q 2900 1003 2900 1516
-L 2900 3500
-L 3475 3500
-L 3475 0
-L 2900 0
-L 2900 538
-Q 2691 219 2414 64
-Q 2138 -91 1772 -91
-Q 1169 -91 856 284
-Q 544 659 544 1381
-z
-M 1991 3584
-L 1991 3584
+      <path id="DejaVuSans-2d" d="M 313 2009
+L 1997 2009
+L 1997 1497
+L 313 1497
+L 313 2009
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-3b" d="M 750 3309
-L 1409 3309
-L 1409 2516
-L 750 2516
-L 750 3309
+      <path id="DejaVuSans-76" d="M 191 3500
+L 800 3500
+L 1894 563
+L 2988 3500
+L 3597 3500
+L 2284 0
+L 1503 0
+L 191 3500
 z
-M 750 794
-L 1409 794
-L 1409 256
-L 897 -744
-L 494 -744
-L 750 256
-L 750 794
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-79" d="M 2059 -325
+Q 1816 -950 1584 -1140
+Q 1353 -1331 966 -1331
+L 506 -1331
+L 506 -850
+L 844 -850
+Q 1081 -850 1212 -737
+Q 1344 -625 1503 -206
+L 1606 56
+L 191 3500
+L 800 3500
+L 1894 763
+L 2988 3500
+L 3597 3500
+L 2059 -325
 z
 " transform="scale(0.015625)"/>
       <path id="DejaVuSans-78" d="M 3513 3500
@@ -4962,103 +5811,288 @@ L 3513 3500
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-53"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(63.476562 0)"/>
-     <use xlink:href="#DejaVuSans-71" transform="translate(125 0)"/>
-     <use xlink:href="#DejaVuSans-75" transform="translate(188.476562 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(251.855469 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(313.378906 0)"/>
-     <use xlink:href="#DejaVuSans-63" transform="translate(376.757812 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(431.738281 0)"/>
-     <use xlink:href="#DejaVuSans-2d" transform="translate(493.261719 0)"/>
-     <use xlink:href="#DejaVuSans-64" transform="translate(529.345703 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(592.822266 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(654.345703 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(695.458984 0)"/>
-     <use xlink:href="#DejaVuSans-76" transform="translate(723.242188 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(782.421875 0)"/>
-     <use xlink:href="#DejaVuSans-64" transform="translate(843.945312 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(907.421875 0)"/>
-     <use xlink:href="#DejaVuSans-70" transform="translate(939.208984 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(1002.685547 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(1063.964844 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(1091.748047 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(1132.861328 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(1160.644531 0)"/>
-     <use xlink:href="#DejaVuSans-67" transform="translate(1224.023438 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(1287.5 0)"/>
-     <use xlink:href="#DejaVuSans-73" transform="translate(1319.287109 0)"/>
-     <use xlink:href="#DejaVuSans-63" transform="translate(1371.386719 0)"/>
-     <use xlink:href="#DejaVuSans-68" transform="translate(1426.367188 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(1489.746094 0)"/>
-     <use xlink:href="#DejaVuSans-6d" transform="translate(1551.269531 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(1648.681641 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(1709.960938 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(1749.169922 0)"/>
-     <use xlink:href="#DejaVuSans-63" transform="translate(1776.953125 0)"/>
-     <use xlink:href="#DejaVuSans-3b" transform="translate(1831.933594 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(1865.625 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(1897.412109 0)"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(1960.791016 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(2021.972656 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(2061.181641 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(2092.96875 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(2154.248047 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(2186.035156 0)"/>
-     <use xlink:href="#DejaVuSans-68" transform="translate(2225.244141 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(2288.623047 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(2350.146484 0)"/>
-     <use xlink:href="#DejaVuSans-6d" transform="translate(2389.509766 0)"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(2486.921875 0)"/>
-     <use xlink:href="#DejaVuSans-64" transform="translate(2548.103516 0)"/>
-     <use xlink:href="#DejaVuSans-79" transform="translate(2611.580078 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(2670.759766 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(2734.138672 0)"/>
-     <use xlink:href="#DejaVuSans-6d" transform="translate(2795.417969 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(2892.830078 0)"/>
-     <use xlink:href="#DejaVuSans-63" transform="translate(2920.613281 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(2975.59375 0)"/>
-     <use xlink:href="#DejaVuSans-70" transform="translate(3007.380859 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(3070.857422 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(3109.720703 0)"/>
-     <use xlink:href="#DejaVuSans-64" transform="translate(3171.244141 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(3234.720703 0)"/>
-     <use xlink:href="#DejaVuSans-63" transform="translate(3262.503906 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(3317.484375 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(3356.693359 0)"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(3384.476562 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(3445.658203 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(3509.037109 0)"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(3540.824219 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(3602.005859 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(3643.119141 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(3674.90625 0)"/>
-     <use xlink:href="#DejaVuSans-78" transform="translate(3734.679688 0)"/>
-     <use xlink:href="#DejaVuSans-70" transform="translate(3793.859375 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(3857.335938 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(3918.859375 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(3959.972656 0)"/>
-     <use xlink:href="#DejaVuSans-6d" transform="translate(3987.755859 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(4085.167969 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(4146.691406 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(4210.070312 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(4249.279297 0)"/>
-     <use xlink:href="#DejaVuSans-6c" transform="translate(4310.558594 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(4338.341797 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(4370.128906 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(4408.992188 0)"/>
-     <use xlink:href="#DejaVuSans-73" transform="translate(4470.515625 0)"/>
-     <use xlink:href="#DejaVuSans-75" transform="translate(4522.615234 0)"/>
-     <use xlink:href="#DejaVuSans-6c" transform="translate(4585.994141 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(4613.777344 0)"/>
-     <use xlink:href="#DejaVuSans-2e" transform="translate(4652.986328 0)"/>
+     <use xlink:href="#DejaVuSans-42"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(68.603516 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(129.882812 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(181.982422 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(243.505859 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(275.292969 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(338.769531 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(400.048828 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(427.832031 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(468.945312 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(496.728516 0)"/>
+     <use xlink:href="#DejaVuSans-67" transform="translate(560.107422 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(623.583984 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(655.371094 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(683.154297 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(735.253906 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(767.041016 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(819.140625 0)"/>
+     <use xlink:href="#DejaVuSans-71" transform="translate(880.664062 0)"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(944.140625 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(1007.519531 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(1069.042969 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(1132.421875 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(1187.402344 0)"/>
+     <use xlink:href="#DejaVuSans-2d" transform="translate(1248.925781 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(1285.009766 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(1348.486328 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(1410.009766 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(1451.123047 0)"/>
+     <use xlink:href="#DejaVuSans-76" transform="translate(1478.90625 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(1538.085938 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(1599.609375 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1663.085938 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(1694.873047 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(1756.152344 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(1819.53125 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1883.007812 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(1914.794922 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(1978.271484 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(2039.453125 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(2100.976562 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2153.076172 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(2184.863281 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(2248.242188 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(2309.423828 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2348.632812 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(2380.419922 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(2441.943359 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(2494.042969 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(2533.251953 0)"/>
+     <use xlink:href="#DejaVuSans-62" transform="translate(2594.53125 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(2658.007812 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(2685.791016 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(2713.574219 0)"/>
+     <use xlink:href="#DejaVuSans-68" transform="translate(2765.673828 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2829.052734 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(2860.839844 0)"/>
+     <use xlink:href="#DejaVuSans-68" transform="translate(2900.048828 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(2963.427734 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(3024.951172 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(3064.314453 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(3161.726562 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(3222.908203 0)"/>
+     <use xlink:href="#DejaVuSans-79" transform="translate(3286.384766 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(3345.564453 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(3408.943359 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(3470.222656 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(3567.634766 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(3595.417969 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3650.398438 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(3682.185547 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(3743.367188 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3784.480469 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(3816.267578 0)"/>
+     <use xlink:href="#DejaVuSans-78" transform="translate(3876.041016 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(3935.220703 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(3998.697266 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(4060.220703 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(4101.333984 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(4129.117188 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(4226.529297 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(4288.052734 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(4351.431641 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(4390.640625 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(4451.919922 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(4479.703125 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(4511.490234 0)"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(4563.589844 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(4626.96875 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(4681.949219 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(4736.929688 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(4798.453125 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(4850.552734 0)"/>
     </g>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p7877afe5bc">
-   <rect x="13.1328" y="2.268" width="1072.512" height="221.13"/>
+  <clipPath id="pf6c431ed3d">
+   <rect x="8.7552" y="1.4724" width="1080.1728" height="290.0628"/>
+  </clipPath>
+  <clipPath id="pd8a1ada235">
+   <path d="M 276.721145 78.4206
+L 950.582791 78.4206
+Q 1020.794023 78.4206 1020.794023 73.8108
+L 1020.794023 73.8108
+Q 1020.794023 69.201 950.582791 69.201
+L 276.721145 69.201
+Q 206.509913 69.201 206.509913 73.8108
+L 206.509913 73.8108
+Q 206.509913 78.4206 276.721145 78.4206
+z
+"/>
+  </clipPath>
+  <clipPath id="p629e5de9df">
+   <path d="M 276.721145 78.4206
+L 950.582791 78.4206
+Q 1020.794023 78.4206 1020.794023 73.8108
+L 1020.794023 73.8108
+Q 1020.794023 69.201 950.582791 69.201
+L 276.721145 69.201
+Q 206.509913 69.201 206.509913 73.8108
+L 206.509913 73.8108
+Q 206.509913 78.4206 276.721145 78.4206
+z
+"/>
+  </clipPath>
+  <clipPath id="p1d5d9186c3">
+   <path d="M 276.721145 78.4206
+L 950.582791 78.4206
+Q 1020.794023 78.4206 1020.794023 73.8108
+L 1020.794023 73.8108
+Q 1020.794023 69.201 950.582791 69.201
+L 276.721145 69.201
+Q 206.509913 69.201 206.509913 73.8108
+L 206.509913 73.8108
+Q 206.509913 78.4206 276.721145 78.4206
+z
+"/>
+  </clipPath>
+  <clipPath id="p1cada285ad">
+   <path d="M 276.721145 96.1506
+L 684.694102 96.1506
+Q 754.905334 96.1506 754.905334 91.5408
+L 754.905334 91.5408
+Q 754.905334 86.931 684.694102 86.931
+L 276.721145 86.931
+Q 206.509913 86.931 206.509913 91.5408
+L 206.509913 91.5408
+Q 206.509913 96.1506 276.721145 96.1506
+z
+"/>
+  </clipPath>
+  <clipPath id="p19ee901b5b">
+   <path d="M 251.79408 140.8302
+L 975.509856 140.8302
+Q 1045.721088 140.8302 1045.721088 136.2204
+L 1045.721088 136.2204
+Q 1045.721088 131.6106 975.509856 131.6106
+L 251.79408 131.6106
+Q 181.582848 131.6106 181.582848 136.2204
+L 181.582848 136.2204
+Q 181.582848 140.8302 251.79408 140.8302
+z
+"/>
+  </clipPath>
+  <clipPath id="p4a7f553509">
+   <path d="M 251.79408 140.8302
+L 975.509856 140.8302
+Q 1045.721088 140.8302 1045.721088 136.2204
+L 1045.721088 136.2204
+Q 1045.721088 131.6106 975.509856 131.6106
+L 251.79408 131.6106
+Q 181.582848 131.6106 181.582848 136.2204
+L 181.582848 136.2204
+Q 181.582848 140.8302 251.79408 140.8302
+z
+"/>
+  </clipPath>
+  <clipPath id="pbc837e291f">
+   <path d="M 251.79408 140.8302
+L 975.509856 140.8302
+Q 1045.721088 140.8302 1045.721088 136.2204
+L 1045.721088 136.2204
+Q 1045.721088 131.6106 975.509856 131.6106
+L 251.79408 131.6106
+Q 181.582848 131.6106 181.582848 136.2204
+L 181.582848 136.2204
+Q 181.582848 140.8302 251.79408 140.8302
+z
+"/>
+  </clipPath>
+  <clipPath id="p9a115cdbd8">
+   <path d="M 251.79408 140.8302
+L 975.509856 140.8302
+Q 1045.721088 140.8302 1045.721088 136.2204
+L 1045.721088 136.2204
+Q 1045.721088 131.6106 975.509856 131.6106
+L 251.79408 131.6106
+Q 181.582848 131.6106 181.582848 136.2204
+L 181.582848 136.2204
+Q 181.582848 140.8302 251.79408 140.8302
+z
+"/>
+  </clipPath>
+  <clipPath id="pb20e9e7f38">
+   <path d="M 351.502338 158.5602
+L 709.621167 158.5602
+Q 779.832399 158.5602 779.832399 153.9504
+L 779.832399 153.9504
+Q 779.832399 149.3406 709.621167 149.3406
+L 351.502338 149.3406
+Q 281.291106 149.3406 281.291106 153.9504
+L 281.291106 153.9504
+Q 281.291106 158.5602 351.502338 158.5602
+z
+"/>
+  </clipPath>
+  <clipPath id="p4f6db620b5">
+   <path d="M 351.502338 158.5602
+L 709.621167 158.5602
+Q 779.832399 158.5602 779.832399 153.9504
+L 779.832399 153.9504
+Q 779.832399 149.3406 709.621167 149.3406
+L 351.502338 149.3406
+Q 281.291106 149.3406 281.291106 153.9504
+L 281.291106 153.9504
+Q 281.291106 158.5602 351.502338 158.5602
+z
+"/>
+  </clipPath>
+  <clipPath id="pe2245db88e">
+   <path d="M 326.575274 203.2398
+L 900.728662 203.2398
+Q 970.939894 203.2398 970.939894 198.63
+L 970.939894 198.63
+Q 970.939894 194.0202 900.728662 194.0202
+L 326.575274 194.0202
+Q 256.364042 194.0202 256.364042 198.63
+L 256.364042 198.63
+Q 256.364042 203.2398 326.575274 203.2398
+z
+"/>
+  </clipPath>
+  <clipPath id="p76b0274912">
+   <path d="M 326.575274 203.2398
+L 900.728662 203.2398
+Q 970.939894 203.2398 970.939894 198.63
+L 970.939894 198.63
+Q 970.939894 194.0202 900.728662 194.0202
+L 326.575274 194.0202
+Q 256.364042 194.0202 256.364042 198.63
+L 256.364042 198.63
+Q 256.364042 203.2398 326.575274 203.2398
+z
+"/>
+  </clipPath>
+  <clipPath id="p2a8ba0e3ce">
+   <path d="M 426.283532 220.9698
+L 900.728662 220.9698
+Q 970.939894 220.9698 970.939894 216.36
+L 970.939894 216.36
+Q 970.939894 211.7502 900.728662 211.7502
+L 426.283532 211.7502
+Q 356.0723 211.7502 356.0723 216.36
+L 356.0723 216.36
+Q 356.0723 220.9698 426.283532 220.9698
+z
+"/>
+  </clipPath>
+  <clipPath id="p743fcea6e1">
+   <path d="M 426.283532 220.9698
+L 900.728662 220.9698
+Q 970.939894 220.9698 970.939894 216.36
+L 970.939894 216.36
+Q 970.939894 211.7502 900.728662 211.7502
+L 426.283532 211.7502
+Q 356.0723 211.7502 356.0723 216.36
+L 356.0723 216.36
+Q 356.0723 220.9698 426.283532 220.9698
+z
+"/>
   </clipPath>
  </defs>
 </svg>

--- a/src/dnadesign/junction/docs/assets/assembly-overview.svg
+++ b/src/dnadesign/junction/docs/assets/assembly-overview.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="1094.4pt" height="302.4pt" viewBox="0 0 1094.4 302.4" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="1094.4pt" height="345.6pt" viewBox="0 0 1094.4 345.6" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -20,91 +20,236 @@
  </defs>
  <g id="figure_1">
   <g id="patch_1">
-   <path d="M 0 302.4
-L 1094.4 302.4
+   <path d="M 0 345.6
+L 1094.4 345.6
 L 1094.4 0
 L 0 0
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="junction-three-way-assembly:overview">
-   <g id="line2d_1">
-    <path d="M 69.93216 160.09056
-L 1045.91808 160.09056
-" clip-path="url(#p1b5c04efdb)" style="fill: none; stroke: #6b7280; stroke-width: 4.2"/>
-   </g>
-   <g id="line2d_2">
-    <path d="M 69.93216 183.79872
-L 1045.91808 183.79872
-" clip-path="url(#p1b5c04efdb)" style="fill: none; stroke: #9aa1aa; stroke-width: 4.2"/>
-   </g>
-   <g id="patch_2">
-    <path d="M 69.93216 167.203008
-L 483.290903 167.203008
-L 483.290903 152.978112
-L 69.93216 152.978112
+   <g id="junction-three-way-assembly:target:top:body">
+    <path d="M 97.817472 191.766528
+L 1018.032768 191.766528
+Q 1045.91808 191.766528 1045.91808 182.96064
+L 1045.91808 182.96064
+Q 1045.91808 174.154752 1018.032768 174.154752
+L 97.817472 174.154752
+Q 69.93216 174.154752 69.93216 182.96064
+L 69.93216 182.96064
+Q 69.93216 191.766528 97.817472 191.766528
 z
-" clip-path="url(#p1b5c04efdb)" style="fill: #e2e6eb"/>
+" clip-path="url(#p93cbc2dd8a)" style="fill: #e8ebef; stroke: #7c8798; stroke-width: 0.7; stroke-linejoin: miter"/>
    </g>
-   <g id="patch_3">
-    <path d="M 540.701839 167.203008
-L 753.122304 167.203008
-L 753.122304 152.978112
-L 540.701839 152.978112
+   <g id="junction-three-way-assembly:target:bottom:body">
+    <path d="M 97.817472 225.635328
+L 1018.032768 225.635328
+Q 1045.91808 225.635328 1045.91808 216.82944
+L 1045.91808 216.82944
+Q 1045.91808 208.023552 1018.032768 208.023552
+L 97.817472 208.023552
+Q 69.93216 208.023552 69.93216 216.82944
+L 69.93216 216.82944
+Q 69.93216 225.635328 97.817472 225.635328
 z
-" clip-path="url(#p1b5c04efdb)" style="fill: #d5dbe2"/>
+" clip-path="url(#p93cbc2dd8a)" style="fill: #e8ebef; stroke: #7c8798; stroke-width: 0.7; stroke-linejoin: miter"/>
    </g>
-   <g id="patch_4">
-    <path d="M 810.53324 167.203008
-L 1045.91808 167.203008
-L 1045.91808 152.978112
-L 810.53324 152.978112
+   <g id="junction-three-way-assembly:target:top:segment:0">
+    <path d="M 69.93216 191.766528
+L 392.007514 191.766528
+L 392.007514 174.154752
+L 69.93216 174.154752
 z
-" clip-path="url(#p1b5c04efdb)" style="fill: #e2e6eb"/>
+" clip-path="url(#pb5fea5629a)" style="fill: #e8ebef"/>
    </g>
-   <g id="line2d_3">
-    <path d="M 535.339279 160.09056
-L 535.339279 83.03904
-" clip-path="url(#p1b5c04efdb)" style="fill: none; stroke: #4e79a7; stroke-width: 3.2; stroke-linecap: round"/>
+   <g id="junction-three-way-assembly:target:top:segment:1">
+    <path d="M 392.007514 191.766528
+L 440.80681 191.766528
+L 440.80681 174.154752
+L 392.007514 174.154752
+z
+" clip-path="url(#pabf2ef6fb0)" style="fill: #f3d6a1"/>
    </g>
-   <g id="line2d_4">
-    <path d="M 546.064399 160.09056
-L 546.064399 83.03904
-" clip-path="url(#p1b5c04efdb)" style="fill: none; stroke: #4e79a7; stroke-opacity: 0.68; stroke-width: 3.2; stroke-linecap: round"/>
+   <g id="junction-three-way-assembly:target:top:segment:2">
+    <path d="M 440.80681 191.766528
+L 684.80329 191.766528
+L 684.80329 174.154752
+L 440.80681 174.154752
+z
+" clip-path="url(#p8aee74c80a)" style="fill: #e8ebef"/>
    </g>
-   <g id="line2d_5">
-    <path d="M 540.701839 191.20752
-L 540.701839 176.38992
-" clip-path="url(#p1b5c04efdb)" style="fill: none; stroke: #172033; stroke-linecap: square"/>
+   <g id="junction-three-way-assembly:target:top:segment:3">
+    <path d="M 684.80329 191.766528
+L 733.602586 191.766528
+L 733.602586 174.154752
+L 684.80329 174.154752
+z
+" clip-path="url(#pd829a155ec)" style="fill: #f3d6a1"/>
    </g>
-   <g id="line2d_6">
-    <path d="M 805.17068 160.09056
-L 805.17068 83.03904
-" clip-path="url(#p1b5c04efdb)" style="fill: none; stroke: #2a9d8f; stroke-width: 3.2; stroke-linecap: round"/>
+   <g id="junction-three-way-assembly:target:top:segment:4">
+    <path d="M 733.602586 191.766528
+L 1045.91808 191.766528
+L 1045.91808 174.154752
+L 733.602586 174.154752
+z
+" clip-path="url(#p5db4f402a5)" style="fill: #e8ebef"/>
    </g>
-   <g id="line2d_7">
-    <path d="M 815.8958 160.09056
-L 815.8958 83.03904
-" clip-path="url(#p1b5c04efdb)" style="fill: none; stroke: #2a9d8f; stroke-opacity: 0.68; stroke-width: 3.2; stroke-linecap: round"/>
+   <g id="junction-three-way-assembly:target:bottom:segment:0">
+    <path d="M 69.93216 225.635328
+L 392.007514 225.635328
+L 392.007514 208.023552
+L 69.93216 208.023552
+z
+" clip-path="url(#pbdf66af590)" style="fill: #e8ebef"/>
    </g>
-   <g id="line2d_8">
-    <path d="M 810.53324 191.20752
-L 810.53324 176.38992
-" clip-path="url(#p1b5c04efdb)" style="fill: none; stroke: #172033; stroke-linecap: square"/>
+   <g id="junction-three-way-assembly:target:bottom:segment:1">
+    <path d="M 392.007514 225.635328
+L 440.80681 225.635328
+L 440.80681 208.023552
+L 392.007514 208.023552
+z
+" clip-path="url(#p5288c438b0)" style="fill: #f3d6a1"/>
+   </g>
+   <g id="junction-three-way-assembly:target:bottom:segment:2">
+    <path d="M 440.80681 225.635328
+L 684.80329 225.635328
+L 684.80329 208.023552
+L 440.80681 208.023552
+z
+" clip-path="url(#p7673eb6e4d)" style="fill: #e8ebef"/>
+   </g>
+   <g id="junction-three-way-assembly:target:bottom:segment:3">
+    <path d="M 684.80329 225.635328
+L 733.602586 225.635328
+L 733.602586 208.023552
+L 684.80329 208.023552
+z
+" clip-path="url(#pa5a05a162e)" style="fill: #f3d6a1"/>
+   </g>
+   <g id="junction-three-way-assembly:target:bottom:segment:4">
+    <path d="M 733.602586 225.635328
+L 1045.91808 225.635328
+L 1045.91808 208.023552
+L 733.602586 208.023552
+z
+" clip-path="url(#p9a08d979ee)" style="fill: #e8ebef"/>
+   </g>
+   <g id="junction-three-way-assembly:synthetic-three-fragment-target:junction-0001:barcode">
+    <path d="M 436.731264 182.96064
+L 436.731264 108.44928
+" clip-path="url(#p93cbc2dd8a)" style="fill: none; stroke: #a9d8d5; stroke-width: 7; stroke-linecap: round"/>
+   </g>
+   <g id="junction-three-way-assembly:synthetic-three-fragment-target:junction-0001:barcode-complement">
+    <path d="M 444.882355 108.44928
+L 444.882355 182.96064
+" clip-path="url(#p93cbc2dd8a)" style="fill: none; stroke: #a9d8d5; stroke-width: 7; stroke-linecap: round"/>
+   </g>
+   <g id="junction-three-way-assembly:synthetic-three-fragment-target:junction-0002:barcode">
+    <path d="M 729.52704 182.96064
+L 729.52704 108.44928
+" clip-path="url(#p93cbc2dd8a)" style="fill: none; stroke: #a9d8d5; stroke-width: 7; stroke-linecap: round"/>
+   </g>
+   <g id="junction-three-way-assembly:synthetic-three-fragment-target:junction-0002:barcode-complement">
+    <path d="M 737.678131 108.44928
+L 737.678131 182.96064
+" clip-path="url(#p93cbc2dd8a)" style="fill: none; stroke: #a9d8d5; stroke-width: 7; stroke-linecap: round"/>
+   </g>
+   <g id="junction-three-way-assembly:target:top:outline">
+    <path d="M 97.817472 191.766528
+L 1018.032768 191.766528
+Q 1045.91808 191.766528 1045.91808 182.96064
+L 1045.91808 182.96064
+Q 1045.91808 174.154752 1018.032768 174.154752
+L 97.817472 174.154752
+Q 69.93216 174.154752 69.93216 182.96064
+L 69.93216 182.96064
+Q 69.93216 191.766528 97.817472 191.766528
+L 97.817472 191.766528
+z
+" clip-path="url(#p93cbc2dd8a)" style="fill: none; stroke: #7c8798; stroke-width: 0.7; stroke-linejoin: miter"/>
+   </g>
+   <g id="junction-three-way-assembly:target:bottom:outline">
+    <path d="M 97.817472 225.635328
+L 1018.032768 225.635328
+Q 1045.91808 225.635328 1045.91808 216.82944
+L 1045.91808 216.82944
+Q 1045.91808 208.023552 1018.032768 208.023552
+L 97.817472 208.023552
+Q 69.93216 208.023552 69.93216 216.82944
+L 69.93216 216.82944
+Q 69.93216 225.635328 97.817472 225.635328
+L 97.817472 225.635328
+z
+" clip-path="url(#p93cbc2dd8a)" style="fill: none; stroke: #7c8798; stroke-width: 0.7; stroke-linejoin: miter"/>
+   </g>
+   <g id="LineCollection_1">
+    <path d="M 437.803776 159.25248
+L 443.809843 159.25248
+" clip-path="url(#p93cbc2dd8a)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.75"/>
+    <path d="M 437.803776 142.31808
+L 443.809843 142.31808
+" clip-path="url(#p93cbc2dd8a)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.75"/>
+    <path d="M 437.803776 125.38368
+L 443.809843 125.38368
+" clip-path="url(#p93cbc2dd8a)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.75"/>
+   </g>
+   <g id="LineCollection_2">
+    <path d="M 730.599552 159.25248
+L 736.605619 159.25248
+" clip-path="url(#p93cbc2dd8a)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.75"/>
+    <path d="M 730.599552 142.31808
+L 736.605619 142.31808
+" clip-path="url(#p93cbc2dd8a)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.75"/>
+    <path d="M 730.599552 125.38368
+L 736.605619 125.38368
+" clip-path="url(#p93cbc2dd8a)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.75"/>
    </g>
    <g id="text_1">
-    <!-- Three-way assembly map -->
-    <g style="fill: #172033" transform="translate(37.7568 30.303167) scale(0.125 -0.125)">
+    <!-- 2 three-way junctions link 3 fragments across synthetic-three-fragment-target -->
+    <g style="fill: #172033" transform="translate(37.7568 31.788056) scale(0.15 -0.15)">
      <defs>
-      <path id="DejaVuSans-Bold-54" d="M 31 4666
-L 4331 4666
-L 4331 3756
-L 2784 3756
-L 2784 0
-L 1581 0
-L 1581 3756
-L 31 3756
-L 31 4666
+      <path id="DejaVuSans-Bold-32" d="M 1844 884
+L 3897 884
+L 3897 0
+L 506 0
+L 506 884
+L 2209 2388
+Q 2438 2594 2547 2791
+Q 2656 2988 2656 3200
+Q 2656 3528 2436 3728
+Q 2216 3928 1850 3928
+Q 1569 3928 1234 3808
+Q 900 3688 519 3450
+L 519 4475
+Q 925 4609 1322 4679
+Q 1719 4750 2100 4750
+Q 2938 4750 3402 4381
+Q 3866 4013 3866 3353
+Q 3866 2972 3669 2642
+Q 3472 2313 2841 1759
+L 1844 884
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-20" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-74" d="M 1759 4494
+L 1759 3500
+L 2913 3500
+L 2913 2700
+L 1759 2700
+L 1759 1216
+Q 1759 972 1856 886
+Q 1953 800 2241 800
+L 2816 800
+L 2816 0
+L 1856 0
+Q 1194 0 917 276
+Q 641 553 641 1216
+L 641 2700
+L 84 2700
+L 84 3500
+L 641 3500
+L 641 4494
+L 1759 4494
 z
 " transform="scale(0.015625)"/>
       <path id="DejaVuSans-Bold-68" d="M 4056 2131
@@ -244,7 +389,125 @@ L 1638 -134
 L 78 3500
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-20" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-6a" d="M 538 3500
+L 1656 3500
+L 1656 63
+Q 1656 -641 1318 -1011
+Q 981 -1381 341 -1381
+L -213 -1381
+L -213 -647
+L -19 -647
+Q 300 -647 419 -503
+Q 538 -359 538 63
+L 538 3500
+z
+M 538 4863
+L 1656 4863
+L 1656 3950
+L 538 3950
+L 538 4863
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-75" d="M 500 1363
+L 500 3500
+L 1625 3500
+L 1625 3150
+Q 1625 2866 1622 2436
+Q 1619 2006 1619 1863
+Q 1619 1441 1641 1255
+Q 1663 1069 1716 984
+Q 1784 875 1895 815
+Q 2006 756 2150 756
+Q 2500 756 2700 1025
+Q 2900 1294 2900 1772
+L 2900 3500
+L 4019 3500
+L 4019 0
+L 2900 0
+L 2900 506
+Q 2647 200 2364 54
+Q 2081 -91 1741 -91
+Q 1134 -91 817 281
+Q 500 653 500 1363
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-6e" d="M 4056 2131
+L 4056 0
+L 2931 0
+L 2931 347
+L 2931 1631
+Q 2931 2084 2911 2256
+Q 2891 2428 2841 2509
+Q 2775 2619 2662 2680
+Q 2550 2741 2406 2741
+Q 2056 2741 1856 2470
+Q 1656 2200 1656 1722
+L 1656 0
+L 538 0
+L 538 3500
+L 1656 3500
+L 1656 2988
+Q 1909 3294 2193 3439
+Q 2478 3584 2822 3584
+Q 3428 3584 3742 3212
+Q 4056 2841 4056 2131
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-63" d="M 3366 3391
+L 3366 2478
+Q 3138 2634 2908 2709
+Q 2678 2784 2431 2784
+Q 1963 2784 1702 2511
+Q 1441 2238 1441 1747
+Q 1441 1256 1702 982
+Q 1963 709 2431 709
+Q 2694 709 2930 787
+Q 3166 866 3366 1019
+L 3366 103
+Q 3103 6 2833 -42
+Q 2563 -91 2291 -91
+Q 1344 -91 809 395
+Q 275 881 275 1747
+Q 275 2613 809 3098
+Q 1344 3584 2291 3584
+Q 2566 3584 2833 3536
+Q 3100 3488 3366 3391
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-69" d="M 538 3500
+L 1656 3500
+L 1656 0
+L 538 0
+L 538 3500
+z
+M 538 4863
+L 1656 4863
+L 1656 3950
+L 538 3950
+L 538 4863
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-6f" d="M 2203 2784
+Q 1831 2784 1636 2517
+Q 1441 2250 1441 1747
+Q 1441 1244 1636 976
+Q 1831 709 2203 709
+Q 2569 709 2762 976
+Q 2956 1244 2956 1747
+Q 2956 2250 2762 2517
+Q 2569 2784 2203 2784
+z
+M 2203 3584
+Q 3106 3584 3614 3096
+Q 4122 2609 4122 1747
+Q 4122 884 3614 396
+Q 3106 -91 2203 -91
+Q 1297 -91 786 396
+Q 275 884 275 1747
+Q 275 2609 786 3096
+Q 1297 3584 2203 3584
+z
+" transform="scale(0.015625)"/>
       <path id="DejaVuSans-Bold-73" d="M 3272 3391
 L 3272 2541
 Q 2913 2691 2578 2766
@@ -274,6 +537,114 @@ Q 331 3047 712 3315
 Q 1094 3584 1881 3584
 Q 2191 3584 2531 3537
 Q 2872 3491 3272 3391
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-6c" d="M 538 4863
+L 1656 4863
+L 1656 0
+L 538 0
+L 538 4863
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-6b" d="M 538 4863
+L 1656 4863
+L 1656 2216
+L 2944 3500
+L 4244 3500
+L 2534 1894
+L 4378 0
+L 3022 0
+L 1656 1459
+L 1656 0
+L 538 0
+L 538 4863
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-33" d="M 2981 2516
+Q 3453 2394 3698 2092
+Q 3944 1791 3944 1325
+Q 3944 631 3412 270
+Q 2881 -91 1863 -91
+Q 1503 -91 1142 -33
+Q 781 25 428 141
+L 428 1069
+Q 766 900 1098 814
+Q 1431 728 1753 728
+Q 2231 728 2486 893
+Q 2741 1059 2741 1369
+Q 2741 1688 2480 1852
+Q 2219 2016 1709 2016
+L 1228 2016
+L 1228 2791
+L 1734 2791
+Q 2188 2791 2409 2933
+Q 2631 3075 2631 3366
+Q 2631 3634 2415 3781
+Q 2200 3928 1806 3928
+Q 1516 3928 1219 3862
+Q 922 3797 628 3669
+L 628 4550
+Q 984 4650 1334 4700
+Q 1684 4750 2022 4750
+Q 2931 4750 3382 4451
+Q 3834 4153 3834 3553
+Q 3834 3144 3618 2883
+Q 3403 2622 2981 2516
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-66" d="M 2841 4863
+L 2841 4128
+L 2222 4128
+Q 1984 4128 1890 4042
+Q 1797 3956 1797 3744
+L 1797 3500
+L 2753 3500
+L 2753 2700
+L 1797 2700
+L 1797 0
+L 678 0
+L 678 2700
+L 122 2700
+L 122 3500
+L 678 3500
+L 678 3744
+Q 678 4316 997 4589
+Q 1316 4863 1984 4863
+L 2841 4863
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-67" d="M 2919 594
+Q 2688 288 2409 144
+Q 2131 0 1766 0
+Q 1125 0 706 504
+Q 288 1009 288 1791
+Q 288 2575 706 3076
+Q 1125 3578 1766 3578
+Q 2131 3578 2409 3434
+Q 2688 3291 2919 2981
+L 2919 3500
+L 4044 3500
+L 4044 353
+Q 4044 -491 3511 -936
+Q 2978 -1381 1966 -1381
+Q 1638 -1381 1331 -1331
+Q 1025 -1281 716 -1178
+L 716 -306
+Q 1009 -475 1290 -558
+Q 1572 -641 1856 -641
+Q 2406 -641 2662 -400
+Q 2919 -159 2919 353
+L 2919 594
+z
+M 2181 2772
+Q 1834 2772 1640 2515
+Q 1447 2259 1447 1791
+Q 1447 1309 1634 1061
+Q 1822 813 2181 813
+Q 2531 813 2725 1069
+Q 2919 1325 2919 1791
+Q 2919 2259 2725 2515
+Q 2531 2772 2181 2772
 z
 " transform="scale(0.015625)"/>
       <path id="DejaVuSans-Bold-6d" d="M 3781 2919
@@ -308,180 +679,99 @@ Q 3081 3584 3359 3409
 Q 3638 3234 3781 2919
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-62" d="M 2400 722
-Q 2759 722 2948 984
-Q 3138 1247 3138 1747
-Q 3138 2247 2948 2509
-Q 2759 2772 2400 2772
-Q 2041 2772 1848 2508
-Q 1656 2244 1656 1747
-Q 1656 1250 1848 986
-Q 2041 722 2400 722
-z
-M 1656 2988
-Q 1888 3294 2169 3439
-Q 2450 3584 2816 3584
-Q 3463 3584 3878 3070
-Q 4294 2556 4294 1747
-Q 4294 938 3878 423
-Q 3463 -91 2816 -91
-Q 2450 -91 2169 54
-Q 1888 200 1656 506
-L 1656 0
-L 538 0
-L 538 4863
-L 1656 4863
-L 1656 2988
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-6c" d="M 538 4863
-L 1656 4863
-L 1656 0
-L 538 0
-L 538 4863
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-70" d="M 1656 506
-L 1656 -1331
-L 538 -1331
-L 538 3500
-L 1656 3500
-L 1656 2988
-Q 1888 3294 2169 3439
-Q 2450 3584 2816 3584
-Q 3463 3584 3878 3070
-Q 4294 2556 4294 1747
-Q 4294 938 3878 423
-Q 3463 -91 2816 -91
-Q 2450 -91 2169 54
-Q 1888 200 1656 506
-z
-M 2400 2772
-Q 2041 2772 1848 2508
-Q 1656 2244 1656 1747
-Q 1656 1250 1848 986
-Q 2041 722 2400 722
-Q 2759 722 2948 984
-Q 3138 1247 3138 1747
-Q 3138 2247 2948 2509
-Q 2759 2772 2400 2772
-z
-" transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-Bold-54"/>
-     <use xlink:href="#DejaVuSans-Bold-68" transform="translate(68.212891 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-72" transform="translate(139.404297 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-65" transform="translate(188.720703 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-65" transform="translate(256.542969 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-2d" transform="translate(324.365234 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-77" transform="translate(365.869141 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-61" transform="translate(458.251953 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-79" transform="translate(522.607422 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(587.792969 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-61" transform="translate(622.607422 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-73" transform="translate(690.087891 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-73" transform="translate(749.609375 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-65" transform="translate(809.130859 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-6d" transform="translate(876.953125 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-62" transform="translate(981.152344 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-6c" transform="translate(1052.734375 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-79" transform="translate(1087.011719 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(1152.197266 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-6d" transform="translate(1187.011719 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-61" transform="translate(1291.210938 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-70" transform="translate(1358.691406 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-32"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(69.580078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-74" transform="translate(104.394531 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-68" transform="translate(152.197266 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-72" transform="translate(223.388672 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-65" transform="translate(272.705078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-65" transform="translate(340.527344 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-2d" transform="translate(408.349609 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-77" transform="translate(449.853516 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-61" transform="translate(542.236328 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-79" transform="translate(606.591797 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(671.777344 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6a" transform="translate(706.591797 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-75" transform="translate(740.869141 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(812.060547 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-63" transform="translate(883.251953 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-74" transform="translate(942.529297 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-69" transform="translate(990.332031 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6f" transform="translate(1024.609375 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(1093.310547 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-73" transform="translate(1164.501953 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(1224.023438 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6c" transform="translate(1258.837891 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-69" transform="translate(1293.115234 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(1327.392578 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6b" transform="translate(1398.583984 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(1465.087891 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-33" transform="translate(1499.902344 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(1569.482422 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-66" transform="translate(1604.296875 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-72" transform="translate(1647.802734 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-61" transform="translate(1697.119141 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-67" transform="translate(1764.599609 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6d" transform="translate(1836.181641 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-65" transform="translate(1940.380859 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(2008.203125 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-74" transform="translate(2079.394531 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-73" transform="translate(2127.197266 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(2186.71875 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-61" transform="translate(2221.533203 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-63" transform="translate(2289.013672 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-72" transform="translate(2348.291016 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6f" transform="translate(2397.607422 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-73" transform="translate(2466.308594 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-73" transform="translate(2525.830078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(2585.351562 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-73" transform="translate(2620.166016 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-79" transform="translate(2679.6875 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(2744.873047 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-74" transform="translate(2816.064453 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-68" transform="translate(2863.867188 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-65" transform="translate(2935.058594 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-74" transform="translate(3002.880859 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-69" transform="translate(3050.683594 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-63" transform="translate(3084.960938 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-2d" transform="translate(3144.238281 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-74" transform="translate(3185.742188 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-68" transform="translate(3233.544922 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-72" transform="translate(3304.736328 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-65" transform="translate(3354.052734 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-65" transform="translate(3421.875 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-2d" transform="translate(3489.697266 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-66" transform="translate(3531.201172 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-72" transform="translate(3574.707031 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-61" transform="translate(3624.023438 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-67" transform="translate(3691.503906 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6d" transform="translate(3763.085938 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-65" transform="translate(3867.285156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(3935.107422 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-74" transform="translate(4006.298828 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-2d" transform="translate(4054.101562 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-74" transform="translate(4095.605469 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-61" transform="translate(4143.408203 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-72" transform="translate(4210.888672 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-67" transform="translate(4260.205078 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-65" transform="translate(4331.787109 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-74" transform="translate(4399.609375 0)"/>
     </g>
    </g>
    <g id="text_2">
-    <!-- synthetic-three-fragment-target · 3 fragments · 2 junctions -->
-    <g style="fill: #667085" transform="translate(37.7568 49.680217) scale(0.068 -0.068)">
+    <!-- The 200 bp target uses 6 fragment oligos spanning 60–104 nt with median 80 nt -->
+    <g style="fill: #667085" transform="translate(37.7568 64.484674) scale(0.09 -0.09)">
      <defs>
-      <path id="DejaVuSans-73" d="M 2834 3397
-L 2834 2853
-Q 2591 2978 2328 3040
-Q 2066 3103 1784 3103
-Q 1356 3103 1142 2972
-Q 928 2841 928 2578
-Q 928 2378 1081 2264
-Q 1234 2150 1697 2047
-L 1894 2003
-Q 2506 1872 2764 1633
-Q 3022 1394 3022 966
-Q 3022 478 2636 193
-Q 2250 -91 1575 -91
-Q 1294 -91 989 -36
-Q 684 19 347 128
-L 347 722
-Q 666 556 975 473
-Q 1284 391 1588 391
-Q 1994 391 2212 530
-Q 2431 669 2431 922
-Q 2431 1156 2273 1281
-Q 2116 1406 1581 1522
-L 1381 1569
-Q 847 1681 609 1914
-Q 372 2147 372 2553
-Q 372 3047 722 3315
-Q 1072 3584 1716 3584
-Q 2034 3584 2315 3537
-Q 2597 3491 2834 3397
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-79" d="M 2059 -325
-Q 1816 -950 1584 -1140
-Q 1353 -1331 966 -1331
-L 506 -1331
-L 506 -850
-L 844 -850
-Q 1081 -850 1212 -737
-Q 1344 -625 1503 -206
-L 1606 56
-L 191 3500
-L 800 3500
-L 1894 763
-L 2988 3500
-L 3597 3500
-L 2059 -325
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-6e" d="M 3513 2113
-L 3513 0
-L 2938 0
-L 2938 2094
-Q 2938 2591 2744 2837
-Q 2550 3084 2163 3084
-Q 1697 3084 1428 2787
-Q 1159 2491 1159 1978
-L 1159 0
-L 581 0
-L 581 3500
-L 1159 3500
-L 1159 2956
-Q 1366 3272 1645 3428
-Q 1925 3584 2291 3584
-Q 2894 3584 3203 3211
-Q 3513 2838 3513 2113
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-74" d="M 1172 4494
-L 1172 3500
-L 2356 3500
-L 2356 3053
-L 1172 3053
-L 1172 1153
-Q 1172 725 1289 603
-Q 1406 481 1766 481
-L 2356 481
-L 2356 0
-L 1766 0
-Q 1100 0 847 248
-Q 594 497 594 1153
-L 594 3053
-L 172 3053
-L 172 3500
-L 594 3500
-L 594 4494
-L 1172 4494
+      <path id="DejaVuSans-54" d="M -19 4666
+L 3928 4666
+L 3928 4134
+L 2272 4134
+L 2272 0
+L 1638 0
+L 1638 4134
+L -19 4134
+L -19 4666
 z
 " transform="scale(0.015625)"/>
       <path id="DejaVuSans-68" d="M 3513 2113
@@ -528,10 +818,724 @@ Q 1016 2553 972 2059
 L 3022 2063
 z
 " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-32" d="M 1228 531
+L 3431 531
+L 3431 0
+L 469 0
+L 469 531
+Q 828 903 1448 1529
+Q 2069 2156 2228 2338
+Q 2531 2678 2651 2914
+Q 2772 3150 2772 3378
+Q 2772 3750 2511 3984
+Q 2250 4219 1831 4219
+Q 1534 4219 1204 4116
+Q 875 4013 500 3803
+L 500 4441
+Q 881 4594 1212 4672
+Q 1544 4750 1819 4750
+Q 2544 4750 2975 4387
+Q 3406 4025 3406 3419
+Q 3406 3131 3298 2873
+Q 3191 2616 2906 2266
+Q 2828 2175 2409 1742
+Q 1991 1309 1228 531
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-30" d="M 2034 4250
+Q 1547 4250 1301 3770
+Q 1056 3291 1056 2328
+Q 1056 1369 1301 889
+Q 1547 409 2034 409
+Q 2525 409 2770 889
+Q 3016 1369 3016 2328
+Q 3016 3291 2770 3770
+Q 2525 4250 2034 4250
+z
+M 2034 4750
+Q 2819 4750 3233 4129
+Q 3647 3509 3647 2328
+Q 3647 1150 3233 529
+Q 2819 -91 2034 -91
+Q 1250 -91 836 529
+Q 422 1150 422 2328
+Q 422 3509 836 4129
+Q 1250 4750 2034 4750
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-62" d="M 3116 1747
+Q 3116 2381 2855 2742
+Q 2594 3103 2138 3103
+Q 1681 3103 1420 2742
+Q 1159 2381 1159 1747
+Q 1159 1113 1420 752
+Q 1681 391 2138 391
+Q 2594 391 2855 752
+Q 3116 1113 3116 1747
+z
+M 1159 2969
+Q 1341 3281 1617 3432
+Q 1894 3584 2278 3584
+Q 2916 3584 3314 3078
+Q 3713 2572 3713 1747
+Q 3713 922 3314 415
+Q 2916 -91 2278 -91
+Q 1894 -91 1617 61
+Q 1341 213 1159 525
+L 1159 0
+L 581 0
+L 581 4863
+L 1159 4863
+L 1159 2969
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-70" d="M 1159 525
+L 1159 -1331
+L 581 -1331
+L 581 3500
+L 1159 3500
+L 1159 2969
+Q 1341 3281 1617 3432
+Q 1894 3584 2278 3584
+Q 2916 3584 3314 3078
+Q 3713 2572 3713 1747
+Q 3713 922 3314 415
+Q 2916 -91 2278 -91
+Q 1894 -91 1617 61
+Q 1341 213 1159 525
+z
+M 3116 1747
+Q 3116 2381 2855 2742
+Q 2594 3103 2138 3103
+Q 1681 3103 1420 2742
+Q 1159 2381 1159 1747
+Q 1159 1113 1420 752
+Q 1681 391 2138 391
+Q 2594 391 2855 752
+Q 3116 1113 3116 1747
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-74" d="M 1172 4494
+L 1172 3500
+L 2356 3500
+L 2356 3053
+L 1172 3053
+L 1172 1153
+Q 1172 725 1289 603
+Q 1406 481 1766 481
+L 2356 481
+L 2356 0
+L 1766 0
+Q 1100 0 847 248
+Q 594 497 594 1153
+L 594 3053
+L 172 3053
+L 172 3500
+L 594 3500
+L 594 4494
+L 1172 4494
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-61" d="M 2194 1759
+Q 1497 1759 1228 1600
+Q 959 1441 959 1056
+Q 959 750 1161 570
+Q 1363 391 1709 391
+Q 2188 391 2477 730
+Q 2766 1069 2766 1631
+L 2766 1759
+L 2194 1759
+z
+M 3341 1997
+L 3341 0
+L 2766 0
+L 2766 531
+Q 2569 213 2275 61
+Q 1981 -91 1556 -91
+Q 1019 -91 701 211
+Q 384 513 384 1019
+Q 384 1609 779 1909
+Q 1175 2209 1959 2209
+L 2766 2209
+L 2766 2266
+Q 2766 2663 2505 2880
+Q 2244 3097 1772 3097
+Q 1472 3097 1187 3025
+Q 903 2953 641 2809
+L 641 3341
+Q 956 3463 1253 3523
+Q 1550 3584 1831 3584
+Q 2591 3584 2966 3190
+Q 3341 2797 3341 1997
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-72" d="M 2631 2963
+Q 2534 3019 2420 3045
+Q 2306 3072 2169 3072
+Q 1681 3072 1420 2755
+Q 1159 2438 1159 1844
+L 1159 0
+L 581 0
+L 581 3500
+L 1159 3500
+L 1159 2956
+Q 1341 3275 1631 3429
+Q 1922 3584 2338 3584
+Q 2397 3584 2469 3576
+Q 2541 3569 2628 3553
+L 2631 2963
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-67" d="M 2906 1791
+Q 2906 2416 2648 2759
+Q 2391 3103 1925 3103
+Q 1463 3103 1205 2759
+Q 947 2416 947 1791
+Q 947 1169 1205 825
+Q 1463 481 1925 481
+Q 2391 481 2648 825
+Q 2906 1169 2906 1791
+z
+M 3481 434
+Q 3481 -459 3084 -895
+Q 2688 -1331 1869 -1331
+Q 1566 -1331 1297 -1286
+Q 1028 -1241 775 -1147
+L 775 -588
+Q 1028 -725 1275 -790
+Q 1522 -856 1778 -856
+Q 2344 -856 2625 -561
+Q 2906 -266 2906 331
+L 2906 616
+Q 2728 306 2450 153
+Q 2172 0 1784 0
+Q 1141 0 747 490
+Q 353 981 353 1791
+Q 353 2603 747 3093
+Q 1141 3584 1784 3584
+Q 2172 3584 2450 3431
+Q 2728 3278 2906 2969
+L 2906 3500
+L 3481 3500
+L 3481 434
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-75" d="M 544 1381
+L 544 3500
+L 1119 3500
+L 1119 1403
+Q 1119 906 1312 657
+Q 1506 409 1894 409
+Q 2359 409 2629 706
+Q 2900 1003 2900 1516
+L 2900 3500
+L 3475 3500
+L 3475 0
+L 2900 0
+L 2900 538
+Q 2691 219 2414 64
+Q 2138 -91 1772 -91
+Q 1169 -91 856 284
+Q 544 659 544 1381
+z
+M 1991 3584
+L 1991 3584
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-73" d="M 2834 3397
+L 2834 2853
+Q 2591 2978 2328 3040
+Q 2066 3103 1784 3103
+Q 1356 3103 1142 2972
+Q 928 2841 928 2578
+Q 928 2378 1081 2264
+Q 1234 2150 1697 2047
+L 1894 2003
+Q 2506 1872 2764 1633
+Q 3022 1394 3022 966
+Q 3022 478 2636 193
+Q 2250 -91 1575 -91
+Q 1294 -91 989 -36
+Q 684 19 347 128
+L 347 722
+Q 666 556 975 473
+Q 1284 391 1588 391
+Q 1994 391 2212 530
+Q 2431 669 2431 922
+Q 2431 1156 2273 1281
+Q 2116 1406 1581 1522
+L 1381 1569
+Q 847 1681 609 1914
+Q 372 2147 372 2553
+Q 372 3047 722 3315
+Q 1072 3584 1716 3584
+Q 2034 3584 2315 3537
+Q 2597 3491 2834 3397
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-36" d="M 2113 2584
+Q 1688 2584 1439 2293
+Q 1191 2003 1191 1497
+Q 1191 994 1439 701
+Q 1688 409 2113 409
+Q 2538 409 2786 701
+Q 3034 994 3034 1497
+Q 3034 2003 2786 2293
+Q 2538 2584 2113 2584
+z
+M 3366 4563
+L 3366 3988
+Q 3128 4100 2886 4159
+Q 2644 4219 2406 4219
+Q 1781 4219 1451 3797
+Q 1122 3375 1075 2522
+Q 1259 2794 1537 2939
+Q 1816 3084 2150 3084
+Q 2853 3084 3261 2657
+Q 3669 2231 3669 1497
+Q 3669 778 3244 343
+Q 2819 -91 2113 -91
+Q 1303 -91 875 529
+Q 447 1150 447 2328
+Q 447 3434 972 4092
+Q 1497 4750 2381 4750
+Q 2619 4750 2861 4703
+Q 3103 4656 3366 4563
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-66" d="M 2375 4863
+L 2375 4384
+L 1825 4384
+Q 1516 4384 1395 4259
+Q 1275 4134 1275 3809
+L 1275 3500
+L 2222 3500
+L 2222 3053
+L 1275 3053
+L 1275 0
+L 697 0
+L 697 3053
+L 147 3053
+L 147 3500
+L 697 3500
+L 697 3744
+Q 697 4328 969 4595
+Q 1241 4863 1831 4863
+L 2375 4863
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-6d" d="M 3328 2828
+Q 3544 3216 3844 3400
+Q 4144 3584 4550 3584
+Q 5097 3584 5394 3201
+Q 5691 2819 5691 2113
+L 5691 0
+L 5113 0
+L 5113 2094
+Q 5113 2597 4934 2840
+Q 4756 3084 4391 3084
+Q 3944 3084 3684 2787
+Q 3425 2491 3425 1978
+L 3425 0
+L 2847 0
+L 2847 2094
+Q 2847 2600 2669 2842
+Q 2491 3084 2119 3084
+Q 1678 3084 1418 2786
+Q 1159 2488 1159 1978
+L 1159 0
+L 581 0
+L 581 3500
+L 1159 3500
+L 1159 2956
+Q 1356 3278 1631 3431
+Q 1906 3584 2284 3584
+Q 2666 3584 2933 3390
+Q 3200 3197 3328 2828
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-6e" d="M 3513 2113
+L 3513 0
+L 2938 0
+L 2938 2094
+Q 2938 2591 2744 2837
+Q 2550 3084 2163 3084
+Q 1697 3084 1428 2787
+Q 1159 2491 1159 1978
+L 1159 0
+L 581 0
+L 581 3500
+L 1159 3500
+L 1159 2956
+Q 1366 3272 1645 3428
+Q 1925 3584 2291 3584
+Q 2894 3584 3203 3211
+Q 3513 2838 3513 2113
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-6f" d="M 1959 3097
+Q 1497 3097 1228 2736
+Q 959 2375 959 1747
+Q 959 1119 1226 758
+Q 1494 397 1959 397
+Q 2419 397 2687 759
+Q 2956 1122 2956 1747
+Q 2956 2369 2687 2733
+Q 2419 3097 1959 3097
+z
+M 1959 3584
+Q 2709 3584 3137 3096
+Q 3566 2609 3566 1747
+Q 3566 888 3137 398
+Q 2709 -91 1959 -91
+Q 1206 -91 779 398
+Q 353 888 353 1747
+Q 353 2609 779 3096
+Q 1206 3584 1959 3584
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-6c" d="M 603 4863
+L 1178 4863
+L 1178 0
+L 603 0
+L 603 4863
+z
+" transform="scale(0.015625)"/>
       <path id="DejaVuSans-69" d="M 603 3500
 L 1178 3500
 L 1178 0
 L 603 0
+L 603 3500
+z
+M 603 4863
+L 1178 4863
+L 1178 4134
+L 603 4134
+L 603 4863
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-2013" d="M 313 1978
+L 2888 1978
+L 2888 1528
+L 313 1528
+L 313 1978
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-31" d="M 794 531
+L 1825 531
+L 1825 4091
+L 703 3866
+L 703 4441
+L 1819 4666
+L 2450 4666
+L 2450 531
+L 3481 531
+L 3481 0
+L 794 0
+L 794 531
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-34" d="M 2419 4116
+L 825 1625
+L 2419 1625
+L 2419 4116
+z
+M 2253 4666
+L 3047 4666
+L 3047 1625
+L 3713 1625
+L 3713 1100
+L 3047 1100
+L 3047 0
+L 2419 0
+L 2419 1100
+L 313 1100
+L 313 1709
+L 2253 4666
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-77" d="M 269 3500
+L 844 3500
+L 1563 769
+L 2278 3500
+L 2956 3500
+L 3675 769
+L 4391 3500
+L 4966 3500
+L 4050 0
+L 3372 0
+L 2619 2869
+L 1863 0
+L 1184 0
+L 269 3500
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-64" d="M 2906 2969
+L 2906 4863
+L 3481 4863
+L 3481 0
+L 2906 0
+L 2906 525
+Q 2725 213 2448 61
+Q 2172 -91 1784 -91
+Q 1150 -91 751 415
+Q 353 922 353 1747
+Q 353 2572 751 3078
+Q 1150 3584 1784 3584
+Q 2172 3584 2448 3432
+Q 2725 3281 2906 2969
+z
+M 947 1747
+Q 947 1113 1208 752
+Q 1469 391 1925 391
+Q 2381 391 2643 752
+Q 2906 1113 2906 1747
+Q 2906 2381 2643 2742
+Q 2381 3103 1925 3103
+Q 1469 3103 1208 2742
+Q 947 2381 947 1747
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-38" d="M 2034 2216
+Q 1584 2216 1326 1975
+Q 1069 1734 1069 1313
+Q 1069 891 1326 650
+Q 1584 409 2034 409
+Q 2484 409 2743 651
+Q 3003 894 3003 1313
+Q 3003 1734 2745 1975
+Q 2488 2216 2034 2216
+z
+M 1403 2484
+Q 997 2584 770 2862
+Q 544 3141 544 3541
+Q 544 4100 942 4425
+Q 1341 4750 2034 4750
+Q 2731 4750 3128 4425
+Q 3525 4100 3525 3541
+Q 3525 3141 3298 2862
+Q 3072 2584 2669 2484
+Q 3125 2378 3379 2068
+Q 3634 1759 3634 1313
+Q 3634 634 3220 271
+Q 2806 -91 2034 -91
+Q 1263 -91 848 271
+Q 434 634 434 1313
+Q 434 1759 690 2068
+Q 947 2378 1403 2484
+z
+M 1172 3481
+Q 1172 3119 1398 2916
+Q 1625 2713 2034 2713
+Q 2441 2713 2670 2916
+Q 2900 3119 2900 3481
+Q 2900 3844 2670 4047
+Q 2441 4250 2034 4250
+Q 1625 4250 1398 4047
+Q 1172 3844 1172 3481
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-54"/>
+     <use xlink:href="#DejaVuSans-68" transform="translate(61.083984 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(124.462891 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(185.986328 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(217.773438 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(281.396484 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(345.019531 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(408.642578 0)"/>
+     <use xlink:href="#DejaVuSans-62" transform="translate(440.429688 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(503.90625 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(567.382812 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(599.169922 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(638.378906 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(699.658203 0)"/>
+     <use xlink:href="#DejaVuSans-67" transform="translate(739.021484 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(802.498047 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(864.021484 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(903.230469 0)"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(935.017578 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(998.396484 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(1050.496094 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(1112.019531 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1164.119141 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(1195.90625 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1259.529297 0)"/>
+     <use xlink:href="#DejaVuSans-66" transform="translate(1291.316406 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(1326.521484 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(1367.634766 0)"/>
+     <use xlink:href="#DejaVuSans-67" transform="translate(1428.914062 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(1492.390625 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(1589.802734 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(1651.326172 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(1714.705078 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1753.914062 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(1785.701172 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(1846.882812 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(1874.666016 0)"/>
+     <use xlink:href="#DejaVuSans-67" transform="translate(1902.449219 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(1965.925781 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(2027.107422 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2079.207031 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(2110.994141 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(2163.09375 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(2226.570312 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(2287.849609 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(2351.228516 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(2414.607422 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(2442.390625 0)"/>
+     <use xlink:href="#DejaVuSans-67" transform="translate(2505.769531 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2569.246094 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(2601.033203 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(2664.65625 0)"/>
+     <use xlink:href="#DejaVuSans-2013" transform="translate(2728.279297 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(2778.279297 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(2841.902344 0)"/>
+     <use xlink:href="#DejaVuSans-34" transform="translate(2905.525391 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2969.148438 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(3000.935547 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(3064.314453 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3103.523438 0)"/>
+     <use xlink:href="#DejaVuSans-77" transform="translate(3135.310547 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(3217.097656 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(3244.880859 0)"/>
+     <use xlink:href="#DejaVuSans-68" transform="translate(3284.089844 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3347.46875 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(3379.255859 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(3476.667969 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(3538.191406 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(3601.667969 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(3629.451172 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(3690.730469 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3754.109375 0)"/>
+     <use xlink:href="#DejaVuSans-38" transform="translate(3785.896484 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(3849.519531 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3913.142578 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(3944.929688 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(4008.308594 0)"/>
+    </g>
+   </g>
+   <g id="text_3">
+    <!-- F01 · first -->
+    <g style="fill: #172033" transform="translate(213.851837 257.862555) scale(0.072 -0.072)">
+     <defs>
+      <path id="DejaVuSans-46" d="M 628 4666
+L 3309 4666
+L 3309 4134
+L 1259 4134
+L 1259 2759
+L 3109 2759
+L 3109 2228
+L 1259 2228
+L 1259 0
+L 628 0
+L 628 4666
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-b7" d="M 684 2619
+L 1344 2619
+L 1344 1825
+L 684 1825
+L 684 2619
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-46"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(57.519531 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(121.142578 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(184.765625 0)"/>
+     <use xlink:href="#DejaVuSans-b7" transform="translate(216.552734 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(248.339844 0)"/>
+     <use xlink:href="#DejaVuSans-66" transform="translate(280.126953 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(315.332031 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(343.115234 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(384.228516 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(436.328125 0)"/>
+    </g>
+   </g>
+   <g id="text_4">
+    <!-- F02 · internal -->
+    <g style="fill: #172033" transform="translate(538.908362 257.862555) scale(0.072 -0.072)">
+     <use xlink:href="#DejaVuSans-46"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(57.519531 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(121.142578 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(184.765625 0)"/>
+     <use xlink:href="#DejaVuSans-b7" transform="translate(216.552734 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(248.339844 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(280.126953 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(307.910156 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(371.289062 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(410.498047 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(472.021484 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(511.384766 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(574.763672 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(636.042969 0)"/>
+    </g>
+   </g>
+   <g id="text_5">
+    <!-- F03 · last -->
+    <g style="fill: #172033" transform="translate(873.183458 257.862555) scale(0.072 -0.072)">
+     <defs>
+      <path id="DejaVuSans-33" d="M 2597 2516
+Q 3050 2419 3304 2112
+Q 3559 1806 3559 1356
+Q 3559 666 3084 287
+Q 2609 -91 1734 -91
+Q 1441 -91 1130 -33
+Q 819 25 488 141
+L 488 750
+Q 750 597 1062 519
+Q 1375 441 1716 441
+Q 2309 441 2620 675
+Q 2931 909 2931 1356
+Q 2931 1769 2642 2001
+Q 2353 2234 1838 2234
+L 1294 2234
+L 1294 2753
+L 1863 2753
+Q 2328 2753 2575 2939
+Q 2822 3125 2822 3475
+Q 2822 3834 2567 4026
+Q 2313 4219 1838 4219
+Q 1578 4219 1281 4162
+Q 984 4106 628 3988
+L 628 4550
+Q 988 4650 1302 4700
+Q 1616 4750 1894 4750
+Q 2613 4750 3031 4423
+Q 3450 4097 3450 3541
+Q 3450 3153 3228 2886
+Q 3006 2619 2597 2516
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-46"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(57.519531 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(121.142578 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(184.765625 0)"/>
+     <use xlink:href="#DejaVuSans-b7" transform="translate(216.552734 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(248.339844 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(280.126953 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(307.910156 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(369.189453 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(421.289062 0)"/>
+    </g>
+   </g>
+   <g id="text_6">
+    <!-- junction-0001 -->
+    <g style="fill: #1f6f70" transform="translate(415.216106 91.669351) scale(0.074 -0.074)">
+     <defs>
+      <path id="DejaVuSans-6a" d="M 603 3500
+L 1178 3500
+L 1178 -63
+Q 1178 -731 923 -1031
+Q 669 -1331 103 -1331
+L -116 -1331
+L -116 -844
+L 38 -844
+Q 366 -844 484 -692
+Q 603 -541 603 -63
 L 603 3500
 z
 M 603 4863
@@ -569,411 +1573,176 @@ L 313 1497
 L 313 2009
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-72" d="M 2631 2963
-Q 2534 3019 2420 3045
-Q 2306 3072 2169 3072
-Q 1681 3072 1420 2755
-Q 1159 2438 1159 1844
-L 1159 0
-L 581 0
-L 581 3500
-L 1159 3500
-L 1159 2956
-Q 1341 3275 1631 3429
-Q 1922 3584 2338 3584
-Q 2397 3584 2469 3576
-Q 2541 3569 2628 3553
-L 2631 2963
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-66" d="M 2375 4863
-L 2375 4384
-L 1825 4384
-Q 1516 4384 1395 4259
-Q 1275 4134 1275 3809
-L 1275 3500
-L 2222 3500
-L 2222 3053
-L 1275 3053
-L 1275 0
-L 697 0
-L 697 3053
-L 147 3053
-L 147 3500
-L 697 3500
-L 697 3744
-Q 697 4328 969 4595
-Q 1241 4863 1831 4863
-L 2375 4863
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-61" d="M 2194 1759
-Q 1497 1759 1228 1600
-Q 959 1441 959 1056
-Q 959 750 1161 570
-Q 1363 391 1709 391
-Q 2188 391 2477 730
-Q 2766 1069 2766 1631
-L 2766 1759
-L 2194 1759
-z
-M 3341 1997
-L 3341 0
-L 2766 0
-L 2766 531
-Q 2569 213 2275 61
-Q 1981 -91 1556 -91
-Q 1019 -91 701 211
-Q 384 513 384 1019
-Q 384 1609 779 1909
-Q 1175 2209 1959 2209
-L 2766 2209
-L 2766 2266
-Q 2766 2663 2505 2880
-Q 2244 3097 1772 3097
-Q 1472 3097 1187 3025
-Q 903 2953 641 2809
-L 641 3341
-Q 956 3463 1253 3523
-Q 1550 3584 1831 3584
-Q 2591 3584 2966 3190
-Q 3341 2797 3341 1997
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-67" d="M 2906 1791
-Q 2906 2416 2648 2759
-Q 2391 3103 1925 3103
-Q 1463 3103 1205 2759
-Q 947 2416 947 1791
-Q 947 1169 1205 825
-Q 1463 481 1925 481
-Q 2391 481 2648 825
-Q 2906 1169 2906 1791
-z
-M 3481 434
-Q 3481 -459 3084 -895
-Q 2688 -1331 1869 -1331
-Q 1566 -1331 1297 -1286
-Q 1028 -1241 775 -1147
-L 775 -588
-Q 1028 -725 1275 -790
-Q 1522 -856 1778 -856
-Q 2344 -856 2625 -561
-Q 2906 -266 2906 331
-L 2906 616
-Q 2728 306 2450 153
-Q 2172 0 1784 0
-Q 1141 0 747 490
-Q 353 981 353 1791
-Q 353 2603 747 3093
-Q 1141 3584 1784 3584
-Q 2172 3584 2450 3431
-Q 2728 3278 2906 2969
-L 2906 3500
-L 3481 3500
-L 3481 434
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-6d" d="M 3328 2828
-Q 3544 3216 3844 3400
-Q 4144 3584 4550 3584
-Q 5097 3584 5394 3201
-Q 5691 2819 5691 2113
-L 5691 0
-L 5113 0
-L 5113 2094
-Q 5113 2597 4934 2840
-Q 4756 3084 4391 3084
-Q 3944 3084 3684 2787
-Q 3425 2491 3425 1978
-L 3425 0
-L 2847 0
-L 2847 2094
-Q 2847 2600 2669 2842
-Q 2491 3084 2119 3084
-Q 1678 3084 1418 2786
-Q 1159 2488 1159 1978
-L 1159 0
-L 581 0
-L 581 3500
-L 1159 3500
-L 1159 2956
-Q 1356 3278 1631 3431
-Q 1906 3584 2284 3584
-Q 2666 3584 2933 3390
-Q 3200 3197 3328 2828
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-20" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-b7" d="M 684 2619
-L 1344 2619
-L 1344 1825
-L 684 1825
-L 684 2619
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-33" d="M 2597 2516
-Q 3050 2419 3304 2112
-Q 3559 1806 3559 1356
-Q 3559 666 3084 287
-Q 2609 -91 1734 -91
-Q 1441 -91 1130 -33
-Q 819 25 488 141
-L 488 750
-Q 750 597 1062 519
-Q 1375 441 1716 441
-Q 2309 441 2620 675
-Q 2931 909 2931 1356
-Q 2931 1769 2642 2001
-Q 2353 2234 1838 2234
-L 1294 2234
-L 1294 2753
-L 1863 2753
-Q 2328 2753 2575 2939
-Q 2822 3125 2822 3475
-Q 2822 3834 2567 4026
-Q 2313 4219 1838 4219
-Q 1578 4219 1281 4162
-Q 984 4106 628 3988
-L 628 4550
-Q 988 4650 1302 4700
-Q 1616 4750 1894 4750
-Q 2613 4750 3031 4423
-Q 3450 4097 3450 3541
-Q 3450 3153 3228 2886
-Q 3006 2619 2597 2516
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-32" d="M 1228 531
-L 3431 531
-L 3431 0
-L 469 0
-L 469 531
-Q 828 903 1448 1529
-Q 2069 2156 2228 2338
-Q 2531 2678 2651 2914
-Q 2772 3150 2772 3378
-Q 2772 3750 2511 3984
-Q 2250 4219 1831 4219
-Q 1534 4219 1204 4116
-Q 875 4013 500 3803
-L 500 4441
-Q 881 4594 1212 4672
-Q 1544 4750 1819 4750
-Q 2544 4750 2975 4387
-Q 3406 4025 3406 3419
-Q 3406 3131 3298 2873
-Q 3191 2616 2906 2266
-Q 2828 2175 2409 1742
-Q 1991 1309 1228 531
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-6a" d="M 603 3500
-L 1178 3500
-L 1178 -63
-Q 1178 -731 923 -1031
-Q 669 -1331 103 -1331
-L -116 -1331
-L -116 -844
-L 38 -844
-Q 366 -844 484 -692
-Q 603 -541 603 -63
-L 603 3500
-z
-M 603 4863
-L 1178 4863
-L 1178 4134
-L 603 4134
-L 603 4863
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-75" d="M 544 1381
-L 544 3500
-L 1119 3500
-L 1119 1403
-Q 1119 906 1312 657
-Q 1506 409 1894 409
-Q 2359 409 2629 706
-Q 2900 1003 2900 1516
-L 2900 3500
-L 3475 3500
-L 3475 0
-L 2900 0
-L 2900 538
-Q 2691 219 2414 64
-Q 2138 -91 1772 -91
-Q 1169 -91 856 284
-Q 544 659 544 1381
-z
-M 1991 3584
-L 1991 3584
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-6f" d="M 1959 3097
-Q 1497 3097 1228 2736
-Q 959 2375 959 1747
-Q 959 1119 1226 758
-Q 1494 397 1959 397
-Q 2419 397 2687 759
-Q 2956 1122 2956 1747
-Q 2956 2369 2687 2733
-Q 2419 3097 1959 3097
-z
-M 1959 3584
-Q 2709 3584 3137 3096
-Q 3566 2609 3566 1747
-Q 3566 888 3137 398
-Q 2709 -91 1959 -91
-Q 1206 -91 779 398
-Q 353 888 353 1747
-Q 353 2609 779 3096
-Q 1206 3584 1959 3584
-z
-" transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-73"/>
-     <use xlink:href="#DejaVuSans-79" transform="translate(52.099609 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(111.279297 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(174.658203 0)"/>
-     <use xlink:href="#DejaVuSans-68" transform="translate(213.867188 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(277.246094 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(338.769531 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(377.978516 0)"/>
-     <use xlink:href="#DejaVuSans-63" transform="translate(405.761719 0)"/>
-     <use xlink:href="#DejaVuSans-2d" transform="translate(460.742188 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(496.826172 0)"/>
-     <use xlink:href="#DejaVuSans-68" transform="translate(536.035156 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(599.414062 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(638.277344 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(699.800781 0)"/>
-     <use xlink:href="#DejaVuSans-2d" transform="translate(761.324219 0)"/>
-     <use xlink:href="#DejaVuSans-66" transform="translate(797.408203 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(832.613281 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(873.726562 0)"/>
-     <use xlink:href="#DejaVuSans-67" transform="translate(935.005859 0)"/>
-     <use xlink:href="#DejaVuSans-6d" transform="translate(998.482422 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(1095.894531 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(1157.417969 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(1220.796875 0)"/>
-     <use xlink:href="#DejaVuSans-2d" transform="translate(1260.005859 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(1296.089844 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(1335.298828 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(1396.578125 0)"/>
-     <use xlink:href="#DejaVuSans-67" transform="translate(1435.941406 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(1499.417969 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(1560.941406 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(1600.150391 0)"/>
-     <use xlink:href="#DejaVuSans-b7" transform="translate(1631.9375 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(1663.724609 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(1695.511719 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(1759.134766 0)"/>
-     <use xlink:href="#DejaVuSans-66" transform="translate(1790.921875 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(1826.126953 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(1867.240234 0)"/>
-     <use xlink:href="#DejaVuSans-67" transform="translate(1928.519531 0)"/>
-     <use xlink:href="#DejaVuSans-6d" transform="translate(1991.996094 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(2089.408203 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(2150.931641 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(2214.310547 0)"/>
-     <use xlink:href="#DejaVuSans-73" transform="translate(2253.519531 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(2305.619141 0)"/>
-     <use xlink:href="#DejaVuSans-b7" transform="translate(2337.40625 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(2369.193359 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(2400.980469 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(2464.603516 0)"/>
-     <use xlink:href="#DejaVuSans-6a" transform="translate(2496.390625 0)"/>
-     <use xlink:href="#DejaVuSans-75" transform="translate(2524.173828 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(2587.552734 0)"/>
-     <use xlink:href="#DejaVuSans-63" transform="translate(2650.931641 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(2705.912109 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(2745.121094 0)"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(2772.904297 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(2834.085938 0)"/>
-     <use xlink:href="#DejaVuSans-73" transform="translate(2897.464844 0)"/>
-    </g>
-   </g>
-   <g id="text_3">
-    <!-- F1 -->
-    <g style="fill: #172033" transform="translate(273.219594 211.762005) scale(0.056 -0.056)">
-     <defs>
-      <path id="DejaVuSans-46" d="M 628 4666
-L 3309 4666
-L 3309 4134
-L 1259 4134
-L 1259 2759
-L 3109 2759
-L 3109 2228
-L 1259 2228
-L 1259 0
-L 628 0
-L 628 4666
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-31" d="M 794 531
-L 1825 531
-L 1825 4091
-L 703 3866
-L 703 4441
-L 1819 4666
-L 2450 4666
-L 2450 531
-L 3481 531
-L 3481 0
-L 794 0
-L 794 531
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-46"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(57.519531 0)"/>
-    </g>
-   </g>
-   <g id="text_4">
-    <!-- F2 -->
-    <g style="fill: #172033" transform="translate(643.520134 211.762005) scale(0.056 -0.056)">
-     <use xlink:href="#DejaVuSans-46"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(57.519531 0)"/>
-    </g>
-   </g>
-   <g id="text_5">
-    <!-- F3 -->
-    <g style="fill: #172033" transform="translate(924.833723 211.762005) scale(0.056 -0.056)">
-     <use xlink:href="#DejaVuSans-46"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(57.519531 0)"/>
-    </g>
-   </g>
-   <g id="text_6">
-    <!-- J1 -->
-    <g style="fill: #4e79a7" transform="translate(538.140902 70.041132) scale(0.055 -0.055)">
-     <defs>
-      <path id="DejaVuSans-4a" d="M 628 4666
-L 1259 4666
-L 1259 325
-Q 1259 -519 939 -900
-Q 619 -1281 -91 -1281
-L -331 -1281
-L -331 -750
-L -134 -750
-Q 284 -750 456 -515
-Q 628 -281 628 325
-L 628 4666
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-4a"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(29.492188 0)"/>
+     <use xlink:href="#DejaVuSans-6a"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(27.783203 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(91.162109 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(154.541016 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(209.521484 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(248.730469 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(276.513672 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(337.695312 0)"/>
+     <use xlink:href="#DejaVuSans-2d" transform="translate(401.074219 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(437.158203 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(500.78125 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(564.404297 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(628.027344 0)"/>
     </g>
    </g>
    <g id="text_7">
-    <!-- J2 -->
-    <g style="fill: #2a9d8f" transform="translate(807.972303 70.041132) scale(0.055 -0.055)">
-     <use xlink:href="#DejaVuSans-4a"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(29.492188 0)"/>
+    <!-- bp 67–76 -->
+    <g style="fill: #667085" transform="translate(426.44606 102.079554) scale(0.062 -0.062)">
+     <defs>
+      <path id="DejaVuSans-37" d="M 525 4666
+L 3525 4666
+L 3525 4397
+L 1831 0
+L 1172 0
+L 2766 4134
+L 525 4134
+L 525 4666
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-62"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(63.476562 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(126.953125 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(158.740234 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(222.363281 0)"/>
+     <use xlink:href="#DejaVuSans-2013" transform="translate(285.986328 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(335.986328 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(399.609375 0)"/>
     </g>
    </g>
    <g id="text_8">
-    <!-- Each vertical stem marks one barcode-mediated three-way interface. Use view: junction_detail for exact bases. -->
-    <g style="fill: #667085" transform="translate(37.7568 268.278956) scale(0.062 -0.062)">
+    <!-- junction-0002 -->
+    <g style="fill: #1f6f70" transform="translate(708.011882 91.669351) scale(0.074 -0.074)">
+     <use xlink:href="#DejaVuSans-6a"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(27.783203 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(91.162109 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(154.541016 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(209.521484 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(248.730469 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(276.513672 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(337.695312 0)"/>
+     <use xlink:href="#DejaVuSans-2d" transform="translate(401.074219 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(437.158203 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(500.78125 0)"/>
+     <use xlink:href="#DejaVuSans-30" transform="translate(564.404297 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(628.027344 0)"/>
+    </g>
+   </g>
+   <g id="text_9">
+    <!-- bp 127–136 -->
+    <g style="fill: #667085" transform="translate(715.297086 102.079554) scale(0.062 -0.062)">
+     <use xlink:href="#DejaVuSans-62"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(63.476562 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(126.953125 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(158.740234 0)"/>
+     <use xlink:href="#DejaVuSans-32" transform="translate(222.363281 0)"/>
+     <use xlink:href="#DejaVuSans-37" transform="translate(285.986328 0)"/>
+     <use xlink:href="#DejaVuSans-2013" transform="translate(349.609375 0)"/>
+     <use xlink:href="#DejaVuSans-31" transform="translate(399.609375 0)"/>
+     <use xlink:href="#DejaVuSans-33" transform="translate(463.232422 0)"/>
+     <use xlink:href="#DejaVuSans-36" transform="translate(526.855469 0)"/>
+    </g>
+   </g>
+   <g id="text_10">
+    <!-- 5′ -->
+    <g style="fill: #667085" transform="translate(55.136439 184.94739) scale(0.072 -0.072)">
+     <defs>
+      <path id="DejaVuSans-35" d="M 691 4666
+L 3169 4666
+L 3169 4134
+L 1269 4134
+L 1269 2991
+Q 1406 3038 1543 3061
+Q 1681 3084 1819 3084
+Q 2600 3084 3056 2656
+Q 3513 2228 3513 1497
+Q 3513 744 3044 326
+Q 2575 -91 1722 -91
+Q 1428 -91 1123 -41
+Q 819 9 494 109
+L 494 744
+Q 775 591 1075 516
+Q 1375 441 1709 441
+Q 2250 441 2565 725
+Q 2881 1009 2881 1497
+Q 2881 1984 2565 2268
+Q 2250 2553 1709 2553
+Q 1456 2553 1204 2497
+Q 953 2441 691 2322
+L 691 4666
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-2032" d="M 125 3500
+L 666 4666
+L 1300 4666
+L 397 3500
+L 125 3500
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSans-35"/>
+     <use xlink:href="#DejaVuSans-2032" transform="translate(63.623047 0)"/>
+    </g>
+   </g>
+   <g id="text_11">
+    <!-- 3′ -->
+    <g style="fill: #667085" transform="translate(1054.498176 184.94739) scale(0.072 -0.072)">
+     <use xlink:href="#DejaVuSans-33"/>
+     <use xlink:href="#DejaVuSans-2032" transform="translate(63.623047 0)"/>
+    </g>
+   </g>
+   <g id="text_12">
+    <!-- 3′ -->
+    <g style="fill: #667085" transform="translate(55.136439 218.81619) scale(0.072 -0.072)">
+     <use xlink:href="#DejaVuSans-33"/>
+     <use xlink:href="#DejaVuSans-2032" transform="translate(63.623047 0)"/>
+    </g>
+   </g>
+   <g id="text_13">
+    <!-- 5′ -->
+    <g style="fill: #667085" transform="translate(1054.498176 218.81619) scale(0.072 -0.072)">
+     <use xlink:href="#DejaVuSans-35"/>
+     <use xlink:href="#DejaVuSans-2032" transform="translate(63.623047 0)"/>
+    </g>
+   </g>
+   <g id="text_14">
+    <!-- barcode stems -->
+    <g style="fill: #1f6f70" transform="translate(69.93216 151.023403) scale(0.07 -0.07)">
+     <use xlink:href="#DejaVuSans-62"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(63.476562 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(124.755859 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(163.619141 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(218.599609 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(279.78125 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(343.257812 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(404.78125 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(436.568359 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(488.667969 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(527.876953 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(589.400391 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(686.8125 0)"/>
+    </g>
+   </g>
+   <g id="text_15">
+    <!-- toeholds -->
+    <g style="fill: #8a5a00" transform="translate(69.93216 198.439723) scale(0.07 -0.07)">
+     <use xlink:href="#DejaVuSans-74"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(39.208984 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(100.390625 0)"/>
+     <use xlink:href="#DejaVuSans-68" transform="translate(161.914062 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(225.292969 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(286.474609 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(314.257812 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(377.734375 0)"/>
+    </g>
+   </g>
+   <g id="text_16">
+    <!-- Each stable junction ID opens an exact nucleotide-level view of the expected local annealing geometry -->
+    <g style="fill: #667085" transform="translate(37.7568 313.38521) scale(0.08 -0.08)">
      <defs>
       <path id="DejaVuSans-45" d="M 628 4666
 L 3578 4666
@@ -990,147 +1759,30 @@ L 628 0
 L 628 4666
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-76" d="M 191 3500
-L 800 3500
-L 1894 563
-L 2988 3500
-L 3597 3500
-L 2284 0
-L 1503 0
-L 191 3500
+      <path id="DejaVuSans-49" d="M 628 4666
+L 1259 4666
+L 1259 0
+L 628 0
+L 628 4666
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-6c" d="M 603 4863
-L 1178 4863
-L 1178 0
-L 603 0
-L 603 4863
+      <path id="DejaVuSans-44" d="M 1259 4147
+L 1259 519
+L 2022 519
+Q 2988 519 3436 956
+Q 3884 1394 3884 2338
+Q 3884 3275 3436 3711
+Q 2988 4147 2022 4147
+L 1259 4147
 z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-6b" d="M 581 4863
-L 1159 4863
-L 1159 1991
-L 2875 3500
-L 3609 3500
-L 1753 1863
-L 3688 0
-L 2938 0
-L 1159 1709
-L 1159 0
-L 581 0
-L 581 4863
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-62" d="M 3116 1747
-Q 3116 2381 2855 2742
-Q 2594 3103 2138 3103
-Q 1681 3103 1420 2742
-Q 1159 2381 1159 1747
-Q 1159 1113 1420 752
-Q 1681 391 2138 391
-Q 2594 391 2855 752
-Q 3116 1113 3116 1747
-z
-M 1159 2969
-Q 1341 3281 1617 3432
-Q 1894 3584 2278 3584
-Q 2916 3584 3314 3078
-Q 3713 2572 3713 1747
-Q 3713 922 3314 415
-Q 2916 -91 2278 -91
-Q 1894 -91 1617 61
-Q 1341 213 1159 525
-L 1159 0
-L 581 0
-L 581 4863
-L 1159 4863
-L 1159 2969
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-64" d="M 2906 2969
-L 2906 4863
-L 3481 4863
-L 3481 0
-L 2906 0
-L 2906 525
-Q 2725 213 2448 61
-Q 2172 -91 1784 -91
-Q 1150 -91 751 415
-Q 353 922 353 1747
-Q 353 2572 751 3078
-Q 1150 3584 1784 3584
-Q 2172 3584 2448 3432
-Q 2725 3281 2906 2969
-z
-M 947 1747
-Q 947 1113 1208 752
-Q 1469 391 1925 391
-Q 2381 391 2643 752
-Q 2906 1113 2906 1747
-Q 2906 2381 2643 2742
-Q 2381 3103 1925 3103
-Q 1469 3103 1208 2742
-Q 947 2381 947 1747
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-77" d="M 269 3500
-L 844 3500
-L 1563 769
-L 2278 3500
-L 2956 3500
-L 3675 769
-L 4391 3500
-L 4966 3500
-L 4050 0
-L 3372 0
-L 2619 2869
-L 1863 0
-L 1184 0
-L 269 3500
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-2e" d="M 684 794
-L 1344 794
-L 1344 0
-L 684 0
-L 684 794
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-55" d="M 556 4666
-L 1191 4666
-L 1191 1831
-Q 1191 1081 1462 751
-Q 1734 422 2344 422
-Q 2950 422 3222 751
-Q 3494 1081 3494 1831
-L 3494 4666
-L 4128 4666
-L 4128 1753
-Q 4128 841 3676 375
-Q 3225 -91 2344 -91
-Q 1459 -91 1007 375
-Q 556 841 556 1753
-L 556 4666
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-3a" d="M 750 794
-L 1409 794
-L 1409 0
-L 750 0
-L 750 794
-z
-M 750 3309
-L 1409 3309
-L 1409 2516
-L 750 2516
-L 750 3309
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-5f" d="M 3263 -1063
-L 3263 -1509
-L -63 -1509
-L -63 -1063
-L 3263 -1063
+M 628 4666
+L 1925 4666
+Q 3281 4666 3915 4102
+Q 4550 3538 4550 2338
+Q 4550 1131 3912 565
+Q 3275 0 1925 0
+L 628 0
+L 628 4666
 z
 " transform="scale(0.015625)"/>
       <path id="DejaVuSans-78" d="M 3513 3500
@@ -1148,153 +1800,141 @@ L 2834 3500
 L 3513 3500
 z
 " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-76" d="M 191 3500
+L 800 3500
+L 1894 563
+L 2988 3500
+L 3597 3500
+L 2284 0
+L 1503 0
+L 191 3500
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-79" d="M 2059 -325
+Q 1816 -950 1584 -1140
+Q 1353 -1331 966 -1331
+L 506 -1331
+L 506 -850
+L 844 -850
+Q 1081 -850 1212 -737
+Q 1344 -625 1503 -206
+L 1606 56
+L 191 3500
+L 800 3500
+L 1894 763
+L 2988 3500
+L 3597 3500
+L 2059 -325
+z
+" transform="scale(0.015625)"/>
      </defs>
      <use xlink:href="#DejaVuSans-45"/>
      <use xlink:href="#DejaVuSans-61" transform="translate(63.183594 0)"/>
      <use xlink:href="#DejaVuSans-63" transform="translate(124.462891 0)"/>
      <use xlink:href="#DejaVuSans-68" transform="translate(179.443359 0)"/>
      <use xlink:href="#DejaVuSans-20" transform="translate(242.822266 0)"/>
-     <use xlink:href="#DejaVuSans-76" transform="translate(274.609375 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(333.789062 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(395.3125 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(436.425781 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(475.634766 0)"/>
-     <use xlink:href="#DejaVuSans-63" transform="translate(503.417969 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(558.398438 0)"/>
-     <use xlink:href="#DejaVuSans-6c" transform="translate(619.677734 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(647.460938 0)"/>
-     <use xlink:href="#DejaVuSans-73" transform="translate(679.248047 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(731.347656 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(770.556641 0)"/>
-     <use xlink:href="#DejaVuSans-6d" transform="translate(832.080078 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(929.492188 0)"/>
-     <use xlink:href="#DejaVuSans-6d" transform="translate(961.279297 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(1058.691406 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(1119.970703 0)"/>
-     <use xlink:href="#DejaVuSans-6b" transform="translate(1161.083984 0)"/>
-     <use xlink:href="#DejaVuSans-73" transform="translate(1218.994141 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(1271.09375 0)"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(1302.880859 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(1364.0625 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(1427.441406 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(1488.964844 0)"/>
-     <use xlink:href="#DejaVuSans-62" transform="translate(1520.751953 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(1584.228516 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(1645.507812 0)"/>
-     <use xlink:href="#DejaVuSans-63" transform="translate(1684.371094 0)"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(1739.351562 0)"/>
-     <use xlink:href="#DejaVuSans-64" transform="translate(1800.533203 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(1864.009766 0)"/>
-     <use xlink:href="#DejaVuSans-2d" transform="translate(1925.533203 0)"/>
-     <use xlink:href="#DejaVuSans-6d" transform="translate(1961.617188 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(2059.029297 0)"/>
-     <use xlink:href="#DejaVuSans-64" transform="translate(2120.552734 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(2184.029297 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(2211.8125 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(2273.091797 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(2312.300781 0)"/>
-     <use xlink:href="#DejaVuSans-64" transform="translate(2373.824219 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(2437.300781 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(2469.087891 0)"/>
-     <use xlink:href="#DejaVuSans-68" transform="translate(2508.296875 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(2571.675781 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(2610.539062 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(2672.0625 0)"/>
-     <use xlink:href="#DejaVuSans-2d" transform="translate(2733.585938 0)"/>
-     <use xlink:href="#DejaVuSans-77" transform="translate(2769.669922 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(2851.457031 0)"/>
-     <use xlink:href="#DejaVuSans-79" transform="translate(2912.736328 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(2971.916016 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(3003.703125 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(3031.486328 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(3094.865234 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(3134.074219 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(3195.597656 0)"/>
-     <use xlink:href="#DejaVuSans-66" transform="translate(3236.710938 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(3271.916016 0)"/>
-     <use xlink:href="#DejaVuSans-63" transform="translate(3333.195312 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(3388.175781 0)"/>
-     <use xlink:href="#DejaVuSans-2e" transform="translate(3449.699219 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(3481.486328 0)"/>
-     <use xlink:href="#DejaVuSans-55" transform="translate(3513.273438 0)"/>
-     <use xlink:href="#DejaVuSans-73" transform="translate(3586.466797 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(3638.566406 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(3700.089844 0)"/>
-     <use xlink:href="#DejaVuSans-76" transform="translate(3731.876953 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(3791.056641 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(3818.839844 0)"/>
-     <use xlink:href="#DejaVuSans-77" transform="translate(3880.363281 0)"/>
-     <use xlink:href="#DejaVuSans-3a" transform="translate(3956.650391 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(3990.341797 0)"/>
-     <use xlink:href="#DejaVuSans-6a" transform="translate(4022.128906 0)"/>
-     <use xlink:href="#DejaVuSans-75" transform="translate(4049.912109 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(4113.291016 0)"/>
-     <use xlink:href="#DejaVuSans-63" transform="translate(4176.669922 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(4231.650391 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(4270.859375 0)"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(4298.642578 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(4359.824219 0)"/>
-     <use xlink:href="#DejaVuSans-5f" transform="translate(4423.203125 0)"/>
-     <use xlink:href="#DejaVuSans-64" transform="translate(4473.203125 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(4536.679688 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(4598.203125 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(4637.412109 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(4698.691406 0)"/>
-     <use xlink:href="#DejaVuSans-6c" transform="translate(4726.474609 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(4754.257812 0)"/>
-     <use xlink:href="#DejaVuSans-66" transform="translate(4786.044922 0)"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(4821.25 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(4882.431641 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(4923.544922 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(4955.332031 0)"/>
-     <use xlink:href="#DejaVuSans-78" transform="translate(5015.105469 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(5074.285156 0)"/>
-     <use xlink:href="#DejaVuSans-63" transform="translate(5135.564453 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(5190.544922 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(5229.753906 0)"/>
-     <use xlink:href="#DejaVuSans-62" transform="translate(5261.541016 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(5325.017578 0)"/>
-     <use xlink:href="#DejaVuSans-73" transform="translate(5386.296875 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(5438.396484 0)"/>
-     <use xlink:href="#DejaVuSans-73" transform="translate(5499.919922 0)"/>
-     <use xlink:href="#DejaVuSans-2e" transform="translate(5552.019531 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(274.609375 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(326.708984 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(365.917969 0)"/>
+     <use xlink:href="#DejaVuSans-62" transform="translate(427.197266 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(490.673828 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(518.457031 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(579.980469 0)"/>
+     <use xlink:href="#DejaVuSans-6a" transform="translate(611.767578 0)"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(639.550781 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(702.929688 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(766.308594 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(821.289062 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(860.498047 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(888.28125 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(949.462891 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1012.841797 0)"/>
+     <use xlink:href="#DejaVuSans-49" transform="translate(1044.628906 0)"/>
+     <use xlink:href="#DejaVuSans-44" transform="translate(1074.121094 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1151.123047 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(1182.910156 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(1244.091797 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(1307.568359 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(1369.091797 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(1432.470703 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1484.570312 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(1516.357422 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(1577.636719 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1641.015625 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(1672.802734 0)"/>
+     <use xlink:href="#DejaVuSans-78" transform="translate(1732.576172 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(1791.755859 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(1853.035156 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(1908.015625 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1947.224609 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(1979.011719 0)"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(2042.390625 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(2105.769531 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(2160.75 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(2188.533203 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(2250.056641 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(2311.238281 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(2350.447266 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(2378.230469 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(2441.707031 0)"/>
+     <use xlink:href="#DejaVuSans-2d" transform="translate(2503.230469 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(2539.314453 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(2567.097656 0)"/>
+     <use xlink:href="#DejaVuSans-76" transform="translate(2628.621094 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(2687.800781 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(2749.324219 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2777.107422 0)"/>
+     <use xlink:href="#DejaVuSans-76" transform="translate(2808.894531 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(2868.074219 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(2895.857422 0)"/>
+     <use xlink:href="#DejaVuSans-77" transform="translate(2957.380859 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3039.167969 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(3070.955078 0)"/>
+     <use xlink:href="#DejaVuSans-66" transform="translate(3132.136719 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3167.341797 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(3199.128906 0)"/>
+     <use xlink:href="#DejaVuSans-68" transform="translate(3238.337891 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(3301.716797 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3363.240234 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(3395.027344 0)"/>
+     <use xlink:href="#DejaVuSans-78" transform="translate(3454.800781 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(3513.980469 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(3577.457031 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(3638.980469 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(3693.960938 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(3733.169922 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(3794.693359 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3858.169922 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(3889.957031 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(3917.740234 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(3978.921875 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(4033.902344 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(4095.181641 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(4122.964844 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(4154.751953 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(4216.03125 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(4279.410156 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(4342.789062 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(4404.3125 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(4465.591797 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(4493.375 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(4521.158203 0)"/>
+     <use xlink:href="#DejaVuSans-67" transform="translate(4584.537109 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(4648.013672 0)"/>
+     <use xlink:href="#DejaVuSans-67" transform="translate(4679.800781 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(4743.277344 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(4804.800781 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(4865.982422 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(4963.394531 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(5024.917969 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(5064.126953 0)"/>
+     <use xlink:href="#DejaVuSans-79" transform="translate(5105.240234 0)"/>
     </g>
    </g>
-   <g id="text_9">
-    <!-- Sequence-derived topology; not a structure or assembly simulation. -->
-    <g style="fill: #667085" transform="translate(852.083512 268.492988) scale(0.06 -0.06)">
+   <g id="text_17">
+    <!-- The map is sequence-derived and does not establish assembly success -->
+    <g style="fill: #667085" transform="translate(770.6432 313.38521) scale(0.08 -0.08)">
      <defs>
-      <path id="DejaVuSans-53" d="M 3425 4513
-L 3425 3897
-Q 3066 4069 2747 4153
-Q 2428 4238 2131 4238
-Q 1616 4238 1336 4038
-Q 1056 3838 1056 3469
-Q 1056 3159 1242 3001
-Q 1428 2844 1947 2747
-L 2328 2669
-Q 3034 2534 3370 2195
-Q 3706 1856 3706 1288
-Q 3706 609 3251 259
-Q 2797 -91 1919 -91
-Q 1588 -91 1214 -16
-Q 841 59 441 206
-L 441 856
-Q 825 641 1194 531
-Q 1563 422 1919 422
-Q 2459 422 2753 634
-Q 3047 847 3047 1241
-Q 3047 1584 2836 1778
-Q 2625 1972 2144 2069
-L 1759 2144
-Q 1053 2284 737 2584
-Q 422 2884 422 3419
-Q 422 4038 858 4394
-Q 1294 4750 2059 4750
-Q 2388 4750 2728 4690
-Q 3069 4631 3425 4513
-z
-" transform="scale(0.015625)"/>
       <path id="DejaVuSans-71" d="M 947 1747
 Q 947 1113 1208 752
 Q 1469 391 1925 391
@@ -1321,121 +1961,221 @@ L 2906 -1331
 L 2906 525
 z
 " transform="scale(0.015625)"/>
-      <path id="DejaVuSans-70" d="M 1159 525
-L 1159 -1331
-L 581 -1331
-L 581 3500
-L 1159 3500
-L 1159 2969
-Q 1341 3281 1617 3432
-Q 1894 3584 2278 3584
-Q 2916 3584 3314 3078
-Q 3713 2572 3713 1747
-Q 3713 922 3314 415
-Q 2916 -91 2278 -91
-Q 1894 -91 1617 61
-Q 1341 213 1159 525
-z
-M 3116 1747
-Q 3116 2381 2855 2742
-Q 2594 3103 2138 3103
-Q 1681 3103 1420 2742
-Q 1159 2381 1159 1747
-Q 1159 1113 1420 752
-Q 1681 391 2138 391
-Q 2594 391 2855 752
-Q 3116 1113 3116 1747
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-3b" d="M 750 3309
-L 1409 3309
-L 1409 2516
-L 750 2516
-L 750 3309
-z
-M 750 794
-L 1409 794
-L 1409 256
-L 897 -744
-L 494 -744
-L 750 256
-L 750 794
-z
-" transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-53"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(63.476562 0)"/>
-     <use xlink:href="#DejaVuSans-71" transform="translate(125 0)"/>
-     <use xlink:href="#DejaVuSans-75" transform="translate(188.476562 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(251.855469 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(313.378906 0)"/>
-     <use xlink:href="#DejaVuSans-63" transform="translate(376.757812 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(431.738281 0)"/>
-     <use xlink:href="#DejaVuSans-2d" transform="translate(493.261719 0)"/>
-     <use xlink:href="#DejaVuSans-64" transform="translate(529.345703 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(592.822266 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(654.345703 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(695.458984 0)"/>
-     <use xlink:href="#DejaVuSans-76" transform="translate(723.242188 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(782.421875 0)"/>
-     <use xlink:href="#DejaVuSans-64" transform="translate(843.945312 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(907.421875 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(939.208984 0)"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(978.417969 0)"/>
-     <use xlink:href="#DejaVuSans-70" transform="translate(1039.599609 0)"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(1103.076172 0)"/>
-     <use xlink:href="#DejaVuSans-6c" transform="translate(1164.257812 0)"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(1192.041016 0)"/>
-     <use xlink:href="#DejaVuSans-67" transform="translate(1253.222656 0)"/>
-     <use xlink:href="#DejaVuSans-79" transform="translate(1316.699219 0)"/>
-     <use xlink:href="#DejaVuSans-3b" transform="translate(1375.878906 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(1409.570312 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(1441.357422 0)"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(1504.736328 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(1565.917969 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(1605.126953 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(1636.914062 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(1698.193359 0)"/>
-     <use xlink:href="#DejaVuSans-73" transform="translate(1729.980469 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(1782.080078 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(1821.289062 0)"/>
-     <use xlink:href="#DejaVuSans-75" transform="translate(1862.402344 0)"/>
-     <use xlink:href="#DejaVuSans-63" transform="translate(1925.78125 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(1980.761719 0)"/>
-     <use xlink:href="#DejaVuSans-75" transform="translate(2019.970703 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(2083.349609 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(2122.212891 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(2183.736328 0)"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(2215.523438 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(2276.705078 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(2317.818359 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(2349.605469 0)"/>
-     <use xlink:href="#DejaVuSans-73" transform="translate(2410.884766 0)"/>
-     <use xlink:href="#DejaVuSans-73" transform="translate(2462.984375 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(2515.083984 0)"/>
-     <use xlink:href="#DejaVuSans-6d" transform="translate(2576.607422 0)"/>
-     <use xlink:href="#DejaVuSans-62" transform="translate(2674.019531 0)"/>
-     <use xlink:href="#DejaVuSans-6c" transform="translate(2737.496094 0)"/>
-     <use xlink:href="#DejaVuSans-79" transform="translate(2765.279297 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(2824.458984 0)"/>
-     <use xlink:href="#DejaVuSans-73" transform="translate(2856.246094 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(2908.345703 0)"/>
-     <use xlink:href="#DejaVuSans-6d" transform="translate(2936.128906 0)"/>
-     <use xlink:href="#DejaVuSans-75" transform="translate(3033.541016 0)"/>
-     <use xlink:href="#DejaVuSans-6c" transform="translate(3096.919922 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(3124.703125 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(3185.982422 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(3225.191406 0)"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(3252.974609 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(3314.15625 0)"/>
-     <use xlink:href="#DejaVuSans-2e" transform="translate(3377.535156 0)"/>
+     <use xlink:href="#DejaVuSans-54"/>
+     <use xlink:href="#DejaVuSans-68" transform="translate(61.083984 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(124.462891 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(185.986328 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(217.773438 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(315.185547 0)"/>
+     <use xlink:href="#DejaVuSans-70" transform="translate(376.464844 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(439.941406 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(471.728516 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(499.511719 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(551.611328 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(583.398438 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(635.498047 0)"/>
+     <use xlink:href="#DejaVuSans-71" transform="translate(697.021484 0)"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(760.498047 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(823.876953 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(885.400391 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(948.779297 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(1003.759766 0)"/>
+     <use xlink:href="#DejaVuSans-2d" transform="translate(1065.283203 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(1101.367188 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(1164.84375 0)"/>
+     <use xlink:href="#DejaVuSans-72" transform="translate(1226.367188 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(1267.480469 0)"/>
+     <use xlink:href="#DejaVuSans-76" transform="translate(1295.263672 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(1354.443359 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(1415.966797 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1479.443359 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(1511.230469 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(1572.509766 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(1635.888672 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1699.365234 0)"/>
+     <use xlink:href="#DejaVuSans-64" transform="translate(1731.152344 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(1794.628906 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(1855.810547 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(1917.333984 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(1969.433594 0)"/>
+     <use xlink:href="#DejaVuSans-6e" transform="translate(2001.220703 0)"/>
+     <use xlink:href="#DejaVuSans-6f" transform="translate(2064.599609 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(2125.78125 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2164.990234 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(2196.777344 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(2258.300781 0)"/>
+     <use xlink:href="#DejaVuSans-74" transform="translate(2310.400391 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(2349.609375 0)"/>
+     <use xlink:href="#DejaVuSans-62" transform="translate(2410.888672 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(2474.365234 0)"/>
+     <use xlink:href="#DejaVuSans-69" transform="translate(2502.148438 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(2529.931641 0)"/>
+     <use xlink:href="#DejaVuSans-68" transform="translate(2582.03125 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(2645.410156 0)"/>
+     <use xlink:href="#DejaVuSans-61" transform="translate(2677.197266 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(2738.476562 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(2790.576172 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(2842.675781 0)"/>
+     <use xlink:href="#DejaVuSans-6d" transform="translate(2904.199219 0)"/>
+     <use xlink:href="#DejaVuSans-62" transform="translate(3001.611328 0)"/>
+     <use xlink:href="#DejaVuSans-6c" transform="translate(3065.087891 0)"/>
+     <use xlink:href="#DejaVuSans-79" transform="translate(3092.871094 0)"/>
+     <use xlink:href="#DejaVuSans-20" transform="translate(3152.050781 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(3183.837891 0)"/>
+     <use xlink:href="#DejaVuSans-75" transform="translate(3235.9375 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(3299.316406 0)"/>
+     <use xlink:href="#DejaVuSans-63" transform="translate(3354.296875 0)"/>
+     <use xlink:href="#DejaVuSans-65" transform="translate(3409.277344 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(3470.800781 0)"/>
+     <use xlink:href="#DejaVuSans-73" transform="translate(3522.900391 0)"/>
     </g>
+   </g>
+   <g id="line2d_1">
+    <path d="M 389.326234 227.667456
+L 394.688794 205.991424
+" clip-path="url(#p93cbc2dd8a)" style="fill: none; stroke: #172033; stroke-width: 1.1; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_2">
+    <path d="M 682.12201 227.667456
+L 687.48457 205.991424
+" clip-path="url(#p93cbc2dd8a)" style="fill: none; stroke: #172033; stroke-width: 1.1; stroke-linecap: square"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p1b5c04efdb">
-   <rect x="10.944" y="3.024" width="1072.512" height="296.352"/>
+  <clipPath id="p93cbc2dd8a">
+   <rect x="10.944" y="3.456" width="1072.512" height="338.688"/>
+  </clipPath>
+  <clipPath id="pb5fea5629a">
+   <path d="M 97.817472 191.766528
+L 1018.032768 191.766528
+Q 1045.91808 191.766528 1045.91808 182.96064
+L 1045.91808 182.96064
+Q 1045.91808 174.154752 1018.032768 174.154752
+L 97.817472 174.154752
+Q 69.93216 174.154752 69.93216 182.96064
+L 69.93216 182.96064
+Q 69.93216 191.766528 97.817472 191.766528
+z
+"/>
+  </clipPath>
+  <clipPath id="pabf2ef6fb0">
+   <path d="M 97.817472 191.766528
+L 1018.032768 191.766528
+Q 1045.91808 191.766528 1045.91808 182.96064
+L 1045.91808 182.96064
+Q 1045.91808 174.154752 1018.032768 174.154752
+L 97.817472 174.154752
+Q 69.93216 174.154752 69.93216 182.96064
+L 69.93216 182.96064
+Q 69.93216 191.766528 97.817472 191.766528
+z
+"/>
+  </clipPath>
+  <clipPath id="p8aee74c80a">
+   <path d="M 97.817472 191.766528
+L 1018.032768 191.766528
+Q 1045.91808 191.766528 1045.91808 182.96064
+L 1045.91808 182.96064
+Q 1045.91808 174.154752 1018.032768 174.154752
+L 97.817472 174.154752
+Q 69.93216 174.154752 69.93216 182.96064
+L 69.93216 182.96064
+Q 69.93216 191.766528 97.817472 191.766528
+z
+"/>
+  </clipPath>
+  <clipPath id="pd829a155ec">
+   <path d="M 97.817472 191.766528
+L 1018.032768 191.766528
+Q 1045.91808 191.766528 1045.91808 182.96064
+L 1045.91808 182.96064
+Q 1045.91808 174.154752 1018.032768 174.154752
+L 97.817472 174.154752
+Q 69.93216 174.154752 69.93216 182.96064
+L 69.93216 182.96064
+Q 69.93216 191.766528 97.817472 191.766528
+z
+"/>
+  </clipPath>
+  <clipPath id="p5db4f402a5">
+   <path d="M 97.817472 191.766528
+L 1018.032768 191.766528
+Q 1045.91808 191.766528 1045.91808 182.96064
+L 1045.91808 182.96064
+Q 1045.91808 174.154752 1018.032768 174.154752
+L 97.817472 174.154752
+Q 69.93216 174.154752 69.93216 182.96064
+L 69.93216 182.96064
+Q 69.93216 191.766528 97.817472 191.766528
+z
+"/>
+  </clipPath>
+  <clipPath id="pbdf66af590">
+   <path d="M 97.817472 225.635328
+L 1018.032768 225.635328
+Q 1045.91808 225.635328 1045.91808 216.82944
+L 1045.91808 216.82944
+Q 1045.91808 208.023552 1018.032768 208.023552
+L 97.817472 208.023552
+Q 69.93216 208.023552 69.93216 216.82944
+L 69.93216 216.82944
+Q 69.93216 225.635328 97.817472 225.635328
+z
+"/>
+  </clipPath>
+  <clipPath id="p5288c438b0">
+   <path d="M 97.817472 225.635328
+L 1018.032768 225.635328
+Q 1045.91808 225.635328 1045.91808 216.82944
+L 1045.91808 216.82944
+Q 1045.91808 208.023552 1018.032768 208.023552
+L 97.817472 208.023552
+Q 69.93216 208.023552 69.93216 216.82944
+L 69.93216 216.82944
+Q 69.93216 225.635328 97.817472 225.635328
+z
+"/>
+  </clipPath>
+  <clipPath id="p7673eb6e4d">
+   <path d="M 97.817472 225.635328
+L 1018.032768 225.635328
+Q 1045.91808 225.635328 1045.91808 216.82944
+L 1045.91808 216.82944
+Q 1045.91808 208.023552 1018.032768 208.023552
+L 97.817472 208.023552
+Q 69.93216 208.023552 69.93216 216.82944
+L 69.93216 216.82944
+Q 69.93216 225.635328 97.817472 225.635328
+z
+"/>
+  </clipPath>
+  <clipPath id="pa5a05a162e">
+   <path d="M 97.817472 225.635328
+L 1018.032768 225.635328
+Q 1045.91808 225.635328 1045.91808 216.82944
+L 1045.91808 216.82944
+Q 1045.91808 208.023552 1018.032768 208.023552
+L 97.817472 208.023552
+Q 69.93216 208.023552 69.93216 216.82944
+L 69.93216 216.82944
+Q 69.93216 225.635328 97.817472 225.635328
+z
+"/>
+  </clipPath>
+  <clipPath id="p9a08d979ee">
+   <path d="M 97.817472 225.635328
+L 1018.032768 225.635328
+Q 1045.91808 225.635328 1045.91808 216.82944
+L 1045.91808 216.82944
+Q 1045.91808 208.023552 1018.032768 208.023552
+L 97.817472 208.023552
+Q 69.93216 208.023552 69.93216 216.82944
+L 69.93216 216.82944
+Q 69.93216 225.635328 97.817472 225.635328
+z
+"/>
   </clipPath>
  </defs>
 </svg>

--- a/src/dnadesign/junction/docs/assets/junction-detail.svg
+++ b/src/dnadesign/junction/docs/assets/junction-detail.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
   "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="1094.4pt" height="370.8pt" viewBox="0 0 1094.4 370.8" xmlns="http://www.w3.org/2000/svg" version="1.1">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="1094.4pt" height="464.4pt" viewBox="0 0 1094.4 464.4" xmlns="http://www.w3.org/2000/svg" version="1.1">
  <metadata>
   <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
    <cc:Work>
@@ -20,224 +20,391 @@
  </defs>
  <g id="figure_1">
   <g id="patch_1">
-   <path d="M 0 370.8
-L 1094.4 370.8
+   <path d="M 0 464.4
+L 1094.4 464.4
 L 1094.4 0
 L 0 0
 z
 " style="fill: #ffffff"/>
   </g>
   <g id="junction-three-way-assembly:synthetic-three-fragment-target:junction-0001:detail">
-   <g id="patch_2">
-    <path d="M 157.641882 170.758035
-L 280.560706 170.758035
-L 280.560706 152.505405
-L 157.641882 152.505405
-z
-" clip-path="url(#p1ed6e3343e)" style="fill: #4e79a7; opacity: 0.24"/>
-   </g>
-   <g id="patch_3">
-    <path d="M 157.641882 217.219275
-L 280.560706 217.219275
-L 280.560706 198.966645
-L 157.641882 198.966645
-z
-" clip-path="url(#p1ed6e3343e)" style="fill: #4e79a7; opacity: 0.24"/>
-   </g>
-   <g id="patch_4">
-    <path d="M 268.791882 161.63172
-L 284.483647 161.63172
-L 284.483647 78.66522
-L 268.791882 78.66522
-z
-" clip-path="url(#p1ed6e3343e)" style="fill: #4e79a7; opacity: 0.22"/>
-   </g>
-   <g id="patch_5">
-    <path d="M 292.329529 161.63172
-L 308.021294 161.63172
-L 308.021294 78.66522
-L 292.329529 78.66522
-z
-" clip-path="url(#p1ed6e3343e)" style="fill: #4e79a7; opacity: 0.22"/>
-   </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0001:target-pairs">
-    <path d="M 95.528647 167.439375
-L 95.528647 202.285305
-" clip-path="url(#p1ed6e3343e)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 107.297471 167.439375
-L 107.297471 202.285305
-" clip-path="url(#p1ed6e3343e)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 119.066294 167.439375
-L 119.066294 202.285305
-" clip-path="url(#p1ed6e3343e)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 130.835118 167.439375
-L 130.835118 202.285305
-" clip-path="url(#p1ed6e3343e)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 142.603941 167.439375
-L 142.603941 202.285305
-" clip-path="url(#p1ed6e3343e)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 154.372765 167.439375
-L 154.372765 202.285305
-" clip-path="url(#p1ed6e3343e)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 166.141588 167.439375
-L 166.141588 202.285305
-" clip-path="url(#p1ed6e3343e)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 177.910412 167.439375
-L 177.910412 202.285305
-" clip-path="url(#p1ed6e3343e)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 189.679235 167.439375
-L 189.679235 202.285305
-" clip-path="url(#p1ed6e3343e)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 201.448059 167.439375
-L 201.448059 202.285305
-" clip-path="url(#p1ed6e3343e)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 213.216882 167.439375
-L 213.216882 202.285305
-" clip-path="url(#p1ed6e3343e)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 224.985706 167.439375
-L 224.985706 202.285305
-" clip-path="url(#p1ed6e3343e)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 236.754529 167.439375
-L 236.754529 202.285305
-" clip-path="url(#p1ed6e3343e)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 248.523353 167.439375
-L 248.523353 202.285305
-" clip-path="url(#p1ed6e3343e)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 260.292176 167.439375
-L 260.292176 202.285305
-" clip-path="url(#p1ed6e3343e)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 272.061 167.439375
-L 272.061 202.285305
-" clip-path="url(#p1ed6e3343e)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 304.752176 167.439375
-L 304.752176 202.285305
-" clip-path="url(#p1ed6e3343e)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 316.521 167.439375
-L 316.521 202.285305
-" clip-path="url(#p1ed6e3343e)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 328.289824 167.439375
-L 328.289824 202.285305
-" clip-path="url(#p1ed6e3343e)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 340.058647 167.439375
-L 340.058647 202.285305
-" clip-path="url(#p1ed6e3343e)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 351.827471 167.439375
-L 351.827471 202.285305
-" clip-path="url(#p1ed6e3343e)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 363.596294 167.439375
-L 363.596294 202.285305
-" clip-path="url(#p1ed6e3343e)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-   </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-pairs">
-    <path d="M 283.699059 146.471478
-L 293.114118 146.471478
-" clip-path="url(#p1ed6e3343e)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 283.699059 142.700273
-L 293.114118 142.700273
-" clip-path="url(#p1ed6e3343e)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 283.699059 138.929069
-L 293.114118 138.929069
-" clip-path="url(#p1ed6e3343e)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 283.699059 135.157864
-L 293.114118 135.157864
-" clip-path="url(#p1ed6e3343e)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 283.699059 131.38666
-L 293.114118 131.38666
-" clip-path="url(#p1ed6e3343e)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 283.699059 127.615455
-L 293.114118 127.615455
-" clip-path="url(#p1ed6e3343e)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 283.699059 123.84425
-L 293.114118 123.84425
-" clip-path="url(#p1ed6e3343e)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 283.699059 120.073046
-L 293.114118 120.073046
-" clip-path="url(#p1ed6e3343e)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 283.699059 116.301841
-L 293.114118 116.301841
-" clip-path="url(#p1ed6e3343e)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 283.699059 112.530637
-L 293.114118 112.530637
-" clip-path="url(#p1ed6e3343e)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 283.699059 108.759432
-L 293.114118 108.759432
-" clip-path="url(#p1ed6e3343e)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 283.699059 104.988228
-L 293.114118 104.988228
-" clip-path="url(#p1ed6e3343e)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 283.699059 101.217023
-L 293.114118 101.217023
-" clip-path="url(#p1ed6e3343e)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 283.699059 97.445819
-L 293.114118 97.445819
-" clip-path="url(#p1ed6e3343e)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 283.699059 93.674614
-L 293.114118 93.674614
-" clip-path="url(#p1ed6e3343e)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 283.699059 89.90341
-L 293.114118 89.90341
-" clip-path="url(#p1ed6e3343e)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 283.699059 86.132205
-L 293.114118 86.132205
-" clip-path="url(#p1ed6e3343e)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 283.699059 82.361
-L 293.114118 82.361
-" clip-path="url(#p1ed6e3343e)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 283.699059 78.589796
-L 293.114118 78.589796
-" clip-path="url(#p1ed6e3343e)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 283.699059 74.818591
-L 293.114118 74.818591
-" clip-path="url(#p1ed6e3343e)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 283.699059 71.047387
-L 293.114118 71.047387
-" clip-path="url(#p1ed6e3343e)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 283.699059 67.276182
-L 293.114118 67.276182
-" clip-path="url(#p1ed6e3343e)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-   </g>
    <g id="junction:synthetic-three-fragment-target:junction-0001:left-and-barcode-arm">
-    <path d="M 89.644235 161.63172
-L 268.791882 161.63172
-L 268.791882 65.39058
-" clip-path="url(#p1ed6e3343e)" style="fill: none; stroke: #172033; stroke-width: 1.1; stroke-linecap: round"/>
+    <path d="M 94.969039 365.456263
+L 270.342401 365.456263
+L 270.342401 101.478034
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #7c8798; stroke-width: 11; stroke-linecap: round"/>
    </g>
    <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-and-right-arm">
-    <path d="M 308.021294 65.39058
-L 308.021294 161.63172
-L 369.480706 161.63172
-" clip-path="url(#p1ed6e3343e)" style="fill: none; stroke: #172033; stroke-width: 1.1; stroke-linecap: round"/>
+    <path d="M 286.869734 101.478034
+L 286.869734 365.456263
+L 462.243096 365.456263
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #7c8798; stroke-width: 11; stroke-linecap: round"/>
    </g>
    <g id="junction:synthetic-three-fragment-target:junction-0001:left-complement-arm">
-    <path d="M 89.644235 208.09296
-L 157.118824 208.09296
-" clip-path="url(#p1ed6e3343e)" style="fill: none; stroke: #4b5563; stroke-width: 1.1; stroke-linecap: round"/>
+    <path d="M 94.969039 395.29728
+L 159.930638 395.29728
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #7c8798; stroke-width: 11; stroke-linecap: round"/>
    </g>
    <g id="junction:synthetic-three-fragment-target:junction-0001:right-complement-arm">
-    <path d="M 163.395529 208.09296
-L 369.480706 208.09296
-" clip-path="url(#p1ed6e3343e)" style="fill: none; stroke: #4b5563; stroke-width: 1.1; stroke-linecap: round"/>
+    <path d="M 167.735211 395.29728
+L 462.243096 395.29728
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #7c8798; stroke-width: 11; stroke-linecap: round"/>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0001:nick">
-    <path d="M 157.118824 215.559945
-L 163.395529 200.625975
-" clip-path="url(#p1ed6e3343e)" style="fill: none; stroke: #111827; stroke-width: 1.1; stroke-linecap: square"/>
+   <g id="junction:synthetic-three-fragment-target:junction-0001:left-target-top">
+    <path d="M 94.969039 365.456263
+L 163.832924 365.456263
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #e8ebef; stroke-width: 8.5; stroke-linecap: round"/>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0001:left-target-bottom">
+    <path d="M 94.969039 395.29728
+L 159.930638 395.29728
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #e8ebef; stroke-width: 8.5; stroke-linecap: round"/>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0001:toehold-top-path">
+    <path d="M 163.832924 365.456263
+L 270.342401 365.456263
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #f3d6a1; stroke-width: 8.5; stroke-linecap: round"/>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-left-path">
+    <path d="M 270.342401 365.456263
+L 270.342401 101.478034
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #a9d8d5; stroke-width: 8.5; stroke-linecap: round"/>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-right-path">
+    <path d="M 286.869734 101.478034
+L 286.869734 365.456263
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #a9d8d5; stroke-width: 8.5; stroke-linecap: round"/>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0001:right-target-top">
+    <path d="M 286.869734 365.456263
+L 462.243096 365.456263
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #e8ebef; stroke-width: 8.5; stroke-linecap: round"/>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0001:right-target-bottom">
+    <path d="M 278.606067 395.29728
+L 462.243096 395.29728
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #e8ebef; stroke-width: 8.5; stroke-linecap: round"/>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0001:toehold-bottom-path">
+    <path d="M 167.735211 395.29728
+L 278.606067 395.29728
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #f3d6a1; stroke-width: 8.5; stroke-linecap: round"/>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0001:target-pairs">
+    <path d="M 100.707696 370.965374
+L 100.707696 389.788169
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 112.18501 370.965374
+L 112.18501 389.788169
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 123.662324 370.965374
+L 123.662324 389.788169
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 135.139639 370.965374
+L 135.139639 389.788169
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 146.616953 370.965374
+L 146.616953 389.788169
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 158.094267 370.965374
+L 158.094267 389.788169
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 169.571582 370.965374
+L 169.571582 389.788169
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 181.048896 370.965374
+L 181.048896 389.788169
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 192.52621 370.965374
+L 192.52621 389.788169
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 204.003524 370.965374
+L 204.003524 389.788169
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 215.480839 370.965374
+L 215.480839 389.788169
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 226.958153 370.965374
+L 226.958153 389.788169
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 238.435467 370.965374
+L 238.435467 389.788169
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 249.912782 370.965374
+L 249.912782 389.788169
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 261.390096 370.965374
+L 261.390096 389.788169
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 272.86741 370.965374
+L 272.86741 389.788169
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 284.344724 370.965374
+L 284.344724 389.788169
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 295.822039 370.965374
+L 295.822039 389.788169
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 307.299353 370.965374
+L 307.299353 389.788169
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 318.776667 370.965374
+L 318.776667 389.788169
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 330.253982 370.965374
+L 330.253982 389.788169
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 341.731296 370.965374
+L 341.731296 389.788169
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 353.20861 370.965374
+L 353.20861 389.788169
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 364.685924 370.965374
+L 364.685924 389.788169
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 376.163239 370.965374
+L 376.163239 389.788169
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 387.640553 370.965374
+L 387.640553 389.788169
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 399.117867 370.965374
+L 399.117867 389.788169
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 410.595182 370.965374
+L 410.595182 389.788169
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 422.072496 370.965374
+L 422.072496 389.788169
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 433.54981 370.965374
+L 433.54981 389.788169
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 445.027124 370.965374
+L 445.027124 389.788169
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 456.504439 370.965374
+L 456.504439 389.788169
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-pairs">
+    <path d="M 274.015142 348.240291
+L 283.196993 348.240291
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 274.015142 336.762977
+L 283.196993 336.762977
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 274.015142 325.285663
+L 283.196993 325.285663
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 274.015142 313.808349
+L 283.196993 313.808349
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 274.015142 302.331034
+L 283.196993 302.331034
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 274.015142 290.85372
+L 283.196993 290.85372
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 274.015142 279.376406
+L 283.196993 279.376406
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 274.015142 267.899091
+L 283.196993 267.899091
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 274.015142 256.421777
+L 283.196993 256.421777
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 274.015142 244.944463
+L 283.196993 244.944463
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 274.015142 233.467149
+L 283.196993 233.467149
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 274.015142 221.989834
+L 283.196993 221.989834
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 274.015142 210.51252
+L 283.196993 210.51252
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 274.015142 199.035206
+L 283.196993 199.035206
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 274.015142 187.557891
+L 283.196993 187.557891
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 274.015142 176.080577
+L 283.196993 176.080577
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 274.015142 164.603263
+L 283.196993 164.603263
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 274.015142 153.125949
+L 283.196993 153.125949
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 274.015142 141.648634
+L 283.196993 141.648634
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 274.015142 130.17132
+L 283.196993 130.17132
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 274.015142 118.694006
+L 283.196993 118.694006
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 274.015142 107.216691
+L 283.196993 107.216691
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
    </g>
    <g id="text_1">
-    <!-- J01 · F01 → F02 -->
-    <g style="fill: #172033" transform="translate(26.877176 39.182216) scale(0.07 -0.07)">
+    <!-- junction-0001 joins F01 to F02 at target bp 67–76 -->
+    <g style="fill: #172033" transform="translate(70.866679 60.49183) scale(0.095 -0.095)">
      <defs>
-      <path id="DejaVuSans-Bold-4a" d="M 588 4666
-L 1791 4666
-L 1791 453
-Q 1791 -419 1317 -850
-Q 844 -1281 -116 -1281
-L -359 -1281
-L -359 -372
-L -172 -372
-Q 203 -372 395 -162
-Q 588 47 588 453
-L 588 4666
+      <path id="DejaVuSans-Bold-6a" d="M 538 3500
+L 1656 3500
+L 1656 63
+Q 1656 -641 1318 -1011
+Q 981 -1381 341 -1381
+L -213 -1381
+L -213 -647
+L -19 -647
+Q 300 -647 419 -503
+Q 538 -359 538 63
+L 538 3500
+z
+M 538 4863
+L 1656 4863
+L 1656 3950
+L 538 3950
+L 538 4863
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-75" d="M 500 1363
+L 500 3500
+L 1625 3500
+L 1625 3150
+Q 1625 2866 1622 2436
+Q 1619 2006 1619 1863
+Q 1619 1441 1641 1255
+Q 1663 1069 1716 984
+Q 1784 875 1895 815
+Q 2006 756 2150 756
+Q 2500 756 2700 1025
+Q 2900 1294 2900 1772
+L 2900 3500
+L 4019 3500
+L 4019 0
+L 2900 0
+L 2900 506
+Q 2647 200 2364 54
+Q 2081 -91 1741 -91
+Q 1134 -91 817 281
+Q 500 653 500 1363
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-6e" d="M 4056 2131
+L 4056 0
+L 2931 0
+L 2931 347
+L 2931 1631
+Q 2931 2084 2911 2256
+Q 2891 2428 2841 2509
+Q 2775 2619 2662 2680
+Q 2550 2741 2406 2741
+Q 2056 2741 1856 2470
+Q 1656 2200 1656 1722
+L 1656 0
+L 538 0
+L 538 3500
+L 1656 3500
+L 1656 2988
+Q 1909 3294 2193 3439
+Q 2478 3584 2822 3584
+Q 3428 3584 3742 3212
+Q 4056 2841 4056 2131
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-63" d="M 3366 3391
+L 3366 2478
+Q 3138 2634 2908 2709
+Q 2678 2784 2431 2784
+Q 1963 2784 1702 2511
+Q 1441 2238 1441 1747
+Q 1441 1256 1702 982
+Q 1963 709 2431 709
+Q 2694 709 2930 787
+Q 3166 866 3366 1019
+L 3366 103
+Q 3103 6 2833 -42
+Q 2563 -91 2291 -91
+Q 1344 -91 809 395
+Q 275 881 275 1747
+Q 275 2613 809 3098
+Q 1344 3584 2291 3584
+Q 2566 3584 2833 3536
+Q 3100 3488 3366 3391
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-74" d="M 1759 4494
+L 1759 3500
+L 2913 3500
+L 2913 2700
+L 1759 2700
+L 1759 1216
+Q 1759 972 1856 886
+Q 1953 800 2241 800
+L 2816 800
+L 2816 0
+L 1856 0
+Q 1194 0 917 276
+Q 641 553 641 1216
+L 641 2700
+L 84 2700
+L 84 3500
+L 641 3500
+L 641 4494
+L 1759 4494
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-69" d="M 538 3500
+L 1656 3500
+L 1656 0
+L 538 0
+L 538 3500
+z
+M 538 4863
+L 1656 4863
+L 1656 3950
+L 538 3950
+L 538 4863
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-6f" d="M 2203 2784
+Q 1831 2784 1636 2517
+Q 1441 2250 1441 1747
+Q 1441 1244 1636 976
+Q 1831 709 2203 709
+Q 2569 709 2762 976
+Q 2956 1244 2956 1747
+Q 2956 2250 2762 2517
+Q 2569 2784 2203 2784
+z
+M 2203 3584
+Q 3106 3584 3614 3096
+Q 4122 2609 4122 1747
+Q 4122 884 3614 396
+Q 3106 -91 2203 -91
+Q 1297 -91 786 396
+Q 275 884 275 1747
+Q 275 2609 786 3096
+Q 1297 3584 2203 3584
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-2d" d="M 347 2297
+L 2309 2297
+L 2309 1388
+L 347 1388
+L 347 2297
 z
 " transform="scale(0.015625)"/>
       <path id="DejaVuSans-Bold-30" d="M 2944 2338
@@ -276,11 +443,35 @@ L 750 831
 z
 " transform="scale(0.015625)"/>
       <path id="DejaVuSans-Bold-20" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-b7" d="M 653 2828
-L 1778 2828
-L 1778 1619
-L 653 1619
-L 653 2828
+      <path id="DejaVuSans-Bold-73" d="M 3272 3391
+L 3272 2541
+Q 2913 2691 2578 2766
+Q 2244 2841 1947 2841
+Q 1628 2841 1473 2761
+Q 1319 2681 1319 2516
+Q 1319 2381 1436 2309
+Q 1553 2238 1856 2203
+L 2053 2175
+Q 2913 2066 3209 1816
+Q 3506 1566 3506 1031
+Q 3506 472 3093 190
+Q 2681 -91 1863 -91
+Q 1516 -91 1145 -36
+Q 775 19 384 128
+L 384 978
+Q 719 816 1070 734
+Q 1422 653 1784 653
+Q 2113 653 2278 743
+Q 2444 834 2444 1013
+Q 2444 1163 2330 1236
+Q 2216 1309 1875 1350
+L 1678 1375
+Q 931 1469 631 1722
+Q 331 1975 331 2491
+Q 331 3047 712 3315
+Q 1094 3584 1881 3584
+Q 2191 3584 2531 3537
+Q 2872 3491 3272 3391
 z
 " transform="scale(0.015625)"/>
       <path id="DejaVuSans-Bold-46" d="M 588 4666
@@ -294,19 +485,6 @@ L 1791 1978
 L 1791 0
 L 588 0
 L 588 4666
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-Bold-2192" d="M 5050 2225
-L 5050 1788
-L 3822 559
-L 3369 1013
-L 3988 1631
-L 366 1631
-L 366 2381
-L 3988 2381
-L 3369 3000
-L 3822 3453
-L 5050 2225
 z
 " transform="scale(0.015625)"/>
       <path id="DejaVuSans-Bold-32" d="M 1844 884
@@ -331,344 +509,288 @@ Q 3472 2313 2841 1759
 L 1844 884
 z
 " transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-61" d="M 2106 1575
+Q 1756 1575 1579 1456
+Q 1403 1338 1403 1106
+Q 1403 894 1545 773
+Q 1688 653 1941 653
+Q 2256 653 2472 879
+Q 2688 1106 2688 1447
+L 2688 1575
+L 2106 1575
+z
+M 3816 1997
+L 3816 0
+L 2688 0
+L 2688 519
+Q 2463 200 2181 54
+Q 1900 -91 1497 -91
+Q 953 -91 614 226
+Q 275 544 275 1050
+Q 275 1666 698 1953
+Q 1122 2241 2028 2241
+L 2688 2241
+L 2688 2328
+Q 2688 2594 2478 2717
+Q 2269 2841 1825 2841
+Q 1466 2841 1156 2769
+Q 847 2697 581 2553
+L 581 3406
+Q 941 3494 1303 3539
+Q 1666 3584 2028 3584
+Q 2975 3584 3395 3211
+Q 3816 2838 3816 1997
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-72" d="M 3138 2547
+Q 2991 2616 2845 2648
+Q 2700 2681 2553 2681
+Q 2122 2681 1889 2404
+Q 1656 2128 1656 1613
+L 1656 0
+L 538 0
+L 538 3500
+L 1656 3500
+L 1656 2925
+Q 1872 3269 2151 3426
+Q 2431 3584 2822 3584
+Q 2878 3584 2943 3579
+Q 3009 3575 3134 3559
+L 3138 2547
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-67" d="M 2919 594
+Q 2688 288 2409 144
+Q 2131 0 1766 0
+Q 1125 0 706 504
+Q 288 1009 288 1791
+Q 288 2575 706 3076
+Q 1125 3578 1766 3578
+Q 2131 3578 2409 3434
+Q 2688 3291 2919 2981
+L 2919 3500
+L 4044 3500
+L 4044 353
+Q 4044 -491 3511 -936
+Q 2978 -1381 1966 -1381
+Q 1638 -1381 1331 -1331
+Q 1025 -1281 716 -1178
+L 716 -306
+Q 1009 -475 1290 -558
+Q 1572 -641 1856 -641
+Q 2406 -641 2662 -400
+Q 2919 -159 2919 353
+L 2919 594
+z
+M 2181 2772
+Q 1834 2772 1640 2515
+Q 1447 2259 1447 1791
+Q 1447 1309 1634 1061
+Q 1822 813 2181 813
+Q 2531 813 2725 1069
+Q 2919 1325 2919 1791
+Q 2919 2259 2725 2515
+Q 2531 2772 2181 2772
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-65" d="M 4031 1759
+L 4031 1441
+L 1416 1441
+Q 1456 1047 1700 850
+Q 1944 653 2381 653
+Q 2734 653 3104 758
+Q 3475 863 3866 1075
+L 3866 213
+Q 3469 63 3072 -14
+Q 2675 -91 2278 -91
+Q 1328 -91 801 392
+Q 275 875 275 1747
+Q 275 2603 792 3093
+Q 1309 3584 2216 3584
+Q 3041 3584 3536 3087
+Q 4031 2591 4031 1759
+z
+M 2881 2131
+Q 2881 2450 2695 2645
+Q 2509 2841 2209 2841
+Q 1884 2841 1681 2658
+Q 1478 2475 1428 2131
+L 2881 2131
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-62" d="M 2400 722
+Q 2759 722 2948 984
+Q 3138 1247 3138 1747
+Q 3138 2247 2948 2509
+Q 2759 2772 2400 2772
+Q 2041 2772 1848 2508
+Q 1656 2244 1656 1747
+Q 1656 1250 1848 986
+Q 2041 722 2400 722
+z
+M 1656 2988
+Q 1888 3294 2169 3439
+Q 2450 3584 2816 3584
+Q 3463 3584 3878 3070
+Q 4294 2556 4294 1747
+Q 4294 938 3878 423
+Q 3463 -91 2816 -91
+Q 2450 -91 2169 54
+Q 1888 200 1656 506
+L 1656 0
+L 538 0
+L 538 4863
+L 1656 4863
+L 1656 2988
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-70" d="M 1656 506
+L 1656 -1331
+L 538 -1331
+L 538 3500
+L 1656 3500
+L 1656 2988
+Q 1888 3294 2169 3439
+Q 2450 3584 2816 3584
+Q 3463 3584 3878 3070
+Q 4294 2556 4294 1747
+Q 4294 938 3878 423
+Q 3463 -91 2816 -91
+Q 2450 -91 2169 54
+Q 1888 200 1656 506
+z
+M 2400 2772
+Q 2041 2772 1848 2508
+Q 1656 2244 1656 1747
+Q 1656 1250 1848 986
+Q 2041 722 2400 722
+Q 2759 722 2948 984
+Q 3138 1247 3138 1747
+Q 3138 2247 2948 2509
+Q 2759 2772 2400 2772
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-36" d="M 2316 2303
+Q 2000 2303 1842 2098
+Q 1684 1894 1684 1484
+Q 1684 1075 1842 870
+Q 2000 666 2316 666
+Q 2634 666 2792 870
+Q 2950 1075 2950 1484
+Q 2950 1894 2792 2098
+Q 2634 2303 2316 2303
+z
+M 3803 4544
+L 3803 3681
+Q 3506 3822 3243 3889
+Q 2981 3956 2731 3956
+Q 2194 3956 1894 3657
+Q 1594 3359 1544 2772
+Q 1750 2925 1990 3001
+Q 2231 3078 2516 3078
+Q 3231 3078 3670 2659
+Q 4109 2241 4109 1563
+Q 4109 813 3618 361
+Q 3128 -91 2303 -91
+Q 1394 -91 895 523
+Q 397 1138 397 2266
+Q 397 3422 980 4083
+Q 1563 4744 2578 4744
+Q 2900 4744 3203 4694
+Q 3506 4644 3803 4544
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-37" d="M 428 4666
+L 3944 4666
+L 3944 3988
+L 2125 0
+L 953 0
+L 2675 3781
+L 428 3781
+L 428 4666
+z
+" transform="scale(0.015625)"/>
+      <path id="DejaVuSans-Bold-2013" d="M 344 2156
+L 2856 2156
+L 2856 1350
+L 344 1350
+L 344 2156
+z
+" transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-Bold-4a"/>
-     <use xlink:href="#DejaVuSans-Bold-30" transform="translate(37.207031 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-31" transform="translate(106.787109 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(176.367188 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-b7" transform="translate(211.181641 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(249.169922 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-46" transform="translate(283.984375 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-30" transform="translate(352.294922 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-31" transform="translate(421.875 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(491.455078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-2192" transform="translate(526.269531 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(610.058594 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-46" transform="translate(644.873047 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-30" transform="translate(713.183594 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-32" transform="translate(782.763672 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6a"/>
+     <use xlink:href="#DejaVuSans-Bold-75" transform="translate(34.277344 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(105.46875 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-63" transform="translate(176.660156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-74" transform="translate(235.9375 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-69" transform="translate(283.740234 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6f" transform="translate(318.017578 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(386.71875 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-2d" transform="translate(457.910156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-30" transform="translate(499.414062 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-30" transform="translate(568.994141 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-30" transform="translate(638.574219 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-31" transform="translate(708.154297 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(777.734375 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6a" transform="translate(812.548828 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6f" transform="translate(846.826172 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-69" transform="translate(915.527344 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(949.804688 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-73" transform="translate(1020.996094 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(1080.517578 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-46" transform="translate(1115.332031 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-30" transform="translate(1183.642578 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-31" transform="translate(1253.222656 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(1322.802734 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-74" transform="translate(1357.617188 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6f" transform="translate(1405.419922 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(1474.121094 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-46" transform="translate(1508.935547 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-30" transform="translate(1577.246094 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-32" transform="translate(1646.826172 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(1716.40625 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-61" transform="translate(1751.220703 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-74" transform="translate(1818.701172 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(1866.503906 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-74" transform="translate(1901.318359 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-61" transform="translate(1949.121094 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-72" transform="translate(2016.601562 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-67" transform="translate(2065.917969 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-65" transform="translate(2137.5 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-74" transform="translate(2205.322266 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(2253.125 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-62" transform="translate(2287.939453 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-70" transform="translate(2359.521484 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(2431.103516 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-36" transform="translate(2465.917969 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-37" transform="translate(2535.498047 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-2013" transform="translate(2605.078125 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-37" transform="translate(2655.078125 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-36" transform="translate(2724.658203 0)"/>
     </g>
    </g>
-   <g id="text_2">
-    <!-- target bp 73–82 -->
-    <g style="fill: #667085" transform="translate(485.063491 38.042451) scale(0.055 -0.055)">
+   <g id="junction:synthetic-three-fragment-target:junction-0001:left-top:base:0:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(98.244841 367.735666) scale(0.081818 -0.081818)">
      <defs>
-      <path id="DejaVuSans-74" d="M 1172 4494
-L 1172 3500
-L 2356 3500
-L 2356 3053
-L 1172 3053
-L 1172 1153
-Q 1172 725 1289 603
-Q 1406 481 1766 481
-L 2356 481
-L 2356 0
-L 1766 0
-Q 1100 0 847 248
-Q 594 497 594 1153
-L 594 3053
-L 172 3053
-L 172 3500
-L 594 3500
-L 594 4494
-L 1172 4494
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-61" d="M 2194 1759
-Q 1497 1759 1228 1600
-Q 959 1441 959 1056
-Q 959 750 1161 570
-Q 1363 391 1709 391
-Q 2188 391 2477 730
-Q 2766 1069 2766 1631
-L 2766 1759
-L 2194 1759
-z
-M 3341 1997
-L 3341 0
-L 2766 0
-L 2766 531
-Q 2569 213 2275 61
-Q 1981 -91 1556 -91
-Q 1019 -91 701 211
-Q 384 513 384 1019
-Q 384 1609 779 1909
-Q 1175 2209 1959 2209
-L 2766 2209
-L 2766 2266
-Q 2766 2663 2505 2880
-Q 2244 3097 1772 3097
-Q 1472 3097 1187 3025
-Q 903 2953 641 2809
-L 641 3341
-Q 956 3463 1253 3523
-Q 1550 3584 1831 3584
-Q 2591 3584 2966 3190
-Q 3341 2797 3341 1997
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-72" d="M 2631 2963
-Q 2534 3019 2420 3045
-Q 2306 3072 2169 3072
-Q 1681 3072 1420 2755
-Q 1159 2438 1159 1844
-L 1159 0
-L 581 0
-L 581 3500
-L 1159 3500
-L 1159 2956
-Q 1341 3275 1631 3429
-Q 1922 3584 2338 3584
-Q 2397 3584 2469 3576
-Q 2541 3569 2628 3553
-L 2631 2963
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-67" d="M 2906 1791
-Q 2906 2416 2648 2759
-Q 2391 3103 1925 3103
-Q 1463 3103 1205 2759
-Q 947 2416 947 1791
-Q 947 1169 1205 825
-Q 1463 481 1925 481
-Q 2391 481 2648 825
-Q 2906 1169 2906 1791
-z
-M 3481 434
-Q 3481 -459 3084 -895
-Q 2688 -1331 1869 -1331
-Q 1566 -1331 1297 -1286
-Q 1028 -1241 775 -1147
-L 775 -588
-Q 1028 -725 1275 -790
-Q 1522 -856 1778 -856
-Q 2344 -856 2625 -561
-Q 2906 -266 2906 331
-L 2906 616
-Q 2728 306 2450 153
-Q 2172 0 1784 0
-Q 1141 0 747 490
-Q 353 981 353 1791
-Q 353 2603 747 3093
-Q 1141 3584 1784 3584
-Q 2172 3584 2450 3431
-Q 2728 3278 2906 2969
-L 2906 3500
-L 3481 3500
-L 3481 434
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-65" d="M 3597 1894
-L 3597 1613
-L 953 1613
-Q 991 1019 1311 708
-Q 1631 397 2203 397
-Q 2534 397 2845 478
-Q 3156 559 3463 722
-L 3463 178
-Q 3153 47 2828 -22
-Q 2503 -91 2169 -91
-Q 1331 -91 842 396
-Q 353 884 353 1716
-Q 353 2575 817 3079
-Q 1281 3584 2069 3584
-Q 2775 3584 3186 3129
-Q 3597 2675 3597 1894
-z
-M 3022 2063
-Q 3016 2534 2758 2815
-Q 2500 3097 2075 3097
-Q 1594 3097 1305 2825
-Q 1016 2553 972 2059
-L 3022 2063
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-20" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-62" d="M 3116 1747
-Q 3116 2381 2855 2742
-Q 2594 3103 2138 3103
-Q 1681 3103 1420 2742
-Q 1159 2381 1159 1747
-Q 1159 1113 1420 752
-Q 1681 391 2138 391
-Q 2594 391 2855 752
-Q 3116 1113 3116 1747
-z
-M 1159 2969
-Q 1341 3281 1617 3432
-Q 1894 3584 2278 3584
-Q 2916 3584 3314 3078
-Q 3713 2572 3713 1747
-Q 3713 922 3314 415
-Q 2916 -91 2278 -91
-Q 1894 -91 1617 61
-Q 1341 213 1159 525
-L 1159 0
-L 581 0
-L 581 4863
-L 1159 4863
-L 1159 2969
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-70" d="M 1159 525
-L 1159 -1331
-L 581 -1331
-L 581 3500
-L 1159 3500
-L 1159 2969
-Q 1341 3281 1617 3432
-Q 1894 3584 2278 3584
-Q 2916 3584 3314 3078
-Q 3713 2572 3713 1747
-Q 3713 922 3314 415
-Q 2916 -91 2278 -91
-Q 1894 -91 1617 61
-Q 1341 213 1159 525
-z
-M 3116 1747
-Q 3116 2381 2855 2742
-Q 2594 3103 2138 3103
-Q 1681 3103 1420 2742
-Q 1159 2381 1159 1747
-Q 1159 1113 1420 752
-Q 1681 391 2138 391
-Q 2594 391 2855 752
-Q 3116 1113 3116 1747
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-37" d="M 525 4666
-L 3525 4666
-L 3525 4397
-L 1831 0
-L 1172 0
-L 2766 4134
-L 525 4134
-L 525 4666
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-33" d="M 2597 2516
-Q 3050 2419 3304 2112
-Q 3559 1806 3559 1356
-Q 3559 666 3084 287
-Q 2609 -91 1734 -91
-Q 1441 -91 1130 -33
-Q 819 25 488 141
-L 488 750
-Q 750 597 1062 519
-Q 1375 441 1716 441
-Q 2309 441 2620 675
-Q 2931 909 2931 1356
-Q 2931 1769 2642 2001
-Q 2353 2234 1838 2234
-L 1294 2234
-L 1294 2753
-L 1863 2753
-Q 2328 2753 2575 2939
-Q 2822 3125 2822 3475
-Q 2822 3834 2567 4026
-Q 2313 4219 1838 4219
-Q 1578 4219 1281 4162
-Q 984 4106 628 3988
-L 628 4550
-Q 988 4650 1302 4700
-Q 1616 4750 1894 4750
-Q 2613 4750 3031 4423
-Q 3450 4097 3450 3541
-Q 3450 3153 3228 2886
-Q 3006 2619 2597 2516
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-2013" d="M 313 1978
-L 2888 1978
-L 2888 1528
-L 313 1528
-L 313 1978
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-38" d="M 2034 2216
-Q 1584 2216 1326 1975
-Q 1069 1734 1069 1313
-Q 1069 891 1326 650
-Q 1584 409 2034 409
-Q 2484 409 2743 651
-Q 3003 894 3003 1313
-Q 3003 1734 2745 1975
-Q 2488 2216 2034 2216
-z
-M 1403 2484
-Q 997 2584 770 2862
-Q 544 3141 544 3541
-Q 544 4100 942 4425
-Q 1341 4750 2034 4750
-Q 2731 4750 3128 4425
-Q 3525 4100 3525 3541
-Q 3525 3141 3298 2862
-Q 3072 2584 2669 2484
-Q 3125 2378 3379 2068
-Q 3634 1759 3634 1313
-Q 3634 634 3220 271
-Q 2806 -91 2034 -91
-Q 1263 -91 848 271
-Q 434 634 434 1313
-Q 434 1759 690 2068
-Q 947 2378 1403 2484
-z
-M 1172 3481
-Q 1172 3119 1398 2916
-Q 1625 2713 2034 2713
-Q 2441 2713 2670 2916
-Q 2900 3119 2900 3481
-Q 2900 3844 2670 4047
-Q 2441 4250 2034 4250
-Q 1625 4250 1398 4047
-Q 1172 3844 1172 3481
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-32" d="M 1228 531
-L 3431 531
-L 3431 0
-L 469 0
-L 469 531
-Q 828 903 1448 1529
-Q 2069 2156 2228 2338
-Q 2531 2678 2651 2914
-Q 2772 3150 2772 3378
-Q 2772 3750 2511 3984
-Q 2250 4219 1831 4219
-Q 1534 4219 1204 4116
-Q 875 4013 500 3803
-L 500 4441
-Q 881 4594 1212 4672
-Q 1544 4750 1819 4750
-Q 2544 4750 2975 4387
-Q 3406 4025 3406 3419
-Q 3406 3131 3298 2873
-Q 3191 2616 2906 2266
-Q 2828 2175 2409 1742
-Q 1991 1309 1228 531
+      <path id="DejaVuSansMono-54" d="M 147 4666
+L 3706 4666
+L 3706 4134
+L 2247 4134
+L 2247 0
+L 1613 0
+L 1613 4134
+L 147 4134
+L 147 4666
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-74"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(39.208984 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(100.488281 0)"/>
-     <use xlink:href="#DejaVuSans-67" transform="translate(139.851562 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(203.328125 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(264.851562 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(304.060547 0)"/>
-     <use xlink:href="#DejaVuSans-62" transform="translate(335.847656 0)"/>
-     <use xlink:href="#DejaVuSans-70" transform="translate(399.324219 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(462.800781 0)"/>
-     <use xlink:href="#DejaVuSans-37" transform="translate(494.587891 0)"/>
-     <use xlink:href="#DejaVuSans-33" transform="translate(558.210938 0)"/>
-     <use xlink:href="#DejaVuSans-2013" transform="translate(621.833984 0)"/>
-     <use xlink:href="#DejaVuSans-38" transform="translate(671.833984 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(735.457031 0)"/>
+     <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0001:left-top:base:0:C">
+   <g id="junction:synthetic-three-fragment-target:junction-0001:left-top:base:1:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(93.873061 163.163986) scale(0.055 -0.055)">
+    <g style="fill: #172033" transform="translate(109.722155 367.735666) scale(0.081818 -0.081818)">
      <defs>
       <path id="DejaVuSansMono-43" d="M 3353 166
 Q 3113 38 2859 -26
@@ -695,9 +817,57 @@ z
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0001:left-top:base:1:G">
+   <g id="junction:synthetic-three-fragment-target:junction-0001:left-top:base:2:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(121.199469 367.735666) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-54"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0001:left-top:base:3:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(132.676784 367.735666) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-43"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0001:left-top:base:4:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(144.154098 367.735666) scale(0.081818 -0.081818)">
+     <defs>
+      <path id="DejaVuSansMono-41" d="M 1925 4109
+L 1259 1722
+L 2591 1722
+L 1925 4109
+z
+M 1544 4666
+L 2309 4666
+L 3738 0
+L 3084 0
+L 2741 1216
+L 1106 1216
+L 769 0
+L 116 0
+L 1544 4666
+z
+" transform="scale(0.015625)"/>
+     </defs>
+     <use xlink:href="#DejaVuSansMono-41"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0001:left-top:base:5:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(155.631412 367.735666) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-43"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0001:toehold-top:base:0:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(167.108726 367.735666) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-43"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0001:toehold-top:base:1:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(105.641885 163.163986) scale(0.055 -0.055)">
+    <g style="fill: #172033" transform="translate(178.586041 367.735666) scale(0.081818 -0.081818)">
      <defs>
       <path id="DejaVuSansMono-47" d="M 3450 384
 Q 3197 150 2880 29
@@ -728,556 +898,609 @@ z
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0001:left-top:base:2:T">
+   <g id="junction:synthetic-three-fragment-target:junction-0001:toehold-top:base:2:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(117.410708 163.163986) scale(0.055 -0.055)">
-     <defs>
-      <path id="DejaVuSansMono-54" d="M 147 4666
-L 3706 4666
-L 3706 4134
-L 2247 4134
-L 2247 0
-L 1613 0
-L 1613 4134
-L 147 4134
-L 147 4666
-z
-" transform="scale(0.015625)"/>
-     </defs>
+    <g style="fill: #172033" transform="translate(190.063355 367.735666) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-54"/>
-    </g>
-   </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0001:left-top:base:3:A">
-    <!-- A -->
-    <g style="fill: #172033" transform="translate(129.179532 163.163986) scale(0.055 -0.055)">
-     <defs>
-      <path id="DejaVuSansMono-41" d="M 1925 4109
-L 1259 1722
-L 2591 1722
-L 1925 4109
-z
-M 1544 4666
-L 2309 4666
-L 3738 0
-L 3084 0
-L 2741 1216
-L 1106 1216
-L 769 0
-L 116 0
-L 1544 4666
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSansMono-41"/>
-    </g>
-   </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0001:left-top:base:4:G">
-    <!-- G -->
-    <g style="fill: #172033" transform="translate(140.948355 163.163986) scale(0.055 -0.055)">
-     <use xlink:href="#DejaVuSansMono-47"/>
-    </g>
-   </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0001:left-top:base:5:A">
-    <!-- A -->
-    <g style="fill: #172033" transform="translate(152.717179 163.163986) scale(0.055 -0.055)">
-     <use xlink:href="#DejaVuSansMono-41"/>
-    </g>
-   </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0001:toehold-top:base:0:G">
-    <!-- G -->
-    <g style="fill: #172033" transform="translate(164.486002 163.163986) scale(0.055 -0.055)">
-     <use xlink:href="#DejaVuSansMono-47"/>
-    </g>
-   </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0001:toehold-top:base:1:G">
-    <!-- G -->
-    <g style="fill: #172033" transform="translate(176.254826 163.163986) scale(0.055 -0.055)">
-     <use xlink:href="#DejaVuSansMono-47"/>
-    </g>
-   </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0001:toehold-top:base:2:G">
-    <!-- G -->
-    <g style="fill: #172033" transform="translate(188.023649 163.163986) scale(0.055 -0.055)">
-     <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
    <g id="junction:synthetic-three-fragment-target:junction-0001:toehold-top:base:3:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(199.792473 163.163986) scale(0.055 -0.055)">
+    <g style="fill: #172033" transform="translate(201.540669 367.735666) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0001:toehold-top:base:4:C">
-    <!-- C -->
-    <g style="fill: #172033" transform="translate(211.561296 163.163986) scale(0.055 -0.055)">
-     <use xlink:href="#DejaVuSansMono-43"/>
+   <g id="junction:synthetic-three-fragment-target:junction-0001:toehold-top:base:4:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(213.017984 367.735666) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0001:toehold-top:base:5:T">
-    <!-- T -->
-    <g style="fill: #172033" transform="translate(223.33012 163.163986) scale(0.055 -0.055)">
-     <use xlink:href="#DejaVuSansMono-54"/>
-    </g>
-   </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0001:toehold-top:base:6:A">
+   <g id="junction:synthetic-three-fragment-target:junction-0001:toehold-top:base:5:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(235.098943 163.163986) scale(0.055 -0.055)">
+    <g style="fill: #172033" transform="translate(224.495298 367.735666) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-41"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0001:toehold-top:base:6:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(235.972612 367.735666) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
    <g id="junction:synthetic-three-fragment-target:junction-0001:toehold-top:base:7:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(246.867767 163.163986) scale(0.055 -0.055)">
+    <g style="fill: #172033" transform="translate(247.449926 367.735666) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
    <g id="junction:synthetic-three-fragment-target:junction-0001:toehold-top:base:8:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(258.636591 163.163986) scale(0.055 -0.055)">
+    <g style="fill: #172033" transform="translate(258.927241 367.735666) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0001:toehold-top:base:9:G">
-    <!-- G -->
-    <g style="fill: #172033" transform="translate(270.405414 163.163986) scale(0.055 -0.055)">
-     <use xlink:href="#DejaVuSansMono-47"/>
-    </g>
-   </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0001:right-top:base:0:T">
-    <!-- T -->
-    <g style="fill: #172033" transform="translate(303.096591 163.163986) scale(0.055 -0.055)">
-     <use xlink:href="#DejaVuSansMono-54"/>
-    </g>
-   </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0001:right-top:base:1:C">
-    <!-- C -->
-    <g style="fill: #172033" transform="translate(314.865414 163.163986) scale(0.055 -0.055)">
-     <use xlink:href="#DejaVuSansMono-43"/>
-    </g>
-   </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0001:right-top:base:2:T">
-    <!-- T -->
-    <g style="fill: #172033" transform="translate(326.634238 163.163986) scale(0.055 -0.055)">
-     <use xlink:href="#DejaVuSansMono-54"/>
-    </g>
-   </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0001:right-top:base:3:A">
+   <g id="junction:synthetic-three-fragment-target:junction-0001:toehold-top:base:9:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(338.403061 163.163986) scale(0.055 -0.055)">
+    <g style="fill: #172033" transform="translate(270.404555 367.735666) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0001:right-top:base:4:T">
+   <g id="junction:synthetic-three-fragment-target:junction-0001:right-top:base:0:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(281.881869 367.735666) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-43"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0001:right-top:base:1:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(350.171885 163.163986) scale(0.055 -0.055)">
+    <g style="fill: #172033" transform="translate(293.359184 367.735666) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0001:right-top:base:5:C">
-    <!-- C -->
-    <g style="fill: #172033" transform="translate(361.940708 163.163986) scale(0.055 -0.055)">
-     <use xlink:href="#DejaVuSansMono-43"/>
+   <g id="junction:synthetic-three-fragment-target:junction-0001:right-top:base:2:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(304.836498 367.735666) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0001:left-bottom:base:0:G">
+   <g id="junction:synthetic-three-fragment-target:junction-0001:right-top:base:3:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(93.873061 209.625226) scale(0.055 -0.055)">
+    <g style="fill: #172033" transform="translate(316.313812 367.735666) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0001:left-bottom:base:1:C">
+   <g id="junction:synthetic-three-fragment-target:junction-0001:right-top:base:4:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(327.791126 367.735666) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-47"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0001:right-top:base:5:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(339.268441 367.735666) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-47"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0001:right-top:base:6:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(350.745755 367.735666) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-54"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0001:right-top:base:7:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(105.641885 209.625226) scale(0.055 -0.055)">
+    <g style="fill: #172033" transform="translate(362.223069 367.735666) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-43"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0001:right-top:base:8:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(373.700384 367.735666) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-54"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0001:right-top:base:9:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(385.177698 367.735666) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-41"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0001:right-top:base:10:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(396.655012 367.735666) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-54"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0001:right-top:base:11:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(408.132326 367.735666) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-43"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0001:right-top:base:12:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(419.609641 367.735666) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-41"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0001:right-top:base:13:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(431.086955 367.735666) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-47"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0001:right-top:base:14:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(442.564269 367.735666) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-41"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0001:right-top:base:15:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(454.041584 367.735666) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-54"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0001:left-bottom:base:0:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(98.244841 397.576683) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-41"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0001:left-bottom:base:1:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(109.722155 397.576683) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
    <g id="junction:synthetic-three-fragment-target:junction-0001:left-bottom:base:2:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(117.410708 209.625226) scale(0.055 -0.055)">
+    <g style="fill: #172033" transform="translate(121.199469 397.576683) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0001:left-bottom:base:3:T">
+   <g id="junction:synthetic-three-fragment-target:junction-0001:left-bottom:base:3:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(132.676784 397.576683) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-47"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0001:left-bottom:base:4:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(129.179532 209.625226) scale(0.055 -0.055)">
+    <g style="fill: #172033" transform="translate(144.154098 397.576683) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0001:left-bottom:base:4:C">
-    <!-- C -->
-    <g style="fill: #172033" transform="translate(140.948355 209.625226) scale(0.055 -0.055)">
-     <use xlink:href="#DejaVuSansMono-43"/>
+   <g id="junction:synthetic-three-fragment-target:junction-0001:left-bottom:base:5:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(155.631412 397.576683) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0001:left-bottom:base:5:T">
-    <!-- T -->
-    <g style="fill: #172033" transform="translate(152.717179 209.625226) scale(0.055 -0.055)">
-     <use xlink:href="#DejaVuSansMono-54"/>
-    </g>
-   </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0001:toehold-bottom:base:0:C">
-    <!-- C -->
-    <g style="fill: #172033" transform="translate(164.486002 209.625226) scale(0.055 -0.055)">
-     <use xlink:href="#DejaVuSansMono-43"/>
+   <g id="junction:synthetic-three-fragment-target:junction-0001:toehold-bottom:base:0:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(167.108726 397.576683) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
    <g id="junction:synthetic-three-fragment-target:junction-0001:toehold-bottom:base:1:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(176.254826 209.625226) scale(0.055 -0.055)">
+    <g style="fill: #172033" transform="translate(178.586041 397.576683) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0001:toehold-bottom:base:2:C">
-    <!-- C -->
-    <g style="fill: #172033" transform="translate(188.023649 209.625226) scale(0.055 -0.055)">
-     <use xlink:href="#DejaVuSansMono-43"/>
+   <g id="junction:synthetic-three-fragment-target:junction-0001:toehold-bottom:base:2:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(190.063355 397.576683) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
    <g id="junction:synthetic-three-fragment-target:junction-0001:toehold-bottom:base:3:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(199.792473 209.625226) scale(0.055 -0.055)">
+    <g style="fill: #172033" transform="translate(201.540669 397.576683) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0001:toehold-bottom:base:4:G">
-    <!-- G -->
-    <g style="fill: #172033" transform="translate(211.561296 209.625226) scale(0.055 -0.055)">
-     <use xlink:href="#DejaVuSansMono-47"/>
+   <g id="junction:synthetic-three-fragment-target:junction-0001:toehold-bottom:base:4:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(213.017984 397.576683) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0001:toehold-bottom:base:5:A">
-    <!-- A -->
-    <g style="fill: #172033" transform="translate(223.33012 209.625226) scale(0.055 -0.055)">
-     <use xlink:href="#DejaVuSansMono-41"/>
-    </g>
-   </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0001:toehold-bottom:base:6:T">
+   <g id="junction:synthetic-three-fragment-target:junction-0001:toehold-bottom:base:5:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(235.098943 209.625226) scale(0.055 -0.055)">
+    <g style="fill: #172033" transform="translate(224.495298 397.576683) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-54"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0001:toehold-bottom:base:6:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(235.972612 397.576683) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
    <g id="junction:synthetic-three-fragment-target:junction-0001:toehold-bottom:base:7:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(246.867767 209.625226) scale(0.055 -0.055)">
+    <g style="fill: #172033" transform="translate(247.449926 397.576683) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
    <g id="junction:synthetic-three-fragment-target:junction-0001:toehold-bottom:base:8:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(258.636591 209.625226) scale(0.055 -0.055)">
+    <g style="fill: #172033" transform="translate(258.927241 397.576683) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0001:toehold-bottom:base:9:C">
-    <!-- C -->
-    <g style="fill: #172033" transform="translate(270.405414 209.625226) scale(0.055 -0.055)">
-     <use xlink:href="#DejaVuSansMono-43"/>
-    </g>
-   </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0001:right-bottom:base:0:A">
-    <!-- A -->
-    <g style="fill: #172033" transform="translate(303.096591 209.625226) scale(0.055 -0.055)">
-     <use xlink:href="#DejaVuSansMono-41"/>
-    </g>
-   </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0001:right-bottom:base:1:G">
-    <!-- G -->
-    <g style="fill: #172033" transform="translate(314.865414 209.625226) scale(0.055 -0.055)">
-     <use xlink:href="#DejaVuSansMono-47"/>
-    </g>
-   </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0001:right-bottom:base:2:A">
-    <!-- A -->
-    <g style="fill: #172033" transform="translate(326.634238 209.625226) scale(0.055 -0.055)">
-     <use xlink:href="#DejaVuSansMono-41"/>
-    </g>
-   </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0001:right-bottom:base:3:T">
+   <g id="junction:synthetic-three-fragment-target:junction-0001:toehold-bottom:base:9:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(338.403061 209.625226) scale(0.055 -0.055)">
+    <g style="fill: #172033" transform="translate(270.404555 397.576683) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0001:right-bottom:base:4:A">
-    <!-- A -->
-    <g style="fill: #172033" transform="translate(350.171885 209.625226) scale(0.055 -0.055)">
-     <use xlink:href="#DejaVuSansMono-41"/>
-    </g>
-   </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0001:right-bottom:base:5:G">
+   <g id="junction:synthetic-three-fragment-target:junction-0001:right-bottom:base:0:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(361.940708 209.625226) scale(0.055 -0.055)">
+    <g style="fill: #172033" transform="translate(281.881869 397.576683) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b:base:0:A">
+   <g id="junction:synthetic-three-fragment-target:junction-0001:right-bottom:base:1:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(276.350029 147.948025) scale(0.053 -0.053)">
+    <g style="fill: #172033" transform="translate(293.359184 397.576683) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-41"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0001:right-bottom:base:2:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(304.836498 397.576683) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-54"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0001:right-bottom:base:3:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(316.313812 397.576683) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-43"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0001:right-bottom:base:4:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(327.791126 397.576683) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-43"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0001:right-bottom:base:5:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(339.268441 397.576683) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-43"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0001:right-bottom:base:6:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(350.745755 397.576683) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-41"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0001:right-bottom:base:7:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(362.223069 397.576683) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-47"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0001:right-bottom:base:8:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(373.700384 397.576683) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-41"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0001:right-bottom:base:9:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(385.177698 397.576683) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-54"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0001:right-bottom:base:10:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(396.655012 397.576683) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-41"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0001:right-bottom:base:11:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(408.132326 397.576683) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-47"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0001:right-bottom:base:12:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(419.609641 397.576683) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-54"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0001:right-bottom:base:13:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(431.086955 397.576683) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-43"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0001:right-bottom:base:14:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(442.564269 397.576683) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-54"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0001:right-bottom:base:15:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(454.041584 397.576683) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-41"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b:base:0:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(267.879546 350.519695) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
    <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b:base:1:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(276.350029 144.17682) scale(0.053 -0.053)">
+    <g style="fill: #172033" transform="translate(267.879546 339.042381) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b:base:2:A">
-    <!-- A -->
-    <g style="fill: #172033" transform="translate(276.350029 140.405616) scale(0.053 -0.053)">
-     <use xlink:href="#DejaVuSansMono-41"/>
+   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b:base:2:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(267.879546 327.565066) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b:base:3:A">
-    <!-- A -->
-    <g style="fill: #172033" transform="translate(276.350029 136.634411) scale(0.053 -0.053)">
-     <use xlink:href="#DejaVuSansMono-41"/>
+   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b:base:3:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(267.879546 316.087752) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b:base:4:C">
+   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b:base:4:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(267.879546 304.610438) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-47"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b:base:5:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(276.350029 132.863206) scale(0.053 -0.053)">
+    <g style="fill: #172033" transform="translate(267.879546 293.133123) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b:base:5:A">
+   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b:base:6:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(276.350029 129.092002) scale(0.053 -0.053)">
+    <g style="fill: #172033" transform="translate(267.879546 281.655809) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-41"/>
-    </g>
-   </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b:base:6:G">
-    <!-- G -->
-    <g style="fill: #172033" transform="translate(276.350029 125.320797) scale(0.053 -0.053)">
-     <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
    <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b:base:7:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(276.350029 121.549593) scale(0.053 -0.053)">
+    <g style="fill: #172033" transform="translate(267.879546 270.178495) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b:base:8:G">
+   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b:base:8:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(267.879546 258.701181) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-54"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b:base:9:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(276.350029 117.778388) scale(0.053 -0.053)">
+    <g style="fill: #172033" transform="translate(267.879546 247.223866) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b:base:9:C">
+   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b:base:10:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(267.879546 235.746552) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-47"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b:base:11:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(267.879546 224.269238) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-54"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b:base:12:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(276.350029 114.007184) scale(0.053 -0.053)">
+    <g style="fill: #172033" transform="translate(267.879546 212.791923) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b:base:10:T">
-    <!-- T -->
-    <g style="fill: #172033" transform="translate(276.350029 110.235979) scale(0.053 -0.053)">
-     <use xlink:href="#DejaVuSansMono-54"/>
-    </g>
-   </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b:base:11:G">
-    <!-- G -->
-    <g style="fill: #172033" transform="translate(276.350029 106.464775) scale(0.053 -0.053)">
-     <use xlink:href="#DejaVuSansMono-47"/>
-    </g>
-   </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b:base:12:T">
-    <!-- T -->
-    <g style="fill: #172033" transform="translate(276.350029 102.69357) scale(0.053 -0.053)">
-     <use xlink:href="#DejaVuSansMono-54"/>
-    </g>
-   </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b:base:13:T">
-    <!-- T -->
-    <g style="fill: #172033" transform="translate(276.350029 98.922366) scale(0.053 -0.053)">
-     <use xlink:href="#DejaVuSansMono-54"/>
-    </g>
-   </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b:base:14:A">
+   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b:base:13:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(276.350029 95.151161) scale(0.053 -0.053)">
+    <g style="fill: #172033" transform="translate(267.879546 201.314609) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-41"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b:base:14:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(267.879546 189.837295) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
    <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b:base:15:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(276.350029 91.379956) scale(0.053 -0.053)">
+    <g style="fill: #172033" transform="translate(267.879546 178.359981) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b:base:16:G">
-    <!-- G -->
-    <g style="fill: #172033" transform="translate(276.350029 87.608752) scale(0.053 -0.053)">
-     <use xlink:href="#DejaVuSansMono-47"/>
+   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b:base:16:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(267.879546 166.882666) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
    <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b:base:17:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(276.350029 83.837547) scale(0.053 -0.053)">
+    <g style="fill: #172033" transform="translate(267.879546 155.405352) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b:base:18:C">
+   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b:base:18:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(267.879546 143.928038) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-41"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b:base:19:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(276.350029 80.066343) scale(0.053 -0.053)">
+    <g style="fill: #172033" transform="translate(267.879546 132.450723) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b:base:19:G">
-    <!-- G -->
-    <g style="fill: #172033" transform="translate(276.350029 76.295138) scale(0.053 -0.053)">
-     <use xlink:href="#DejaVuSansMono-47"/>
-    </g>
-   </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b:base:20:G">
-    <!-- G -->
-    <g style="fill: #172033" transform="translate(276.350029 72.523934) scale(0.053 -0.053)">
-     <use xlink:href="#DejaVuSansMono-47"/>
-    </g>
-   </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b:base:21:G">
-    <!-- G -->
-    <g style="fill: #172033" transform="translate(276.350029 68.752729) scale(0.053 -0.053)">
-     <use xlink:href="#DejaVuSansMono-47"/>
-    </g>
-   </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b-star:base:0:C">
+   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b:base:20:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(297.272382 68.752729) scale(0.053 -0.053)">
+    <g style="fill: #172033" transform="translate(267.879546 120.973409) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b-star:base:1:C">
+   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b:base:21:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(297.272382 72.523934) scale(0.053 -0.053)">
+    <g style="fill: #172033" transform="translate(267.879546 109.496095) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b-star:base:2:C">
-    <!-- C -->
-    <g style="fill: #172033" transform="translate(297.272382 76.295138) scale(0.053 -0.053)">
-     <use xlink:href="#DejaVuSansMono-43"/>
-    </g>
-   </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b-star:base:3:G">
+   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b-star:base:0:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(297.272382 80.066343) scale(0.053 -0.053)">
+    <g style="fill: #172033" transform="translate(284.406878 109.496095) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-47"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b-star:base:1:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(284.406878 120.973409) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-47"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b-star:base:2:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(284.406878 132.450723) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-47"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b-star:base:3:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(284.406878 143.928038) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
    <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b-star:base:4:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(297.272382 83.837547) scale(0.053 -0.053)">
+    <g style="fill: #172033" transform="translate(284.406878 155.405352) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b-star:base:5:C">
-    <!-- C -->
-    <g style="fill: #172033" transform="translate(297.272382 87.608752) scale(0.053 -0.053)">
-     <use xlink:href="#DejaVuSansMono-43"/>
+   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b-star:base:5:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(284.406878 166.882666) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
    <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b-star:base:6:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(297.272382 91.379956) scale(0.053 -0.053)">
+    <g style="fill: #172033" transform="translate(284.406878 178.359981) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b-star:base:7:T">
+   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b-star:base:7:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(284.406878 189.837295) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-43"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b-star:base:8:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(297.272382 95.151161) scale(0.053 -0.053)">
+    <g style="fill: #172033" transform="translate(284.406878 201.314609) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b-star:base:8:A">
-    <!-- A -->
-    <g style="fill: #172033" transform="translate(297.272382 98.922366) scale(0.053 -0.053)">
-     <use xlink:href="#DejaVuSansMono-41"/>
-    </g>
-   </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b-star:base:9:A">
-    <!-- A -->
-    <g style="fill: #172033" transform="translate(297.272382 102.69357) scale(0.053 -0.053)">
-     <use xlink:href="#DejaVuSansMono-41"/>
-    </g>
-   </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b-star:base:10:C">
-    <!-- C -->
-    <g style="fill: #172033" transform="translate(297.272382 106.464775) scale(0.053 -0.053)">
-     <use xlink:href="#DejaVuSansMono-43"/>
-    </g>
-   </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b-star:base:11:A">
-    <!-- A -->
-    <g style="fill: #172033" transform="translate(297.272382 110.235979) scale(0.053 -0.053)">
-     <use xlink:href="#DejaVuSansMono-41"/>
-    </g>
-   </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b-star:base:12:G">
+   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b-star:base:9:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(297.272382 114.007184) scale(0.053 -0.053)">
+    <g style="fill: #172033" transform="translate(284.406878 212.791923) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b-star:base:13:C">
+   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b-star:base:10:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(284.406878 224.269238) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-41"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b-star:base:11:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(297.272382 117.778388) scale(0.053 -0.053)">
+    <g style="fill: #172033" transform="translate(284.406878 235.746552) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-43"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b-star:base:12:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(284.406878 247.223866) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-43"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b-star:base:13:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(284.406878 258.701181) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
    <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b-star:base:14:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(297.272382 121.549593) scale(0.053 -0.053)">
+    <g style="fill: #172033" transform="translate(284.406878 270.178495) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b-star:base:15:C">
-    <!-- C -->
-    <g style="fill: #172033" transform="translate(297.272382 125.320797) scale(0.053 -0.053)">
-     <use xlink:href="#DejaVuSansMono-43"/>
-    </g>
-   </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b-star:base:16:T">
+   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b-star:base:15:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(297.272382 129.092002) scale(0.053 -0.053)">
+    <g style="fill: #172033" transform="translate(284.406878 281.655809) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b-star:base:17:G">
+   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b-star:base:16:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(297.272382 132.863206) scale(0.053 -0.053)">
+    <g style="fill: #172033" transform="translate(284.406878 293.133123) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b-star:base:18:T">
-    <!-- T -->
-    <g style="fill: #172033" transform="translate(297.272382 136.634411) scale(0.053 -0.053)">
-     <use xlink:href="#DejaVuSansMono-54"/>
+   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b-star:base:17:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(284.406878 304.610438) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b-star:base:19:T">
-    <!-- T -->
-    <g style="fill: #172033" transform="translate(297.272382 140.405616) scale(0.053 -0.053)">
-     <use xlink:href="#DejaVuSansMono-54"/>
+   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b-star:base:18:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(284.406878 316.087752) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-43"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b-star:base:19:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(284.406878 327.565066) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
    <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b-star:base:20:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(297.272382 144.17682) scale(0.053 -0.053)">
+    <g style="fill: #172033" transform="translate(284.406878 339.042381) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b-star:base:21:T">
-    <!-- T -->
-    <g style="fill: #172033" transform="translate(297.272382 147.948025) scale(0.053 -0.053)">
-     <use xlink:href="#DejaVuSansMono-54"/>
+   <g id="junction:synthetic-three-fragment-target:junction-0001:barcode-b-star:base:21:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(284.406878 350.519695) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
-   <g id="text_3">
+   <g id="text_2">
     <!-- nick -->
-    <g style="fill: #667085" transform="translate(154.951958 235.274768) scale(0.052 -0.052)">
+    <g style="fill: #667085" transform="translate(156.691284 412.093501) scale(0.07 -0.07)">
      <defs>
       <path id="DejaVuSans-6e" d="M 3513 2113
 L 3513 0
@@ -1353,10 +1576,31 @@ z
      <use xlink:href="#DejaVuSans-6b" transform="translate(146.142578 0)"/>
     </g>
    </g>
-   <g id="text_4">
+   <g id="text_3">
     <!-- t1 -->
-    <g style="fill: #4e79a7" transform="translate(216.273521 146.69775) scale(0.055 -0.055)">
+    <g style="fill: #8a5a00" transform="translate(213.231608 353.978949) scale(0.075 -0.075)">
      <defs>
+      <path id="DejaVuSans-74" d="M 1172 4494
+L 1172 3500
+L 2356 3500
+L 2356 3053
+L 1172 3053
+L 1172 1153
+Q 1172 725 1289 603
+Q 1406 481 1766 481
+L 2356 481
+L 2356 0
+L 1766 0
+Q 1100 0 847 248
+Q 594 497 594 1153
+L 594 3053
+L 172 3053
+L 172 3500
+L 594 3500
+L 594 4494
+L 1172 4494
+z
+" transform="scale(0.015625)"/>
       <path id="DejaVuSans-31" d="M 794 531
 L 1825 531
 L 1825 4091
@@ -1376,9 +1620,9 @@ z
      <use xlink:href="#DejaVuSans-31" transform="translate(39.208984 0)"/>
     </g>
    </g>
-   <g id="text_5">
+   <g id="text_4">
     <!-- t1* -->
-    <g style="fill: #4e79a7" transform="translate(214.898521 227.206071) scale(0.055 -0.055)">
+    <g style="fill: #8a5a00" transform="translate(215.488441 411.325691) scale(0.075 -0.075)">
      <defs>
       <path id="DejaVuSans-2a" d="M 3009 3897
 L 1888 3291
@@ -1407,25 +1651,85 @@ z
      <use xlink:href="#DejaVuSans-2a" transform="translate(102.832031 0)"/>
     </g>
    </g>
-   <g id="text_6">
+   <g id="text_5">
     <!-- b1 -->
-    <g style="fill: #4e79a7" transform="translate(257.877926 77.00589) scale(0.055 -0.055)">
+    <g style="fill: #1f6f70" transform="translate(249.331884 103.773497) scale(0.075 -0.075)">
+     <defs>
+      <path id="DejaVuSans-62" d="M 3116 1747
+Q 3116 2381 2855 2742
+Q 2594 3103 2138 3103
+Q 1681 3103 1420 2742
+Q 1159 2381 1159 1747
+Q 1159 1113 1420 752
+Q 1681 391 2138 391
+Q 2594 391 2855 752
+Q 3116 1113 3116 1747
+z
+M 1159 2969
+Q 1341 3281 1617 3432
+Q 1894 3584 2278 3584
+Q 2916 3584 3314 3078
+Q 3713 2572 3713 1747
+Q 3713 922 3314 415
+Q 2916 -91 2278 -91
+Q 1894 -91 1617 61
+Q 1341 213 1159 525
+L 1159 0
+L 581 0
+L 581 4863
+L 1159 4863
+L 1159 2969
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-62"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.476562 0)"/>
     </g>
    </g>
-   <g id="text_7">
+   <g id="text_6">
     <!-- b1* -->
-    <g style="fill: #4e79a7" transform="translate(311.944235 77.00589) scale(0.055 -0.055)">
+    <g style="fill: #1f6f70" transform="translate(298.347048 103.773497) scale(0.075 -0.075)">
      <use xlink:href="#DejaVuSans-62"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.476562 0)"/>
      <use xlink:href="#DejaVuSans-2a" transform="translate(127.099609 0)"/>
     </g>
    </g>
-   <g id="text_8">
+   <g id="text_7">
     <!-- 3′ -->
-    <g style="fill: #667085" transform="translate(275.657716 59.310356) scale(0.053 -0.053)">
+    <g style="fill: #667085" transform="translate(267.105096 90.736417) scale(0.075 -0.075)">
      <defs>
+      <path id="DejaVuSans-33" d="M 2597 2516
+Q 3050 2419 3304 2112
+Q 3559 1806 3559 1356
+Q 3559 666 3084 287
+Q 2609 -91 1734 -91
+Q 1441 -91 1130 -33
+Q 819 25 488 141
+L 488 750
+Q 750 597 1062 519
+Q 1375 441 1716 441
+Q 2309 441 2620 675
+Q 2931 909 2931 1356
+Q 2931 1769 2642 2001
+Q 2353 2234 1838 2234
+L 1294 2234
+L 1294 2753
+L 1863 2753
+Q 2328 2753 2575 2939
+Q 2822 3125 2822 3475
+Q 2822 3834 2567 4026
+Q 2313 4219 1838 4219
+Q 1578 4219 1281 4162
+Q 984 4106 628 3988
+L 628 4550
+Q 988 4650 1302 4700
+Q 1616 4750 1894 4750
+Q 2613 4750 3031 4423
+Q 3450 4097 3450 3541
+Q 3450 3153 3228 2886
+Q 3006 2619 2597 2516
+z
+" transform="scale(0.015625)"/>
       <path id="DejaVuSans-2032" d="M 125 3500
 L 666 4666
 L 1300 4666
@@ -1438,9 +1742,9 @@ z
      <use xlink:href="#DejaVuSans-2032" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_9">
+   <g id="text_8">
     <!-- 5′ -->
-    <g style="fill: #667085" transform="translate(296.580069 59.310356) scale(0.053 -0.053)">
+    <g style="fill: #667085" transform="translate(283.632429 90.736417) scale(0.075 -0.075)">
      <defs>
       <path id="DejaVuSans-35" d="M 691 4666
 L 3169 4666
@@ -1472,559 +1776,329 @@ z
      <use xlink:href="#DejaVuSans-2032" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_10">
-    <!-- synthetic-three-fragment-target:junction-0001 -->
-    <g style="fill: #667085" transform="translate(26.877176 329.843536) scale(0.05 -0.05)">
-     <defs>
-      <path id="DejaVuSans-73" d="M 2834 3397
-L 2834 2853
-Q 2591 2978 2328 3040
-Q 2066 3103 1784 3103
-Q 1356 3103 1142 2972
-Q 928 2841 928 2578
-Q 928 2378 1081 2264
-Q 1234 2150 1697 2047
-L 1894 2003
-Q 2506 1872 2764 1633
-Q 3022 1394 3022 966
-Q 3022 478 2636 193
-Q 2250 -91 1575 -91
-Q 1294 -91 989 -36
-Q 684 19 347 128
-L 347 722
-Q 666 556 975 473
-Q 1284 391 1588 391
-Q 1994 391 2212 530
-Q 2431 669 2431 922
-Q 2431 1156 2273 1281
-Q 2116 1406 1581 1522
-L 1381 1569
-Q 847 1681 609 1914
-Q 372 2147 372 2553
-Q 372 3047 722 3315
-Q 1072 3584 1716 3584
-Q 2034 3584 2315 3537
-Q 2597 3491 2834 3397
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-79" d="M 2059 -325
-Q 1816 -950 1584 -1140
-Q 1353 -1331 966 -1331
-L 506 -1331
-L 506 -850
-L 844 -850
-Q 1081 -850 1212 -737
-Q 1344 -625 1503 -206
-L 1606 56
-L 191 3500
-L 800 3500
-L 1894 763
-L 2988 3500
-L 3597 3500
-L 2059 -325
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-68" d="M 3513 2113
-L 3513 0
-L 2938 0
-L 2938 2094
-Q 2938 2591 2744 2837
-Q 2550 3084 2163 3084
-Q 1697 3084 1428 2787
-Q 1159 2491 1159 1978
-L 1159 0
-L 581 0
-L 581 4863
-L 1159 4863
-L 1159 2956
-Q 1366 3272 1645 3428
-Q 1925 3584 2291 3584
-Q 2894 3584 3203 3211
-Q 3513 2838 3513 2113
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-2d" d="M 313 2009
-L 1997 2009
-L 1997 1497
-L 313 1497
-L 313 2009
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-66" d="M 2375 4863
-L 2375 4384
-L 1825 4384
-Q 1516 4384 1395 4259
-Q 1275 4134 1275 3809
-L 1275 3500
-L 2222 3500
-L 2222 3053
-L 1275 3053
-L 1275 0
-L 697 0
-L 697 3053
-L 147 3053
-L 147 3500
-L 697 3500
-L 697 3744
-Q 697 4328 969 4595
-Q 1241 4863 1831 4863
-L 2375 4863
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-6d" d="M 3328 2828
-Q 3544 3216 3844 3400
-Q 4144 3584 4550 3584
-Q 5097 3584 5394 3201
-Q 5691 2819 5691 2113
-L 5691 0
-L 5113 0
-L 5113 2094
-Q 5113 2597 4934 2840
-Q 4756 3084 4391 3084
-Q 3944 3084 3684 2787
-Q 3425 2491 3425 1978
-L 3425 0
-L 2847 0
-L 2847 2094
-Q 2847 2600 2669 2842
-Q 2491 3084 2119 3084
-Q 1678 3084 1418 2786
-Q 1159 2488 1159 1978
-L 1159 0
-L 581 0
-L 581 3500
-L 1159 3500
-L 1159 2956
-Q 1356 3278 1631 3431
-Q 1906 3584 2284 3584
-Q 2666 3584 2933 3390
-Q 3200 3197 3328 2828
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-3a" d="M 750 794
-L 1409 794
-L 1409 0
-L 750 0
-L 750 794
-z
-M 750 3309
-L 1409 3309
-L 1409 2516
-L 750 2516
-L 750 3309
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-6a" d="M 603 3500
-L 1178 3500
-L 1178 -63
-Q 1178 -731 923 -1031
-Q 669 -1331 103 -1331
-L -116 -1331
-L -116 -844
-L 38 -844
-Q 366 -844 484 -692
-Q 603 -541 603 -63
-L 603 3500
-z
-M 603 4863
-L 1178 4863
-L 1178 4134
-L 603 4134
-L 603 4863
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-75" d="M 544 1381
-L 544 3500
-L 1119 3500
-L 1119 1403
-Q 1119 906 1312 657
-Q 1506 409 1894 409
-Q 2359 409 2629 706
-Q 2900 1003 2900 1516
-L 2900 3500
-L 3475 3500
-L 3475 0
-L 2900 0
-L 2900 538
-Q 2691 219 2414 64
-Q 2138 -91 1772 -91
-Q 1169 -91 856 284
-Q 544 659 544 1381
-z
-M 1991 3584
-L 1991 3584
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-6f" d="M 1959 3097
-Q 1497 3097 1228 2736
-Q 959 2375 959 1747
-Q 959 1119 1226 758
-Q 1494 397 1959 397
-Q 2419 397 2687 759
-Q 2956 1122 2956 1747
-Q 2956 2369 2687 2733
-Q 2419 3097 1959 3097
-z
-M 1959 3584
-Q 2709 3584 3137 3096
-Q 3566 2609 3566 1747
-Q 3566 888 3137 398
-Q 2709 -91 1959 -91
-Q 1206 -91 779 398
-Q 353 888 353 1747
-Q 353 2609 779 3096
-Q 1206 3584 1959 3584
-z
-" transform="scale(0.015625)"/>
-      <path id="DejaVuSans-30" d="M 2034 4250
-Q 1547 4250 1301 3770
-Q 1056 3291 1056 2328
-Q 1056 1369 1301 889
-Q 1547 409 2034 409
-Q 2525 409 2770 889
-Q 3016 1369 3016 2328
-Q 3016 3291 2770 3770
-Q 2525 4250 2034 4250
-z
-M 2034 4750
-Q 2819 4750 3233 4129
-Q 3647 3509 3647 2328
-Q 3647 1150 3233 529
-Q 2819 -91 2034 -91
-Q 1250 -91 836 529
-Q 422 1150 422 2328
-Q 422 3509 836 4129
-Q 1250 4750 2034 4750
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-73"/>
-     <use xlink:href="#DejaVuSans-79" transform="translate(52.099609 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(111.279297 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(174.658203 0)"/>
-     <use xlink:href="#DejaVuSans-68" transform="translate(213.867188 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(277.246094 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(338.769531 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(377.978516 0)"/>
-     <use xlink:href="#DejaVuSans-63" transform="translate(405.761719 0)"/>
-     <use xlink:href="#DejaVuSans-2d" transform="translate(460.742188 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(496.826172 0)"/>
-     <use xlink:href="#DejaVuSans-68" transform="translate(536.035156 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(599.414062 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(638.277344 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(699.800781 0)"/>
-     <use xlink:href="#DejaVuSans-2d" transform="translate(761.324219 0)"/>
-     <use xlink:href="#DejaVuSans-66" transform="translate(797.408203 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(832.613281 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(873.726562 0)"/>
-     <use xlink:href="#DejaVuSans-67" transform="translate(935.005859 0)"/>
-     <use xlink:href="#DejaVuSans-6d" transform="translate(998.482422 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(1095.894531 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(1157.417969 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(1220.796875 0)"/>
-     <use xlink:href="#DejaVuSans-2d" transform="translate(1260.005859 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(1296.089844 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(1335.298828 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(1396.578125 0)"/>
-     <use xlink:href="#DejaVuSans-67" transform="translate(1435.941406 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(1499.417969 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(1560.941406 0)"/>
-     <use xlink:href="#DejaVuSans-3a" transform="translate(1600.150391 0)"/>
-     <use xlink:href="#DejaVuSans-6a" transform="translate(1633.841797 0)"/>
-     <use xlink:href="#DejaVuSans-75" transform="translate(1661.625 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(1725.003906 0)"/>
-     <use xlink:href="#DejaVuSans-63" transform="translate(1788.382812 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(1843.363281 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(1882.572266 0)"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(1910.355469 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(1971.537109 0)"/>
-     <use xlink:href="#DejaVuSans-2d" transform="translate(2034.916016 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(2071 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(2134.623047 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(2198.246094 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(2261.869141 0)"/>
-    </g>
-   </g>
    <g id="line2d_1">
-    <path d="M 84.152118 169.098705
-L 88.859647 154.164735
-" clip-path="url(#p1ed6e3343e)" style="fill: none; stroke: #ffffff; stroke-width: 3.2; stroke-linecap: square"/>
+    <path d="M 161.307915 401.265483
+L 166.357934 389.329077
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #ffffff; stroke-width: 4.2; stroke-linecap: square"/>
    </g>
    <g id="line2d_2">
-    <path d="M 90.428824 169.098705
-L 95.136353 154.164735
-" clip-path="url(#p1ed6e3343e)" style="fill: none; stroke: #ffffff; stroke-width: 3.2; stroke-linecap: square"/>
+    <path d="M 90.607659 370.965374
+L 94.739492 359.947152
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #ffffff; stroke-width: 4; stroke-linecap: square"/>
    </g>
    <g id="line2d_3">
-    <path d="M 84.152118 215.559945
-L 88.859647 200.625975
-" clip-path="url(#p1ed6e3343e)" style="fill: none; stroke: #ffffff; stroke-width: 3.2; stroke-linecap: square"/>
+    <path d="M 95.198585 370.965374
+L 99.330418 359.947152
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #ffffff; stroke-width: 4; stroke-linecap: square"/>
    </g>
    <g id="line2d_4">
-    <path d="M 90.428824 215.559945
-L 95.136353 200.625975
-" clip-path="url(#p1ed6e3343e)" style="fill: none; stroke: #ffffff; stroke-width: 3.2; stroke-linecap: square"/>
+    <path d="M 90.607659 400.806391
+L 94.739492 389.788169
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #ffffff; stroke-width: 4; stroke-linecap: square"/>
    </g>
    <g id="line2d_5">
-    <path d="M 363.988588 169.098705
-L 368.696118 154.164735
-" clip-path="url(#p1ed6e3343e)" style="fill: none; stroke: #ffffff; stroke-width: 3.2; stroke-linecap: square"/>
+    <path d="M 95.198585 400.806391
+L 99.330418 389.788169
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #ffffff; stroke-width: 4; stroke-linecap: square"/>
    </g>
    <g id="line2d_6">
-    <path d="M 370.265294 169.098705
-L 374.972824 154.164735
-" clip-path="url(#p1ed6e3343e)" style="fill: none; stroke: #ffffff; stroke-width: 3.2; stroke-linecap: square"/>
+    <path d="M 457.881716 370.965374
+L 462.01355 359.947152
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #ffffff; stroke-width: 4; stroke-linecap: square"/>
    </g>
    <g id="line2d_7">
-    <path d="M 363.988588 215.559945
-L 368.696118 200.625975
-" clip-path="url(#p1ed6e3343e)" style="fill: none; stroke: #ffffff; stroke-width: 3.2; stroke-linecap: square"/>
+    <path d="M 462.472642 370.965374
+L 466.604475 359.947152
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #ffffff; stroke-width: 4; stroke-linecap: square"/>
    </g>
    <g id="line2d_8">
-    <path d="M 370.265294 215.559945
-L 374.972824 200.625975
-" clip-path="url(#p1ed6e3343e)" style="fill: none; stroke: #ffffff; stroke-width: 3.2; stroke-linecap: square"/>
+    <path d="M 457.881716 400.806391
+L 462.01355 389.788169
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #ffffff; stroke-width: 4; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_9">
+    <path d="M 462.472642 400.806391
+L 466.604475 389.788169
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #ffffff; stroke-width: 4; stroke-linecap: square"/>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0001:nick">
+    <path d="M 161.307915 401.265483
+L 166.357934 389.329077
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #172033; stroke-width: 1.2; stroke-linecap: square"/>
    </g>
    <g id="junction:synthetic-three-fragment-target:junction-0001:left-top-break:0">
-    <path d="M 84.152118 169.098705
-L 88.859647 154.164735
-" clip-path="url(#p1ed6e3343e)" style="fill: none; stroke: #172033; stroke-width: 0.9; stroke-linecap: square"/>
+    <path d="M 90.607659 370.965374
+L 94.739492 359.947152
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #172033; stroke-linecap: square"/>
    </g>
    <g id="junction:synthetic-three-fragment-target:junction-0001:left-top-break:1">
-    <path d="M 90.428824 169.098705
-L 95.136353 154.164735
-" clip-path="url(#p1ed6e3343e)" style="fill: none; stroke: #172033; stroke-width: 0.9; stroke-linecap: square"/>
+    <path d="M 95.198585 370.965374
+L 99.330418 359.947152
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #172033; stroke-linecap: square"/>
    </g>
    <g id="junction:synthetic-three-fragment-target:junction-0001:left-bottom-break:0">
-    <path d="M 84.152118 215.559945
-L 88.859647 200.625975
-" clip-path="url(#p1ed6e3343e)" style="fill: none; stroke: #172033; stroke-width: 0.9; stroke-linecap: square"/>
+    <path d="M 90.607659 400.806391
+L 94.739492 389.788169
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #172033; stroke-linecap: square"/>
    </g>
    <g id="junction:synthetic-three-fragment-target:junction-0001:left-bottom-break:1">
-    <path d="M 90.428824 215.559945
-L 95.136353 200.625975
-" clip-path="url(#p1ed6e3343e)" style="fill: none; stroke: #172033; stroke-width: 0.9; stroke-linecap: square"/>
+    <path d="M 95.198585 400.806391
+L 99.330418 389.788169
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #172033; stroke-linecap: square"/>
    </g>
    <g id="junction:synthetic-three-fragment-target:junction-0001:right-top-break:0">
-    <path d="M 363.988588 169.098705
-L 368.696118 154.164735
-" clip-path="url(#p1ed6e3343e)" style="fill: none; stroke: #172033; stroke-width: 0.9; stroke-linecap: square"/>
+    <path d="M 457.881716 370.965374
+L 462.01355 359.947152
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #172033; stroke-linecap: square"/>
    </g>
    <g id="junction:synthetic-three-fragment-target:junction-0001:right-top-break:1">
-    <path d="M 370.265294 169.098705
-L 374.972824 154.164735
-" clip-path="url(#p1ed6e3343e)" style="fill: none; stroke: #172033; stroke-width: 0.9; stroke-linecap: square"/>
+    <path d="M 462.472642 370.965374
+L 466.604475 359.947152
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #172033; stroke-linecap: square"/>
    </g>
    <g id="junction:synthetic-three-fragment-target:junction-0001:right-bottom-break:0">
-    <path d="M 363.988588 215.559945
-L 368.696118 200.625975
-" clip-path="url(#p1ed6e3343e)" style="fill: none; stroke: #172033; stroke-width: 0.9; stroke-linecap: square"/>
+    <path d="M 457.881716 400.806391
+L 462.01355 389.788169
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #172033; stroke-linecap: square"/>
    </g>
    <g id="junction:synthetic-three-fragment-target:junction-0001:right-bottom-break:1">
-    <path d="M 370.265294 215.559945
-L 374.972824 200.625975
-" clip-path="url(#p1ed6e3343e)" style="fill: none; stroke: #172033; stroke-width: 0.9; stroke-linecap: square"/>
+    <path d="M 462.472642 400.806391
+L 466.604475 389.788169
+" clip-path="url(#pb251acdba2)" style="fill: none; stroke: #172033; stroke-linecap: square"/>
    </g>
   </g>
   <g id="junction-three-way-assembly:synthetic-three-fragment-target:junction-0002:detail">
-   <g id="patch_6">
-    <path d="M 701.623059 170.758035
-L 824.541882 170.758035
-L 824.541882 152.505405
-L 701.623059 152.505405
-z
-" clip-path="url(#p51da927130)" style="fill: #2a9d8f; opacity: 0.24"/>
-   </g>
-   <g id="patch_7">
-    <path d="M 701.623059 217.219275
-L 824.541882 217.219275
-L 824.541882 198.966645
-L 701.623059 198.966645
-z
-" clip-path="url(#p51da927130)" style="fill: #2a9d8f; opacity: 0.24"/>
-   </g>
-   <g id="patch_8">
-    <path d="M 812.773059 161.63172
-L 828.464824 161.63172
-L 828.464824 78.66522
-L 812.773059 78.66522
-z
-" clip-path="url(#p51da927130)" style="fill: #2a9d8f; opacity: 0.22"/>
-   </g>
-   <g id="patch_9">
-    <path d="M 836.310706 161.63172
-L 852.002471 161.63172
-L 852.002471 78.66522
-L 836.310706 78.66522
-z
-" clip-path="url(#p51da927130)" style="fill: #2a9d8f; opacity: 0.22"/>
-   </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0002:target-pairs">
-    <path d="M 639.509824 167.439375
-L 639.509824 202.285305
-" clip-path="url(#p51da927130)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 651.278647 167.439375
-L 651.278647 202.285305
-" clip-path="url(#p51da927130)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 663.047471 167.439375
-L 663.047471 202.285305
-" clip-path="url(#p51da927130)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 674.816294 167.439375
-L 674.816294 202.285305
-" clip-path="url(#p51da927130)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 686.585118 167.439375
-L 686.585118 202.285305
-" clip-path="url(#p51da927130)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 698.353941 167.439375
-L 698.353941 202.285305
-" clip-path="url(#p51da927130)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 710.122765 167.439375
-L 710.122765 202.285305
-" clip-path="url(#p51da927130)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 721.891588 167.439375
-L 721.891588 202.285305
-" clip-path="url(#p51da927130)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 733.660412 167.439375
-L 733.660412 202.285305
-" clip-path="url(#p51da927130)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 745.429235 167.439375
-L 745.429235 202.285305
-" clip-path="url(#p51da927130)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 757.198059 167.439375
-L 757.198059 202.285305
-" clip-path="url(#p51da927130)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 768.966882 167.439375
-L 768.966882 202.285305
-" clip-path="url(#p51da927130)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 780.735706 167.439375
-L 780.735706 202.285305
-" clip-path="url(#p51da927130)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 792.504529 167.439375
-L 792.504529 202.285305
-" clip-path="url(#p51da927130)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 804.273353 167.439375
-L 804.273353 202.285305
-" clip-path="url(#p51da927130)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 816.042176 167.439375
-L 816.042176 202.285305
-" clip-path="url(#p51da927130)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 848.733353 167.439375
-L 848.733353 202.285305
-" clip-path="url(#p51da927130)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 860.502176 167.439375
-L 860.502176 202.285305
-" clip-path="url(#p51da927130)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 872.271 167.439375
-L 872.271 202.285305
-" clip-path="url(#p51da927130)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 884.039824 167.439375
-L 884.039824 202.285305
-" clip-path="url(#p51da927130)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 895.808647 167.439375
-L 895.808647 202.285305
-" clip-path="url(#p51da927130)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 907.577471 167.439375
-L 907.577471 202.285305
-" clip-path="url(#p51da927130)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-   </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-pairs">
-    <path d="M 827.680235 146.471478
-L 837.095294 146.471478
-" clip-path="url(#p51da927130)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 827.680235 142.700273
-L 837.095294 142.700273
-" clip-path="url(#p51da927130)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 827.680235 138.929069
-L 837.095294 138.929069
-" clip-path="url(#p51da927130)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 827.680235 135.157864
-L 837.095294 135.157864
-" clip-path="url(#p51da927130)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 827.680235 131.38666
-L 837.095294 131.38666
-" clip-path="url(#p51da927130)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 827.680235 127.615455
-L 837.095294 127.615455
-" clip-path="url(#p51da927130)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 827.680235 123.84425
-L 837.095294 123.84425
-" clip-path="url(#p51da927130)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 827.680235 120.073046
-L 837.095294 120.073046
-" clip-path="url(#p51da927130)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 827.680235 116.301841
-L 837.095294 116.301841
-" clip-path="url(#p51da927130)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 827.680235 112.530637
-L 837.095294 112.530637
-" clip-path="url(#p51da927130)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 827.680235 108.759432
-L 837.095294 108.759432
-" clip-path="url(#p51da927130)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 827.680235 104.988228
-L 837.095294 104.988228
-" clip-path="url(#p51da927130)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 827.680235 101.217023
-L 837.095294 101.217023
-" clip-path="url(#p51da927130)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 827.680235 97.445819
-L 837.095294 97.445819
-" clip-path="url(#p51da927130)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 827.680235 93.674614
-L 837.095294 93.674614
-" clip-path="url(#p51da927130)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 827.680235 89.90341
-L 837.095294 89.90341
-" clip-path="url(#p51da927130)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 827.680235 86.132205
-L 837.095294 86.132205
-" clip-path="url(#p51da927130)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 827.680235 82.361
-L 837.095294 82.361
-" clip-path="url(#p51da927130)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 827.680235 78.589796
-L 837.095294 78.589796
-" clip-path="url(#p51da927130)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 827.680235 74.818591
-L 837.095294 74.818591
-" clip-path="url(#p51da927130)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 827.680235 71.047387
-L 837.095294 71.047387
-" clip-path="url(#p51da927130)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-    <path d="M 827.680235 67.276182
-L 837.095294 67.276182
-" clip-path="url(#p51da927130)" style="fill: none; stroke: #cdd3db; stroke-width: 0.55"/>
-   </g>
    <g id="junction:synthetic-three-fragment-target:junction-0002:left-and-barcode-arm">
-    <path d="M 633.625412 161.63172
-L 812.773059 161.63172
-L 812.773059 65.39058
-" clip-path="url(#p51da927130)" style="fill: none; stroke: #172033; stroke-width: 1.1; stroke-linecap: round"/>
+    <path d="M 636.534504 365.456263
+L 811.907866 365.456263
+L 811.907866 101.478034
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #7c8798; stroke-width: 11; stroke-linecap: round"/>
    </g>
    <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-and-right-arm">
-    <path d="M 852.002471 65.39058
-L 852.002471 161.63172
-L 913.461882 161.63172
-" clip-path="url(#p51da927130)" style="fill: none; stroke: #172033; stroke-width: 1.1; stroke-linecap: round"/>
+    <path d="M 828.435199 101.478034
+L 828.435199 365.456263
+L 1003.808561 365.456263
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #7c8798; stroke-width: 11; stroke-linecap: round"/>
    </g>
    <g id="junction:synthetic-three-fragment-target:junction-0002:left-complement-arm">
-    <path d="M 633.625412 208.09296
-L 701.1 208.09296
-" clip-path="url(#p51da927130)" style="fill: none; stroke: #4b5563; stroke-width: 1.1; stroke-linecap: round"/>
+    <path d="M 636.534504 395.29728
+L 701.496103 395.29728
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #7c8798; stroke-width: 11; stroke-linecap: round"/>
    </g>
    <g id="junction:synthetic-three-fragment-target:junction-0002:right-complement-arm">
-    <path d="M 707.376706 208.09296
-L 913.461882 208.09296
-" clip-path="url(#p51da927130)" style="fill: none; stroke: #4b5563; stroke-width: 1.1; stroke-linecap: round"/>
+    <path d="M 709.300677 395.29728
+L 1003.808561 395.29728
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #7c8798; stroke-width: 11; stroke-linecap: round"/>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0002:nick">
-    <path d="M 701.1 215.559945
-L 707.376706 200.625975
-" clip-path="url(#p51da927130)" style="fill: none; stroke: #111827; stroke-width: 1.1; stroke-linecap: square"/>
+   <g id="junction:synthetic-three-fragment-target:junction-0002:left-target-top">
+    <path d="M 636.534504 365.456263
+L 705.39839 365.456263
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #e8ebef; stroke-width: 8.5; stroke-linecap: round"/>
    </g>
-   <g id="text_11">
-    <!-- J02 · F02 → F03 -->
-    <g style="fill: #172033" transform="translate(570.858353 39.182216) scale(0.07 -0.07)">
+   <g id="junction:synthetic-three-fragment-target:junction-0002:left-target-bottom">
+    <path d="M 636.534504 395.29728
+L 701.496103 395.29728
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #e8ebef; stroke-width: 8.5; stroke-linecap: round"/>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0002:toehold-top-path">
+    <path d="M 705.39839 365.456263
+L 811.907866 365.456263
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #f3d6a1; stroke-width: 8.5; stroke-linecap: round"/>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-left-path">
+    <path d="M 811.907866 365.456263
+L 811.907866 101.478034
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #a9d8d5; stroke-width: 8.5; stroke-linecap: round"/>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-right-path">
+    <path d="M 828.435199 101.478034
+L 828.435199 365.456263
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #a9d8d5; stroke-width: 8.5; stroke-linecap: round"/>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0002:right-target-top">
+    <path d="M 828.435199 365.456263
+L 1003.808561 365.456263
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #e8ebef; stroke-width: 8.5; stroke-linecap: round"/>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0002:right-target-bottom">
+    <path d="M 820.171533 395.29728
+L 1003.808561 395.29728
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #e8ebef; stroke-width: 8.5; stroke-linecap: round"/>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0002:toehold-bottom-path">
+    <path d="M 709.300677 395.29728
+L 820.171533 395.29728
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #f3d6a1; stroke-width: 8.5; stroke-linecap: round"/>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0002:target-pairs">
+    <path d="M 642.273161 370.965374
+L 642.273161 389.788169
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 653.750476 370.965374
+L 653.750476 389.788169
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 665.22779 370.965374
+L 665.22779 389.788169
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 676.705104 370.965374
+L 676.705104 389.788169
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 688.182418 370.965374
+L 688.182418 389.788169
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 699.659733 370.965374
+L 699.659733 389.788169
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 711.137047 370.965374
+L 711.137047 389.788169
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 722.614361 370.965374
+L 722.614361 389.788169
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 734.091676 370.965374
+L 734.091676 389.788169
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 745.56899 370.965374
+L 745.56899 389.788169
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 757.046304 370.965374
+L 757.046304 389.788169
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 768.523618 370.965374
+L 768.523618 389.788169
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 780.000933 370.965374
+L 780.000933 389.788169
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 791.478247 370.965374
+L 791.478247 389.788169
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 802.955561 370.965374
+L 802.955561 389.788169
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 814.432876 370.965374
+L 814.432876 389.788169
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 825.91019 370.965374
+L 825.91019 389.788169
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 837.387504 370.965374
+L 837.387504 389.788169
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 848.864818 370.965374
+L 848.864818 389.788169
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 860.342133 370.965374
+L 860.342133 389.788169
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 871.819447 370.965374
+L 871.819447 389.788169
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 883.296761 370.965374
+L 883.296761 389.788169
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 894.774076 370.965374
+L 894.774076 389.788169
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 906.25139 370.965374
+L 906.25139 389.788169
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 917.728704 370.965374
+L 917.728704 389.788169
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 929.206018 370.965374
+L 929.206018 389.788169
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 940.683333 370.965374
+L 940.683333 389.788169
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 952.160647 370.965374
+L 952.160647 389.788169
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 963.637961 370.965374
+L 963.637961 389.788169
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 975.115276 370.965374
+L 975.115276 389.788169
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 986.59259 370.965374
+L 986.59259 389.788169
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 998.069904 370.965374
+L 998.069904 389.788169
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-pairs">
+    <path d="M 815.580607 348.240291
+L 824.762458 348.240291
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 815.580607 336.762977
+L 824.762458 336.762977
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 815.580607 325.285663
+L 824.762458 325.285663
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 815.580607 313.808349
+L 824.762458 313.808349
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 815.580607 302.331034
+L 824.762458 302.331034
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 815.580607 290.85372
+L 824.762458 290.85372
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 815.580607 279.376406
+L 824.762458 279.376406
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 815.580607 267.899091
+L 824.762458 267.899091
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 815.580607 256.421777
+L 824.762458 256.421777
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 815.580607 244.944463
+L 824.762458 244.944463
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 815.580607 233.467149
+L 824.762458 233.467149
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 815.580607 221.989834
+L 824.762458 221.989834
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 815.580607 210.51252
+L 824.762458 210.51252
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 815.580607 199.035206
+L 824.762458 199.035206
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 815.580607 187.557891
+L 824.762458 187.557891
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 815.580607 176.080577
+L 824.762458 176.080577
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 815.580607 164.603263
+L 824.762458 164.603263
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 815.580607 153.125949
+L 824.762458 153.125949
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 815.580607 141.648634
+L 824.762458 141.648634
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 815.580607 130.17132
+L 824.762458 130.17132
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 815.580607 118.694006
+L 824.762458 118.694006
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+    <path d="M 815.580607 107.216691
+L 824.762458 107.216691
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #b8c0cc; stroke-width: 0.8"/>
+   </g>
+   <g id="text_9">
+    <!-- junction-0002 joins F02 to F03 at target bp 127–136 -->
+    <g style="fill: #172033" transform="translate(612.432144 60.49183) scale(0.095 -0.095)">
      <defs>
       <path id="DejaVuSans-Bold-33" d="M 2981 2516
 Q 3453 2394 3698 2092
@@ -2059,1079 +2133,886 @@ Q 3403 2622 2981 2516
 z
 " transform="scale(0.015625)"/>
      </defs>
-     <use xlink:href="#DejaVuSans-Bold-4a"/>
-     <use xlink:href="#DejaVuSans-Bold-30" transform="translate(37.207031 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-32" transform="translate(106.787109 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(176.367188 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-b7" transform="translate(211.181641 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(249.169922 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-46" transform="translate(283.984375 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-30" transform="translate(352.294922 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-32" transform="translate(421.875 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(491.455078 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-2192" transform="translate(526.269531 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(610.058594 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-46" transform="translate(644.873047 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-30" transform="translate(713.183594 0)"/>
-     <use xlink:href="#DejaVuSans-Bold-33" transform="translate(782.763672 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6a"/>
+     <use xlink:href="#DejaVuSans-Bold-75" transform="translate(34.277344 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(105.46875 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-63" transform="translate(176.660156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-74" transform="translate(235.9375 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-69" transform="translate(283.740234 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6f" transform="translate(318.017578 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(386.71875 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-2d" transform="translate(457.910156 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-30" transform="translate(499.414062 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-30" transform="translate(568.994141 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-30" transform="translate(638.574219 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-32" transform="translate(708.154297 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(777.734375 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6a" transform="translate(812.548828 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6f" transform="translate(846.826172 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-69" transform="translate(915.527344 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(949.804688 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-73" transform="translate(1020.996094 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(1080.517578 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-46" transform="translate(1115.332031 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-30" transform="translate(1183.642578 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-32" transform="translate(1253.222656 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(1322.802734 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-74" transform="translate(1357.617188 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-6f" transform="translate(1405.419922 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(1474.121094 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-46" transform="translate(1508.935547 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-30" transform="translate(1577.246094 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-33" transform="translate(1646.826172 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(1716.40625 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-61" transform="translate(1751.220703 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-74" transform="translate(1818.701172 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(1866.503906 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-74" transform="translate(1901.318359 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-61" transform="translate(1949.121094 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-72" transform="translate(2016.601562 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-67" transform="translate(2065.917969 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-65" transform="translate(2137.5 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-74" transform="translate(2205.322266 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(2253.125 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-62" transform="translate(2287.939453 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-70" transform="translate(2359.521484 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-20" transform="translate(2431.103516 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-31" transform="translate(2465.917969 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-32" transform="translate(2535.498047 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-37" transform="translate(2605.078125 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-2013" transform="translate(2674.658203 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-31" transform="translate(2724.658203 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-33" transform="translate(2794.238281 0)"/>
+     <use xlink:href="#DejaVuSans-Bold-36" transform="translate(2863.818359 0)"/>
     </g>
    </g>
-   <g id="text_12">
-    <!-- target bp 120–129 -->
-    <g style="fill: #667085" transform="translate(1022.045917 38.042451) scale(0.055 -0.055)">
-     <defs>
-      <path id="DejaVuSans-39" d="M 703 97
-L 703 672
-Q 941 559 1184 500
-Q 1428 441 1663 441
-Q 2288 441 2617 861
-Q 2947 1281 2994 2138
-Q 2813 1869 2534 1725
-Q 2256 1581 1919 1581
-Q 1219 1581 811 2004
-Q 403 2428 403 3163
-Q 403 3881 828 4315
-Q 1253 4750 1959 4750
-Q 2769 4750 3195 4129
-Q 3622 3509 3622 2328
-Q 3622 1225 3098 567
-Q 2575 -91 1691 -91
-Q 1453 -91 1209 -44
-Q 966 3 703 97
-z
-M 1959 2075
-Q 2384 2075 2632 2365
-Q 2881 2656 2881 3163
-Q 2881 3666 2632 3958
-Q 2384 4250 1959 4250
-Q 1534 4250 1286 3958
-Q 1038 3666 1038 3163
-Q 1038 2656 1286 2365
-Q 1534 2075 1959 2075
-z
-" transform="scale(0.015625)"/>
-     </defs>
-     <use xlink:href="#DejaVuSans-74"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(39.208984 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(100.488281 0)"/>
-     <use xlink:href="#DejaVuSans-67" transform="translate(139.851562 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(203.328125 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(264.851562 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(304.060547 0)"/>
-     <use xlink:href="#DejaVuSans-62" transform="translate(335.847656 0)"/>
-     <use xlink:href="#DejaVuSans-70" transform="translate(399.324219 0)"/>
-     <use xlink:href="#DejaVuSans-20" transform="translate(462.800781 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(494.587891 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(558.210938 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(621.833984 0)"/>
-     <use xlink:href="#DejaVuSans-2013" transform="translate(685.457031 0)"/>
-     <use xlink:href="#DejaVuSans-31" transform="translate(735.457031 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(799.080078 0)"/>
-     <use xlink:href="#DejaVuSans-39" transform="translate(862.703125 0)"/>
-    </g>
-   </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0002:left-top:base:0:C">
-    <!-- C -->
-    <g style="fill: #172033" transform="translate(637.854238 163.163986) scale(0.055 -0.055)">
-     <use xlink:href="#DejaVuSansMono-43"/>
+   <g id="junction:synthetic-three-fragment-target:junction-0002:left-top:base:0:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(639.810306 367.735666) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
    <g id="junction:synthetic-three-fragment-target:junction-0002:left-top:base:1:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(649.623061 163.163986) scale(0.055 -0.055)">
+    <g style="fill: #172033" transform="translate(651.28762 367.735666) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0002:left-top:base:2:G">
-    <!-- G -->
-    <g style="fill: #172033" transform="translate(661.391885 163.163986) scale(0.055 -0.055)">
-     <use xlink:href="#DejaVuSansMono-47"/>
-    </g>
-   </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0002:left-top:base:3:G">
-    <!-- G -->
-    <g style="fill: #172033" transform="translate(673.160708 163.163986) scale(0.055 -0.055)">
-     <use xlink:href="#DejaVuSansMono-47"/>
-    </g>
-   </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0002:left-top:base:4:T">
+   <g id="junction:synthetic-three-fragment-target:junction-0002:left-top:base:2:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(684.929532 163.163986) scale(0.055 -0.055)">
+    <g style="fill: #172033" transform="translate(662.764935 367.735666) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0002:left-top:base:5:A">
+   <g id="junction:synthetic-three-fragment-target:junction-0002:left-top:base:3:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(674.242249 367.735666) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-43"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0002:left-top:base:4:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(685.719563 367.735666) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-43"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0002:left-top:base:5:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(697.196878 367.735666) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-47"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0002:toehold-top:base:0:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(696.698355 163.163986) scale(0.055 -0.055)">
+    <g style="fill: #172033" transform="translate(708.674192 367.735666) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-41"/>
-    </g>
-   </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0002:toehold-top:base:0:T">
-    <!-- T -->
-    <g style="fill: #172033" transform="translate(708.467179 163.163986) scale(0.055 -0.055)">
-     <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
    <g id="junction:synthetic-three-fragment-target:junction-0002:toehold-top:base:1:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(720.236002 163.163986) scale(0.055 -0.055)">
+    <g style="fill: #172033" transform="translate(720.151506 367.735666) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
    <g id="junction:synthetic-three-fragment-target:junction-0002:toehold-top:base:2:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(732.004826 163.163986) scale(0.055 -0.055)">
+    <g style="fill: #172033" transform="translate(731.62882 367.735666) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0002:toehold-top:base:3:T">
-    <!-- T -->
-    <g style="fill: #172033" transform="translate(743.773649 163.163986) scale(0.055 -0.055)">
-     <use xlink:href="#DejaVuSansMono-54"/>
+   <g id="junction:synthetic-three-fragment-target:junction-0002:toehold-top:base:3:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(743.106135 367.735666) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0002:toehold-top:base:4:C">
-    <!-- C -->
-    <g style="fill: #172033" transform="translate(755.542473 163.163986) scale(0.055 -0.055)">
-     <use xlink:href="#DejaVuSansMono-43"/>
+   <g id="junction:synthetic-three-fragment-target:junction-0002:toehold-top:base:4:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(754.583449 367.735666) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
    <g id="junction:synthetic-three-fragment-target:junction-0002:toehold-top:base:5:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(767.311296 163.163986) scale(0.055 -0.055)">
+    <g style="fill: #172033" transform="translate(766.060763 367.735666) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0002:toehold-top:base:6:G">
+   <g id="junction:synthetic-three-fragment-target:junction-0002:toehold-top:base:6:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(777.538078 367.735666) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-54"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0002:toehold-top:base:7:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(789.015392 367.735666) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-54"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0002:toehold-top:base:8:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(800.492706 367.735666) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-54"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0002:toehold-top:base:9:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(779.08012 163.163986) scale(0.055 -0.055)">
+    <g style="fill: #172033" transform="translate(811.97002 367.735666) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0002:toehold-top:base:7:A">
+   <g id="junction:synthetic-three-fragment-target:junction-0002:right-top:base:0:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(790.848943 163.163986) scale(0.055 -0.055)">
+    <g style="fill: #172033" transform="translate(823.447335 367.735666) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0002:toehold-top:base:8:A">
+   <g id="junction:synthetic-three-fragment-target:junction-0002:right-top:base:1:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(802.617767 163.163986) scale(0.055 -0.055)">
+    <g style="fill: #172033" transform="translate(834.924649 367.735666) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0002:toehold-top:base:9:A">
-    <!-- A -->
-    <g style="fill: #172033" transform="translate(814.386591 163.163986) scale(0.055 -0.055)">
-     <use xlink:href="#DejaVuSansMono-41"/>
-    </g>
-   </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0002:right-top:base:0:C">
-    <!-- C -->
-    <g style="fill: #172033" transform="translate(847.077767 163.163986) scale(0.055 -0.055)">
-     <use xlink:href="#DejaVuSansMono-43"/>
-    </g>
-   </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0002:right-top:base:1:G">
-    <!-- G -->
-    <g style="fill: #172033" transform="translate(858.846591 163.163986) scale(0.055 -0.055)">
-     <use xlink:href="#DejaVuSansMono-47"/>
-    </g>
-   </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0002:right-top:base:2:C">
-    <!-- C -->
-    <g style="fill: #172033" transform="translate(870.615414 163.163986) scale(0.055 -0.055)">
-     <use xlink:href="#DejaVuSansMono-43"/>
+   <g id="junction:synthetic-three-fragment-target:junction-0002:right-top:base:2:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(846.401963 367.735666) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
    <g id="junction:synthetic-three-fragment-target:junction-0002:right-top:base:3:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(882.384238 163.163986) scale(0.055 -0.055)">
+    <g style="fill: #172033" transform="translate(857.879278 367.735666) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
    <g id="junction:synthetic-three-fragment-target:junction-0002:right-top:base:4:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(894.153061 163.163986) scale(0.055 -0.055)">
+    <g style="fill: #172033" transform="translate(869.356592 367.735666) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
    <g id="junction:synthetic-three-fragment-target:junction-0002:right-top:base:5:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(905.921885 163.163986) scale(0.055 -0.055)">
+    <g style="fill: #172033" transform="translate(880.833906 367.735666) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0002:left-bottom:base:0:G">
+   <g id="junction:synthetic-three-fragment-target:junction-0002:right-top:base:6:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(637.854238 209.625226) scale(0.055 -0.055)">
+    <g style="fill: #172033" transform="translate(892.31122 367.735666) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-47"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0002:right-top:base:7:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(903.788535 367.735666) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-47"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0002:right-top:base:8:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(915.265849 367.735666) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-47"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0002:right-top:base:9:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(926.743163 367.735666) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-47"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0002:right-top:base:10:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(938.220478 367.735666) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-41"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0002:right-top:base:11:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(949.697792 367.735666) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-43"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0002:right-top:base:12:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(961.175106 367.735666) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-47"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0002:right-top:base:13:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(972.65242 367.735666) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-43"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0002:right-top:base:14:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(984.129735 367.735666) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-43"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0002:right-top:base:15:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(995.607049 367.735666) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-54"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0002:left-bottom:base:0:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(639.810306 397.576683) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
    <g id="junction:synthetic-three-fragment-target:junction-0002:left-bottom:base:1:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(649.623061 209.625226) scale(0.055 -0.055)">
+    <g style="fill: #172033" transform="translate(651.28762 397.576683) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0002:left-bottom:base:2:C">
-    <!-- C -->
-    <g style="fill: #172033" transform="translate(661.391885 209.625226) scale(0.055 -0.055)">
-     <use xlink:href="#DejaVuSansMono-43"/>
-    </g>
-   </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0002:left-bottom:base:3:C">
-    <!-- C -->
-    <g style="fill: #172033" transform="translate(673.160708 209.625226) scale(0.055 -0.055)">
-     <use xlink:href="#DejaVuSansMono-43"/>
-    </g>
-   </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0002:left-bottom:base:4:A">
+   <g id="junction:synthetic-three-fragment-target:junction-0002:left-bottom:base:2:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(684.929532 209.625226) scale(0.055 -0.055)">
+    <g style="fill: #172033" transform="translate(662.764935 397.576683) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0002:left-bottom:base:5:T">
+   <g id="junction:synthetic-three-fragment-target:junction-0002:left-bottom:base:3:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(674.242249 397.576683) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-47"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0002:left-bottom:base:4:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(685.719563 397.576683) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-47"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0002:left-bottom:base:5:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(697.196878 397.576683) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-43"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0002:toehold-bottom:base:0:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(696.698355 209.625226) scale(0.055 -0.055)">
+    <g style="fill: #172033" transform="translate(708.674192 397.576683) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-54"/>
-    </g>
-   </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0002:toehold-bottom:base:0:A">
-    <!-- A -->
-    <g style="fill: #172033" transform="translate(708.467179 209.625226) scale(0.055 -0.055)">
-     <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
    <g id="junction:synthetic-three-fragment-target:junction-0002:toehold-bottom:base:1:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(720.236002 209.625226) scale(0.055 -0.055)">
+    <g style="fill: #172033" transform="translate(720.151506 397.576683) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
    <g id="junction:synthetic-three-fragment-target:junction-0002:toehold-bottom:base:2:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(732.004826 209.625226) scale(0.055 -0.055)">
+    <g style="fill: #172033" transform="translate(731.62882 397.576683) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0002:toehold-bottom:base:3:A">
-    <!-- A -->
-    <g style="fill: #172033" transform="translate(743.773649 209.625226) scale(0.055 -0.055)">
-     <use xlink:href="#DejaVuSansMono-41"/>
+   <g id="junction:synthetic-three-fragment-target:junction-0002:toehold-bottom:base:3:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(743.106135 397.576683) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0002:toehold-bottom:base:4:G">
-    <!-- G -->
-    <g style="fill: #172033" transform="translate(755.542473 209.625226) scale(0.055 -0.055)">
-     <use xlink:href="#DejaVuSansMono-47"/>
+   <g id="junction:synthetic-three-fragment-target:junction-0002:toehold-bottom:base:4:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(754.583449 397.576683) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
    <g id="junction:synthetic-three-fragment-target:junction-0002:toehold-bottom:base:5:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(767.311296 209.625226) scale(0.055 -0.055)">
+    <g style="fill: #172033" transform="translate(766.060763 397.576683) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0002:toehold-bottom:base:6:C">
+   <g id="junction:synthetic-three-fragment-target:junction-0002:toehold-bottom:base:6:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(777.538078 397.576683) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-41"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0002:toehold-bottom:base:7:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(789.015392 397.576683) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-41"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0002:toehold-bottom:base:8:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(800.492706 397.576683) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-41"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0002:toehold-bottom:base:9:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(779.08012 209.625226) scale(0.055 -0.055)">
+    <g style="fill: #172033" transform="translate(811.97002 397.576683) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0002:toehold-bottom:base:7:T">
+   <g id="junction:synthetic-three-fragment-target:junction-0002:right-bottom:base:0:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(790.848943 209.625226) scale(0.055 -0.055)">
+    <g style="fill: #172033" transform="translate(823.447335 397.576683) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0002:toehold-bottom:base:8:T">
+   <g id="junction:synthetic-three-fragment-target:junction-0002:right-bottom:base:1:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(802.617767 209.625226) scale(0.055 -0.055)">
+    <g style="fill: #172033" transform="translate(834.924649 397.576683) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0002:toehold-bottom:base:9:T">
-    <!-- T -->
-    <g style="fill: #172033" transform="translate(814.386591 209.625226) scale(0.055 -0.055)">
-     <use xlink:href="#DejaVuSansMono-54"/>
-    </g>
-   </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0002:right-bottom:base:0:G">
-    <!-- G -->
-    <g style="fill: #172033" transform="translate(847.077767 209.625226) scale(0.055 -0.055)">
-     <use xlink:href="#DejaVuSansMono-47"/>
-    </g>
-   </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0002:right-bottom:base:1:C">
-    <!-- C -->
-    <g style="fill: #172033" transform="translate(858.846591 209.625226) scale(0.055 -0.055)">
-     <use xlink:href="#DejaVuSansMono-43"/>
-    </g>
-   </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0002:right-bottom:base:2:G">
-    <!-- G -->
-    <g style="fill: #172033" transform="translate(870.615414 209.625226) scale(0.055 -0.055)">
-     <use xlink:href="#DejaVuSansMono-47"/>
+   <g id="junction:synthetic-three-fragment-target:junction-0002:right-bottom:base:2:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(846.401963 397.576683) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
    <g id="junction:synthetic-three-fragment-target:junction-0002:right-bottom:base:3:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(882.384238 209.625226) scale(0.055 -0.055)">
+    <g style="fill: #172033" transform="translate(857.879278 397.576683) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
    <g id="junction:synthetic-three-fragment-target:junction-0002:right-bottom:base:4:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(894.153061 209.625226) scale(0.055 -0.055)">
+    <g style="fill: #172033" transform="translate(869.356592 397.576683) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
    <g id="junction:synthetic-three-fragment-target:junction-0002:right-bottom:base:5:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(905.921885 209.625226) scale(0.055 -0.055)">
+    <g style="fill: #172033" transform="translate(880.833906 397.576683) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b:base:0:C">
+   <g id="junction:synthetic-three-fragment-target:junction-0002:right-bottom:base:6:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(820.331205 147.948025) scale(0.053 -0.053)">
+    <g style="fill: #172033" transform="translate(892.31122 397.576683) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b:base:1:C">
+   <g id="junction:synthetic-three-fragment-target:junction-0002:right-bottom:base:7:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(820.331205 144.17682) scale(0.053 -0.053)">
+    <g style="fill: #172033" transform="translate(903.788535 397.576683) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b:base:2:G">
-    <!-- G -->
-    <g style="fill: #172033" transform="translate(820.331205 140.405616) scale(0.053 -0.053)">
-     <use xlink:href="#DejaVuSansMono-47"/>
-    </g>
-   </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b:base:3:G">
-    <!-- G -->
-    <g style="fill: #172033" transform="translate(820.331205 136.634411) scale(0.053 -0.053)">
-     <use xlink:href="#DejaVuSansMono-47"/>
-    </g>
-   </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b:base:4:C">
+   <g id="junction:synthetic-three-fragment-target:junction-0002:right-bottom:base:8:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(820.331205 132.863206) scale(0.053 -0.053)">
+    <g style="fill: #172033" transform="translate(915.265849 397.576683) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b:base:5:G">
+   <g id="junction:synthetic-three-fragment-target:junction-0002:right-bottom:base:9:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(926.743163 397.576683) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-43"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0002:right-bottom:base:10:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(938.220478 397.576683) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-54"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0002:right-bottom:base:11:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(820.331205 129.092002) scale(0.053 -0.053)">
+    <g style="fill: #172033" transform="translate(949.697792 397.576683) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-47"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0002:right-bottom:base:12:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(961.175106 397.576683) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-43"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0002:right-bottom:base:13:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(972.65242 397.576683) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-47"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0002:right-bottom:base:14:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(984.129735 397.576683) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-47"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0002:right-bottom:base:15:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(995.607049 397.576683) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-41"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b:base:0:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(809.445011 350.519695) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-54"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b:base:1:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(809.445011 339.042381) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-41"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b:base:2:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(809.445011 327.565066) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-43"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b:base:3:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(809.445011 316.087752) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-41"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b:base:4:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(809.445011 304.610438) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-41"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b:base:5:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(809.445011 293.133123) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
    <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b:base:6:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(820.331205 125.320797) scale(0.053 -0.053)">
+    <g style="fill: #172033" transform="translate(809.445011 281.655809) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b:base:7:A">
-    <!-- A -->
-    <g style="fill: #172033" transform="translate(820.331205 121.549593) scale(0.053 -0.053)">
-     <use xlink:href="#DejaVuSansMono-41"/>
-    </g>
-   </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b:base:8:T">
+   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b:base:7:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(820.331205 117.778388) scale(0.053 -0.053)">
+    <g style="fill: #172033" transform="translate(809.445011 270.178495) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b:base:9:A">
+   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b:base:8:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(820.331205 114.007184) scale(0.053 -0.053)">
+    <g style="fill: #172033" transform="translate(809.445011 258.701181) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b:base:10:G">
-    <!-- G -->
-    <g style="fill: #172033" transform="translate(820.331205 110.235979) scale(0.053 -0.053)">
-     <use xlink:href="#DejaVuSansMono-47"/>
+   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b:base:9:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(809.445011 247.223866) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-43"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b:base:10:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(809.445011 235.746552) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
    <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b:base:11:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(820.331205 106.464775) scale(0.053 -0.053)">
+    <g style="fill: #172033" transform="translate(809.445011 224.269238) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b:base:12:T">
-    <!-- T -->
-    <g style="fill: #172033" transform="translate(820.331205 102.69357) scale(0.053 -0.053)">
-     <use xlink:href="#DejaVuSansMono-54"/>
+   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b:base:12:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(809.445011 212.791923) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
    <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b:base:13:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(820.331205 98.922366) scale(0.053 -0.053)">
+    <g style="fill: #172033" transform="translate(809.445011 201.314609) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b:base:14:G">
-    <!-- G -->
-    <g style="fill: #172033" transform="translate(820.331205 95.151161) scale(0.053 -0.053)">
-     <use xlink:href="#DejaVuSansMono-47"/>
-    </g>
-   </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b:base:15:C">
-    <!-- C -->
-    <g style="fill: #172033" transform="translate(820.331205 91.379956) scale(0.053 -0.053)">
-     <use xlink:href="#DejaVuSansMono-43"/>
-    </g>
-   </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b:base:16:G">
-    <!-- G -->
-    <g style="fill: #172033" transform="translate(820.331205 87.608752) scale(0.053 -0.053)">
-     <use xlink:href="#DejaVuSansMono-47"/>
-    </g>
-   </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b:base:17:C">
-    <!-- C -->
-    <g style="fill: #172033" transform="translate(820.331205 83.837547) scale(0.053 -0.053)">
-     <use xlink:href="#DejaVuSansMono-43"/>
-    </g>
-   </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b:base:18:T">
-    <!-- T -->
-    <g style="fill: #172033" transform="translate(820.331205 80.066343) scale(0.053 -0.053)">
-     <use xlink:href="#DejaVuSansMono-54"/>
-    </g>
-   </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b:base:19:T">
-    <!-- T -->
-    <g style="fill: #172033" transform="translate(820.331205 76.295138) scale(0.053 -0.053)">
-     <use xlink:href="#DejaVuSansMono-54"/>
-    </g>
-   </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b:base:20:A">
+   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b:base:14:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(820.331205 72.523934) scale(0.053 -0.053)">
+    <g style="fill: #172033" transform="translate(809.445011 189.837295) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b:base:21:T">
-    <!-- T -->
-    <g style="fill: #172033" transform="translate(820.331205 68.752729) scale(0.053 -0.053)">
-     <use xlink:href="#DejaVuSansMono-54"/>
-    </g>
-   </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b-star:base:0:A">
-    <!-- A -->
-    <g style="fill: #172033" transform="translate(841.253558 68.752729) scale(0.053 -0.053)">
-     <use xlink:href="#DejaVuSansMono-41"/>
-    </g>
-   </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b-star:base:1:T">
-    <!-- T -->
-    <g style="fill: #172033" transform="translate(841.253558 72.523934) scale(0.053 -0.053)">
-     <use xlink:href="#DejaVuSansMono-54"/>
-    </g>
-   </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b-star:base:2:A">
-    <!-- A -->
-    <g style="fill: #172033" transform="translate(841.253558 76.295138) scale(0.053 -0.053)">
-     <use xlink:href="#DejaVuSansMono-41"/>
-    </g>
-   </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b-star:base:3:A">
-    <!-- A -->
-    <g style="fill: #172033" transform="translate(841.253558 80.066343) scale(0.053 -0.053)">
-     <use xlink:href="#DejaVuSansMono-41"/>
-    </g>
-   </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b-star:base:4:G">
+   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b:base:15:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(841.253558 83.837547) scale(0.053 -0.053)">
+    <g style="fill: #172033" transform="translate(809.445011 178.359981) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b-star:base:5:C">
+   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b:base:16:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(841.253558 87.608752) scale(0.053 -0.053)">
+    <g style="fill: #172033" transform="translate(809.445011 166.882666) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-43"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b-star:base:6:G">
+   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b:base:17:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(809.445011 155.405352) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-41"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b:base:18:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(809.445011 143.928038) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-43"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b:base:19:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(809.445011 132.450723) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-43"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b:base:20:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(841.253558 91.379956) scale(0.053 -0.053)">
+    <g style="fill: #172033" transform="translate(809.445011 120.973409) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b-star:base:7:C">
+   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b:base:21:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(809.445011 109.496095) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-47"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b-star:base:0:C">
     <!-- C -->
-    <g style="fill: #172033" transform="translate(841.253558 95.151161) scale(0.053 -0.053)">
+    <g style="fill: #172033" transform="translate(825.972344 109.496095) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-43"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b-star:base:1:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(825.972344 120.973409) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-43"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b-star:base:2:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(825.972344 132.450723) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-47"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b-star:base:3:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(825.972344 143.928038) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-47"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b-star:base:4:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(825.972344 155.405352) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-54"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b-star:base:5:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(825.972344 166.882666) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-47"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b-star:base:6:C">
+    <!-- C -->
+    <g style="fill: #172033" transform="translate(825.972344 178.359981) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-43"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b-star:base:7:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(825.972344 189.837295) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
    <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b-star:base:8:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(841.253558 98.922366) scale(0.053 -0.053)">
+    <g style="fill: #172033" transform="translate(825.972344 201.314609) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b-star:base:9:A">
-    <!-- A -->
-    <g style="fill: #172033" transform="translate(841.253558 102.69357) scale(0.053 -0.053)">
-     <use xlink:href="#DejaVuSansMono-41"/>
+   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b-star:base:9:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(825.972344 212.791923) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
    <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b-star:base:10:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(841.253558 106.464775) scale(0.053 -0.053)">
+    <g style="fill: #172033" transform="translate(825.972344 224.269238) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b-star:base:11:C">
-    <!-- C -->
-    <g style="fill: #172033" transform="translate(841.253558 110.235979) scale(0.053 -0.053)">
-     <use xlink:href="#DejaVuSansMono-43"/>
+   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b-star:base:11:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(825.972344 235.746552) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b-star:base:12:T">
+   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b-star:base:12:G">
+    <!-- G -->
+    <g style="fill: #172033" transform="translate(825.972344 247.223866) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-47"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b-star:base:13:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(841.253558 114.007184) scale(0.053 -0.053)">
+    <g style="fill: #172033" transform="translate(825.972344 258.701181) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b-star:base:13:A">
+   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b-star:base:14:A">
     <!-- A -->
-    <g style="fill: #172033" transform="translate(841.253558 117.778388) scale(0.053 -0.053)">
+    <g style="fill: #172033" transform="translate(825.972344 270.178495) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-41"/>
-    </g>
-   </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b-star:base:14:T">
-    <!-- T -->
-    <g style="fill: #172033" transform="translate(841.253558 121.549593) scale(0.053 -0.053)">
-     <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
    <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b-star:base:15:T">
     <!-- T -->
-    <g style="fill: #172033" transform="translate(841.253558 125.320797) scale(0.053 -0.053)">
+    <g style="fill: #172033" transform="translate(825.972344 281.655809) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b-star:base:16:C">
-    <!-- C -->
-    <g style="fill: #172033" transform="translate(841.253558 129.092002) scale(0.053 -0.053)">
-     <use xlink:href="#DejaVuSansMono-43"/>
+   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b-star:base:16:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(825.972344 293.133123) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b-star:base:17:G">
+   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b-star:base:17:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(825.972344 304.610438) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-54"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b-star:base:18:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(825.972344 316.087752) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-54"/>
+    </g>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b-star:base:19:G">
     <!-- G -->
-    <g style="fill: #172033" transform="translate(841.253558 132.863206) scale(0.053 -0.053)">
+    <g style="fill: #172033" transform="translate(825.972344 327.565066) scale(0.081818 -0.081818)">
      <use xlink:href="#DejaVuSansMono-47"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b-star:base:18:C">
-    <!-- C -->
-    <g style="fill: #172033" transform="translate(841.253558 136.634411) scale(0.053 -0.053)">
-     <use xlink:href="#DejaVuSansMono-43"/>
+   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b-star:base:20:T">
+    <!-- T -->
+    <g style="fill: #172033" transform="translate(825.972344 339.042381) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-54"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b-star:base:19:C">
-    <!-- C -->
-    <g style="fill: #172033" transform="translate(841.253558 140.405616) scale(0.053 -0.053)">
-     <use xlink:href="#DejaVuSansMono-43"/>
+   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b-star:base:21:A">
+    <!-- A -->
+    <g style="fill: #172033" transform="translate(825.972344 350.519695) scale(0.081818 -0.081818)">
+     <use xlink:href="#DejaVuSansMono-41"/>
     </g>
    </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b-star:base:20:G">
-    <!-- G -->
-    <g style="fill: #172033" transform="translate(841.253558 144.17682) scale(0.053 -0.053)">
-     <use xlink:href="#DejaVuSansMono-47"/>
-    </g>
-   </g>
-   <g id="junction:synthetic-three-fragment-target:junction-0002:barcode-b-star:base:21:G">
-    <!-- G -->
-    <g style="fill: #172033" transform="translate(841.253558 147.948025) scale(0.053 -0.053)">
-     <use xlink:href="#DejaVuSansMono-47"/>
-    </g>
-   </g>
-   <g id="text_13">
+   <g id="text_10">
     <!-- nick -->
-    <g style="fill: #667085" transform="translate(698.933134 235.274768) scale(0.052 -0.052)">
+    <g style="fill: #667085" transform="translate(698.256749 412.093501) scale(0.07 -0.07)">
      <use xlink:href="#DejaVuSans-6e"/>
      <use xlink:href="#DejaVuSans-69" transform="translate(63.378906 0)"/>
      <use xlink:href="#DejaVuSans-63" transform="translate(91.162109 0)"/>
      <use xlink:href="#DejaVuSans-6b" transform="translate(146.142578 0)"/>
     </g>
    </g>
-   <g id="text_14">
+   <g id="text_11">
     <!-- t2 -->
-    <g style="fill: #2a9d8f" transform="translate(760.254697 146.69775) scale(0.055 -0.055)">
+    <g style="fill: #8a5a00" transform="translate(754.797073 353.978949) scale(0.075 -0.075)">
+     <defs>
+      <path id="DejaVuSans-32" d="M 1228 531
+L 3431 531
+L 3431 0
+L 469 0
+L 469 531
+Q 828 903 1448 1529
+Q 2069 2156 2228 2338
+Q 2531 2678 2651 2914
+Q 2772 3150 2772 3378
+Q 2772 3750 2511 3984
+Q 2250 4219 1831 4219
+Q 1534 4219 1204 4116
+Q 875 4013 500 3803
+L 500 4441
+Q 881 4594 1212 4672
+Q 1544 4750 1819 4750
+Q 2544 4750 2975 4387
+Q 3406 4025 3406 3419
+Q 3406 3131 3298 2873
+Q 3191 2616 2906 2266
+Q 2828 2175 2409 1742
+Q 1991 1309 1228 531
+z
+" transform="scale(0.015625)"/>
+     </defs>
      <use xlink:href="#DejaVuSans-74"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(39.208984 0)"/>
     </g>
    </g>
-   <g id="text_15">
+   <g id="text_12">
     <!-- t2* -->
-    <g style="fill: #2a9d8f" transform="translate(758.879697 227.206071) scale(0.055 -0.055)">
+    <g style="fill: #8a5a00" transform="translate(757.053907 411.325691) scale(0.075 -0.075)">
      <use xlink:href="#DejaVuSans-74"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(39.208984 0)"/>
      <use xlink:href="#DejaVuSans-2a" transform="translate(102.832031 0)"/>
     </g>
    </g>
-   <g id="text_16">
+   <g id="text_13">
     <!-- b2 -->
-    <g style="fill: #2a9d8f" transform="translate(801.859102 77.00589) scale(0.055 -0.055)">
+    <g style="fill: #1f6f70" transform="translate(790.897349 103.773497) scale(0.075 -0.075)">
      <use xlink:href="#DejaVuSans-62"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.476562 0)"/>
     </g>
    </g>
-   <g id="text_17">
+   <g id="text_14">
     <!-- b2* -->
-    <g style="fill: #2a9d8f" transform="translate(855.925412 77.00589) scale(0.055 -0.055)">
+    <g style="fill: #1f6f70" transform="translate(839.912513 103.773497) scale(0.075 -0.075)">
      <use xlink:href="#DejaVuSans-62"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.476562 0)"/>
      <use xlink:href="#DejaVuSans-2a" transform="translate(127.099609 0)"/>
     </g>
    </g>
-   <g id="text_18">
+   <g id="text_15">
     <!-- 3′ -->
-    <g style="fill: #667085" transform="translate(819.638893 59.310356) scale(0.053 -0.053)">
+    <g style="fill: #667085" transform="translate(808.670562 90.736417) scale(0.075 -0.075)">
      <use xlink:href="#DejaVuSans-33"/>
      <use xlink:href="#DejaVuSans-2032" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_19">
+   <g id="text_16">
     <!-- 5′ -->
-    <g style="fill: #667085" transform="translate(840.561246 59.310356) scale(0.053 -0.053)">
+    <g style="fill: #667085" transform="translate(825.197894 90.736417) scale(0.075 -0.075)">
      <use xlink:href="#DejaVuSans-35"/>
      <use xlink:href="#DejaVuSans-2032" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_20">
-    <!-- synthetic-three-fragment-target:junction-0002 -->
-    <g style="fill: #667085" transform="translate(570.858353 329.843536) scale(0.05 -0.05)">
-     <use xlink:href="#DejaVuSans-73"/>
-     <use xlink:href="#DejaVuSans-79" transform="translate(52.099609 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(111.279297 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(174.658203 0)"/>
-     <use xlink:href="#DejaVuSans-68" transform="translate(213.867188 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(277.246094 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(338.769531 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(377.978516 0)"/>
-     <use xlink:href="#DejaVuSans-63" transform="translate(405.761719 0)"/>
-     <use xlink:href="#DejaVuSans-2d" transform="translate(460.742188 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(496.826172 0)"/>
-     <use xlink:href="#DejaVuSans-68" transform="translate(536.035156 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(599.414062 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(638.277344 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(699.800781 0)"/>
-     <use xlink:href="#DejaVuSans-2d" transform="translate(761.324219 0)"/>
-     <use xlink:href="#DejaVuSans-66" transform="translate(797.408203 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(832.613281 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(873.726562 0)"/>
-     <use xlink:href="#DejaVuSans-67" transform="translate(935.005859 0)"/>
-     <use xlink:href="#DejaVuSans-6d" transform="translate(998.482422 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(1095.894531 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(1157.417969 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(1220.796875 0)"/>
-     <use xlink:href="#DejaVuSans-2d" transform="translate(1260.005859 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(1296.089844 0)"/>
-     <use xlink:href="#DejaVuSans-61" transform="translate(1335.298828 0)"/>
-     <use xlink:href="#DejaVuSans-72" transform="translate(1396.578125 0)"/>
-     <use xlink:href="#DejaVuSans-67" transform="translate(1435.941406 0)"/>
-     <use xlink:href="#DejaVuSans-65" transform="translate(1499.417969 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(1560.941406 0)"/>
-     <use xlink:href="#DejaVuSans-3a" transform="translate(1600.150391 0)"/>
-     <use xlink:href="#DejaVuSans-6a" transform="translate(1633.841797 0)"/>
-     <use xlink:href="#DejaVuSans-75" transform="translate(1661.625 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(1725.003906 0)"/>
-     <use xlink:href="#DejaVuSans-63" transform="translate(1788.382812 0)"/>
-     <use xlink:href="#DejaVuSans-74" transform="translate(1843.363281 0)"/>
-     <use xlink:href="#DejaVuSans-69" transform="translate(1882.572266 0)"/>
-     <use xlink:href="#DejaVuSans-6f" transform="translate(1910.355469 0)"/>
-     <use xlink:href="#DejaVuSans-6e" transform="translate(1971.537109 0)"/>
-     <use xlink:href="#DejaVuSans-2d" transform="translate(2034.916016 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(2071 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(2134.623047 0)"/>
-     <use xlink:href="#DejaVuSans-30" transform="translate(2198.246094 0)"/>
-     <use xlink:href="#DejaVuSans-32" transform="translate(2261.869141 0)"/>
-    </g>
-   </g>
-   <g id="line2d_9">
-    <path d="M 628.133294 169.098705
-L 632.840824 154.164735
-" clip-path="url(#p51da927130)" style="fill: none; stroke: #ffffff; stroke-width: 3.2; stroke-linecap: square"/>
-   </g>
    <g id="line2d_10">
-    <path d="M 634.41 169.098705
-L 639.117529 154.164735
-" clip-path="url(#p51da927130)" style="fill: none; stroke: #ffffff; stroke-width: 3.2; stroke-linecap: square"/>
+    <path d="M 702.873381 401.265483
+L 707.923399 389.329077
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #ffffff; stroke-width: 4.2; stroke-linecap: square"/>
    </g>
    <g id="line2d_11">
-    <path d="M 628.133294 215.559945
-L 632.840824 200.625975
-" clip-path="url(#p51da927130)" style="fill: none; stroke: #ffffff; stroke-width: 3.2; stroke-linecap: square"/>
+    <path d="M 632.173125 370.965374
+L 636.304958 359.947152
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #ffffff; stroke-width: 4; stroke-linecap: square"/>
    </g>
    <g id="line2d_12">
-    <path d="M 634.41 215.559945
-L 639.117529 200.625975
-" clip-path="url(#p51da927130)" style="fill: none; stroke: #ffffff; stroke-width: 3.2; stroke-linecap: square"/>
+    <path d="M 636.76405 370.965374
+L 640.895884 359.947152
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #ffffff; stroke-width: 4; stroke-linecap: square"/>
    </g>
    <g id="line2d_13">
-    <path d="M 907.969765 169.098705
-L 912.677294 154.164735
-" clip-path="url(#p51da927130)" style="fill: none; stroke: #ffffff; stroke-width: 3.2; stroke-linecap: square"/>
+    <path d="M 632.173125 400.806391
+L 636.304958 389.788169
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #ffffff; stroke-width: 4; stroke-linecap: square"/>
    </g>
    <g id="line2d_14">
-    <path d="M 914.246471 169.098705
-L 918.954 154.164735
-" clip-path="url(#p51da927130)" style="fill: none; stroke: #ffffff; stroke-width: 3.2; stroke-linecap: square"/>
+    <path d="M 636.76405 400.806391
+L 640.895884 389.788169
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #ffffff; stroke-width: 4; stroke-linecap: square"/>
    </g>
    <g id="line2d_15">
-    <path d="M 907.969765 215.559945
-L 912.677294 200.625975
-" clip-path="url(#p51da927130)" style="fill: none; stroke: #ffffff; stroke-width: 3.2; stroke-linecap: square"/>
+    <path d="M 999.447182 370.965374
+L 1003.579015 359.947152
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #ffffff; stroke-width: 4; stroke-linecap: square"/>
    </g>
    <g id="line2d_16">
-    <path d="M 914.246471 215.559945
-L 918.954 200.625975
-" clip-path="url(#p51da927130)" style="fill: none; stroke: #ffffff; stroke-width: 3.2; stroke-linecap: square"/>
+    <path d="M 1004.038108 370.965374
+L 1008.169941 359.947152
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #ffffff; stroke-width: 4; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_17">
+    <path d="M 999.447182 400.806391
+L 1003.579015 389.788169
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #ffffff; stroke-width: 4; stroke-linecap: square"/>
+   </g>
+   <g id="line2d_18">
+    <path d="M 1004.038108 400.806391
+L 1008.169941 389.788169
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #ffffff; stroke-width: 4; stroke-linecap: square"/>
+   </g>
+   <g id="junction:synthetic-three-fragment-target:junction-0002:nick">
+    <path d="M 702.873381 401.265483
+L 707.923399 389.329077
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #172033; stroke-width: 1.2; stroke-linecap: square"/>
    </g>
    <g id="junction:synthetic-three-fragment-target:junction-0002:left-top-break:0">
-    <path d="M 628.133294 169.098705
-L 632.840824 154.164735
-" clip-path="url(#p51da927130)" style="fill: none; stroke: #172033; stroke-width: 0.9; stroke-linecap: square"/>
+    <path d="M 632.173125 370.965374
+L 636.304958 359.947152
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #172033; stroke-linecap: square"/>
    </g>
    <g id="junction:synthetic-three-fragment-target:junction-0002:left-top-break:1">
-    <path d="M 634.41 169.098705
-L 639.117529 154.164735
-" clip-path="url(#p51da927130)" style="fill: none; stroke: #172033; stroke-width: 0.9; stroke-linecap: square"/>
+    <path d="M 636.76405 370.965374
+L 640.895884 359.947152
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #172033; stroke-linecap: square"/>
    </g>
    <g id="junction:synthetic-three-fragment-target:junction-0002:left-bottom-break:0">
-    <path d="M 628.133294 215.559945
-L 632.840824 200.625975
-" clip-path="url(#p51da927130)" style="fill: none; stroke: #172033; stroke-width: 0.9; stroke-linecap: square"/>
+    <path d="M 632.173125 400.806391
+L 636.304958 389.788169
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #172033; stroke-linecap: square"/>
    </g>
    <g id="junction:synthetic-three-fragment-target:junction-0002:left-bottom-break:1">
-    <path d="M 634.41 215.559945
-L 639.117529 200.625975
-" clip-path="url(#p51da927130)" style="fill: none; stroke: #172033; stroke-width: 0.9; stroke-linecap: square"/>
+    <path d="M 636.76405 400.806391
+L 640.895884 389.788169
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #172033; stroke-linecap: square"/>
    </g>
    <g id="junction:synthetic-three-fragment-target:junction-0002:right-top-break:0">
-    <path d="M 907.969765 169.098705
-L 912.677294 154.164735
-" clip-path="url(#p51da927130)" style="fill: none; stroke: #172033; stroke-width: 0.9; stroke-linecap: square"/>
+    <path d="M 999.447182 370.965374
+L 1003.579015 359.947152
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #172033; stroke-linecap: square"/>
    </g>
    <g id="junction:synthetic-three-fragment-target:junction-0002:right-top-break:1">
-    <path d="M 914.246471 169.098705
-L 918.954 154.164735
-" clip-path="url(#p51da927130)" style="fill: none; stroke: #172033; stroke-width: 0.9; stroke-linecap: square"/>
+    <path d="M 1004.038108 370.965374
+L 1008.169941 359.947152
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #172033; stroke-linecap: square"/>
    </g>
    <g id="junction:synthetic-three-fragment-target:junction-0002:right-bottom-break:0">
-    <path d="M 907.969765 215.559945
-L 912.677294 200.625975
-" clip-path="url(#p51da927130)" style="fill: none; stroke: #172033; stroke-width: 0.9; stroke-linecap: square"/>
+    <path d="M 999.447182 400.806391
+L 1003.579015 389.788169
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #172033; stroke-linecap: square"/>
    </g>
    <g id="junction:synthetic-three-fragment-target:junction-0002:right-bottom-break:1">
-    <path d="M 914.246471 215.559945
-L 918.954 200.625975
-" clip-path="url(#p51da927130)" style="fill: none; stroke: #172033; stroke-width: 0.9; stroke-linecap: square"/>
+    <path d="M 1004.038108 400.806391
+L 1008.169941 389.788169
+" clip-path="url(#p764d4c8958)" style="fill: none; stroke: #172033; stroke-linecap: square"/>
    </g>
   </g>
-  <g id="text_21">
-   <!-- Three-way junction details · synthetic-three-fragment-target -->
-   <g style="fill: #172033" transform="translate(21.888 11.352047) scale(0.125 -0.125)">
+  <g id="text_17">
+   <!-- 2 selected three-way junctions show the expected local annealing geometry -->
+   <g style="fill: #172033" transform="translate(21.888 13.719656) scale(0.15 -0.15)">
     <defs>
-     <path id="DejaVuSans-Bold-54" d="M 31 4666
-L 4331 4666
-L 4331 3756
-L 2784 3756
-L 2784 0
-L 1581 0
-L 1581 3756
-L 31 3756
-L 31 4666
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Bold-68" d="M 4056 2131
-L 4056 0
-L 2931 0
-L 2931 347
-L 2931 1625
-Q 2931 2084 2911 2256
-Q 2891 2428 2841 2509
-Q 2775 2619 2662 2680
-Q 2550 2741 2406 2741
-Q 2056 2741 1856 2470
-Q 1656 2200 1656 1722
+     <path id="DejaVuSans-Bold-6c" d="M 538 4863
+L 1656 4863
 L 1656 0
 L 538 0
 L 538 4863
-L 1656 4863
-L 1656 2988
-Q 1909 3294 2193 3439
-Q 2478 3584 2822 3584
-Q 3428 3584 3742 3212
-Q 4056 2841 4056 2131
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Bold-72" d="M 3138 2547
-Q 2991 2616 2845 2648
-Q 2700 2681 2553 2681
-Q 2122 2681 1889 2404
-Q 1656 2128 1656 1613
-L 1656 0
-L 538 0
-L 538 3500
-L 1656 3500
-L 1656 2925
-Q 1872 3269 2151 3426
-Q 2431 3584 2822 3584
-Q 2878 3584 2943 3579
-Q 3009 3575 3134 3559
-L 3138 2547
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Bold-65" d="M 4031 1759
-L 4031 1441
-L 1416 1441
-Q 1456 1047 1700 850
-Q 1944 653 2381 653
-Q 2734 653 3104 758
-Q 3475 863 3866 1075
-L 3866 213
-Q 3469 63 3072 -14
-Q 2675 -91 2278 -91
-Q 1328 -91 801 392
-Q 275 875 275 1747
-Q 275 2603 792 3093
-Q 1309 3584 2216 3584
-Q 3041 3584 3536 3087
-Q 4031 2591 4031 1759
-z
-M 2881 2131
-Q 2881 2450 2695 2645
-Q 2509 2841 2209 2841
-Q 1884 2841 1681 2658
-Q 1478 2475 1428 2131
-L 2881 2131
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Bold-2d" d="M 347 2297
-L 2309 2297
-L 2309 1388
-L 347 1388
-L 347 2297
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Bold-77" d="M 225 3500
-L 1313 3500
-L 1900 1088
-L 2491 3500
-L 3425 3500
-L 4013 1113
-L 4603 3500
-L 5691 3500
-L 4769 0
-L 3547 0
-L 2956 2406
-L 2369 0
-L 1147 0
-L 225 3500
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Bold-61" d="M 2106 1575
-Q 1756 1575 1579 1456
-Q 1403 1338 1403 1106
-Q 1403 894 1545 773
-Q 1688 653 1941 653
-Q 2256 653 2472 879
-Q 2688 1106 2688 1447
-L 2688 1575
-L 2106 1575
-z
-M 3816 1997
-L 3816 0
-L 2688 0
-L 2688 519
-Q 2463 200 2181 54
-Q 1900 -91 1497 -91
-Q 953 -91 614 226
-Q 275 544 275 1050
-Q 275 1666 698 1953
-Q 1122 2241 2028 2241
-L 2688 2241
-L 2688 2328
-Q 2688 2594 2478 2717
-Q 2269 2841 1825 2841
-Q 1466 2841 1156 2769
-Q 847 2697 581 2553
-L 581 3406
-Q 941 3494 1303 3539
-Q 1666 3584 2028 3584
-Q 2975 3584 3395 3211
-Q 3816 2838 3816 1997
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Bold-79" d="M 78 3500
-L 1197 3500
-L 2138 1125
-L 2938 3500
-L 4056 3500
-L 2584 -331
-Q 2363 -916 2067 -1148
-Q 1772 -1381 1288 -1381
-L 641 -1381
-L 641 -647
-L 991 -647
-Q 1275 -647 1404 -556
-Q 1534 -466 1606 -231
-L 1638 -134
-L 78 3500
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Bold-6a" d="M 538 3500
-L 1656 3500
-L 1656 63
-Q 1656 -641 1318 -1011
-Q 981 -1381 341 -1381
-L -213 -1381
-L -213 -647
-L -19 -647
-Q 300 -647 419 -503
-Q 538 -359 538 63
-L 538 3500
-z
-M 538 4863
-L 1656 4863
-L 1656 3950
-L 538 3950
-L 538 4863
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Bold-75" d="M 500 1363
-L 500 3500
-L 1625 3500
-L 1625 3150
-Q 1625 2866 1622 2436
-Q 1619 2006 1619 1863
-Q 1619 1441 1641 1255
-Q 1663 1069 1716 984
-Q 1784 875 1895 815
-Q 2006 756 2150 756
-Q 2500 756 2700 1025
-Q 2900 1294 2900 1772
-L 2900 3500
-L 4019 3500
-L 4019 0
-L 2900 0
-L 2900 506
-Q 2647 200 2364 54
-Q 2081 -91 1741 -91
-Q 1134 -91 817 281
-Q 500 653 500 1363
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Bold-6e" d="M 4056 2131
-L 4056 0
-L 2931 0
-L 2931 347
-L 2931 1631
-Q 2931 2084 2911 2256
-Q 2891 2428 2841 2509
-Q 2775 2619 2662 2680
-Q 2550 2741 2406 2741
-Q 2056 2741 1856 2470
-Q 1656 2200 1656 1722
-L 1656 0
-L 538 0
-L 538 3500
-L 1656 3500
-L 1656 2988
-Q 1909 3294 2193 3439
-Q 2478 3584 2822 3584
-Q 3428 3584 3742 3212
-Q 4056 2841 4056 2131
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Bold-63" d="M 3366 3391
-L 3366 2478
-Q 3138 2634 2908 2709
-Q 2678 2784 2431 2784
-Q 1963 2784 1702 2511
-Q 1441 2238 1441 1747
-Q 1441 1256 1702 982
-Q 1963 709 2431 709
-Q 2694 709 2930 787
-Q 3166 866 3366 1019
-L 3366 103
-Q 3103 6 2833 -42
-Q 2563 -91 2291 -91
-Q 1344 -91 809 395
-Q 275 881 275 1747
-Q 275 2613 809 3098
-Q 1344 3584 2291 3584
-Q 2566 3584 2833 3536
-Q 3100 3488 3366 3391
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Bold-74" d="M 1759 4494
-L 1759 3500
-L 2913 3500
-L 2913 2700
-L 1759 2700
-L 1759 1216
-Q 1759 972 1856 886
-Q 1953 800 2241 800
-L 2816 800
-L 2816 0
-L 1856 0
-Q 1194 0 917 276
-Q 641 553 641 1216
-L 641 2700
-L 84 2700
-L 84 3500
-L 641 3500
-L 641 4494
-L 1759 4494
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Bold-69" d="M 538 3500
-L 1656 3500
-L 1656 0
-L 538 0
-L 538 3500
-z
-M 538 4863
-L 1656 4863
-L 1656 3950
-L 538 3950
-L 538 4863
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Bold-6f" d="M 2203 2784
-Q 1831 2784 1636 2517
-Q 1441 2250 1441 1747
-Q 1441 1244 1636 976
-Q 1831 709 2203 709
-Q 2569 709 2762 976
-Q 2956 1244 2956 1747
-Q 2956 2250 2762 2517
-Q 2569 2784 2203 2784
-z
-M 2203 3584
-Q 3106 3584 3614 3096
-Q 4122 2609 4122 1747
-Q 4122 884 3614 396
-Q 3106 -91 2203 -91
-Q 1297 -91 786 396
-Q 275 884 275 1747
-Q 275 2609 786 3096
-Q 1297 3584 2203 3584
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-Bold-64" d="M 2919 2988
@@ -3160,97 +3041,74 @@ Q 1447 1247 1636 984
 Q 1825 722 2181 722
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Bold-6c" d="M 538 4863
-L 1656 4863
+     <path id="DejaVuSans-Bold-68" d="M 4056 2131
+L 4056 0
+L 2931 0
+L 2931 347
+L 2931 1625
+Q 2931 2084 2911 2256
+Q 2891 2428 2841 2509
+Q 2775 2619 2662 2680
+Q 2550 2741 2406 2741
+Q 2056 2741 1856 2470
+Q 1656 2200 1656 1722
 L 1656 0
 L 538 0
 L 538 4863
+L 1656 4863
+L 1656 2988
+Q 1909 3294 2193 3439
+Q 2478 3584 2822 3584
+Q 3428 3584 3742 3212
+Q 4056 2841 4056 2131
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Bold-73" d="M 3272 3391
-L 3272 2541
-Q 2913 2691 2578 2766
-Q 2244 2841 1947 2841
-Q 1628 2841 1473 2761
-Q 1319 2681 1319 2516
-Q 1319 2381 1436 2309
-Q 1553 2238 1856 2203
-L 2053 2175
-Q 2913 2066 3209 1816
-Q 3506 1566 3506 1031
-Q 3506 472 3093 190
-Q 2681 -91 1863 -91
-Q 1516 -91 1145 -36
-Q 775 19 384 128
-L 384 978
-Q 719 816 1070 734
-Q 1422 653 1784 653
-Q 2113 653 2278 743
-Q 2444 834 2444 1013
-Q 2444 1163 2330 1236
-Q 2216 1309 1875 1350
-L 1678 1375
-Q 931 1469 631 1722
-Q 331 1975 331 2491
-Q 331 3047 712 3315
-Q 1094 3584 1881 3584
-Q 2191 3584 2531 3537
-Q 2872 3491 3272 3391
+     <path id="DejaVuSans-Bold-77" d="M 225 3500
+L 1313 3500
+L 1900 1088
+L 2491 3500
+L 3425 3500
+L 4013 1113
+L 4603 3500
+L 5691 3500
+L 4769 0
+L 3547 0
+L 2956 2406
+L 2369 0
+L 1147 0
+L 225 3500
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Bold-66" d="M 2841 4863
-L 2841 4128
-L 2222 4128
-Q 1984 4128 1890 4042
-Q 1797 3956 1797 3744
-L 1797 3500
-L 2753 3500
-L 2753 2700
-L 1797 2700
-L 1797 0
-L 678 0
-L 678 2700
-L 122 2700
-L 122 3500
-L 678 3500
-L 678 3744
-Q 678 4316 997 4589
-Q 1316 4863 1984 4863
-L 2841 4863
+     <path id="DejaVuSans-Bold-79" d="M 78 3500
+L 1197 3500
+L 2138 1125
+L 2938 3500
+L 4056 3500
+L 2584 -331
+Q 2363 -916 2067 -1148
+Q 1772 -1381 1288 -1381
+L 641 -1381
+L 641 -647
+L 991 -647
+Q 1275 -647 1404 -556
+Q 1534 -466 1606 -231
+L 1638 -134
+L 78 3500
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-Bold-67" d="M 2919 594
-Q 2688 288 2409 144
-Q 2131 0 1766 0
-Q 1125 0 706 504
-Q 288 1009 288 1791
-Q 288 2575 706 3076
-Q 1125 3578 1766 3578
-Q 2131 3578 2409 3434
-Q 2688 3291 2919 2981
-L 2919 3500
-L 4044 3500
-L 4044 353
-Q 4044 -491 3511 -936
-Q 2978 -1381 1966 -1381
-Q 1638 -1381 1331 -1331
-Q 1025 -1281 716 -1178
-L 716 -306
-Q 1009 -475 1290 -558
-Q 1572 -641 1856 -641
-Q 2406 -641 2662 -400
-Q 2919 -159 2919 353
-L 2919 594
-z
-M 2181 2772
-Q 1834 2772 1640 2515
-Q 1447 2259 1447 1791
-Q 1447 1309 1634 1061
-Q 1822 813 2181 813
-Q 2531 813 2725 1069
-Q 2919 1325 2919 1791
-Q 2919 2259 2725 2515
-Q 2531 2772 2181 2772
+     <path id="DejaVuSans-Bold-78" d="M 1422 1791
+L 159 3500
+L 1344 3500
+L 2059 2463
+L 2784 3500
+L 3969 3500
+L 2706 1797
+L 4031 0
+L 2847 0
+L 2059 1106
+L 1281 0
+L 97 0
+L 1422 1791
 z
 " transform="scale(0.015625)"/>
      <path id="DejaVuSans-Bold-6d" d="M 3781 2919
@@ -3286,71 +3144,668 @@ Q 3638 3234 3781 2919
 z
 " transform="scale(0.015625)"/>
     </defs>
-    <use xlink:href="#DejaVuSans-Bold-54"/>
-    <use xlink:href="#DejaVuSans-Bold-68" transform="translate(68.212891 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-72" transform="translate(139.404297 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(188.720703 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(256.542969 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-2d" transform="translate(324.365234 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-77" transform="translate(365.869141 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-61" transform="translate(458.251953 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-79" transform="translate(522.607422 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(587.792969 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-6a" transform="translate(622.607422 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-75" transform="translate(656.884766 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(728.076172 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-63" transform="translate(799.267578 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-74" transform="translate(858.544922 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-69" transform="translate(906.347656 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-6f" transform="translate(940.625 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(1009.326172 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(1080.517578 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-64" transform="translate(1115.332031 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(1186.914062 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-74" transform="translate(1254.736328 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-61" transform="translate(1302.539062 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-69" transform="translate(1370.019531 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-6c" transform="translate(1404.296875 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-73" transform="translate(1438.574219 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(1498.095703 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-b7" transform="translate(1532.910156 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(1570.898438 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-73" transform="translate(1605.712891 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-79" transform="translate(1665.234375 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(1730.419922 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-74" transform="translate(1801.611328 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-68" transform="translate(1849.414062 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(1920.605469 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-74" transform="translate(1988.427734 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-69" transform="translate(2036.230469 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-63" transform="translate(2070.507812 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-2d" transform="translate(2129.785156 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-74" transform="translate(2171.289062 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-68" transform="translate(2219.091797 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-72" transform="translate(2290.283203 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(2339.599609 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(2407.421875 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-2d" transform="translate(2475.244141 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-66" transform="translate(2516.748047 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-72" transform="translate(2560.253906 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-61" transform="translate(2609.570312 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-67" transform="translate(2677.050781 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-6d" transform="translate(2748.632812 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(2852.832031 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(2920.654297 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-74" transform="translate(2991.845703 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-2d" transform="translate(3039.648438 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-74" transform="translate(3081.152344 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-61" transform="translate(3128.955078 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-72" transform="translate(3196.435547 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-67" transform="translate(3245.751953 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(3317.333984 0)"/>
-    <use xlink:href="#DejaVuSans-Bold-74" transform="translate(3385.15625 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-32"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(69.580078 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-73" transform="translate(104.394531 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(163.916016 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6c" transform="translate(231.738281 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(266.015625 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-63" transform="translate(333.837891 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-74" transform="translate(393.115234 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(440.917969 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-64" transform="translate(508.740234 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(580.322266 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-74" transform="translate(615.136719 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-68" transform="translate(662.939453 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-72" transform="translate(734.130859 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(783.447266 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(851.269531 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-2d" transform="translate(919.091797 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-77" transform="translate(960.595703 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-61" transform="translate(1052.978516 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-79" transform="translate(1117.333984 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(1182.519531 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6a" transform="translate(1217.333984 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-75" transform="translate(1251.611328 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(1322.802734 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-63" transform="translate(1393.994141 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-74" transform="translate(1453.271484 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-69" transform="translate(1501.074219 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6f" transform="translate(1535.351562 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(1604.052734 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-73" transform="translate(1675.244141 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(1734.765625 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-73" transform="translate(1769.580078 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-68" transform="translate(1829.101562 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6f" transform="translate(1900.292969 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-77" transform="translate(1968.994141 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(2061.376953 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-74" transform="translate(2096.191406 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-68" transform="translate(2143.994141 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(2215.185547 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(2283.007812 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(2317.822266 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-78" transform="translate(2385.644531 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-70" transform="translate(2450.146484 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(2521.728516 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-63" transform="translate(2589.550781 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-74" transform="translate(2648.828125 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(2696.630859 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-64" transform="translate(2764.453125 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(2836.035156 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6c" transform="translate(2870.849609 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6f" transform="translate(2905.126953 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-63" transform="translate(2973.828125 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-61" transform="translate(3033.105469 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6c" transform="translate(3100.585938 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(3134.863281 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-61" transform="translate(3169.677734 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(3237.158203 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(3308.349609 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(3379.541016 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-61" transform="translate(3447.363281 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6c" transform="translate(3514.84375 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-69" transform="translate(3549.121094 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6e" transform="translate(3583.398438 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-67" transform="translate(3654.589844 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-20" transform="translate(3726.171875 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-67" transform="translate(3760.986328 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(3832.568359 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6f" transform="translate(3900.390625 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-6d" transform="translate(3969.091797 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-65" transform="translate(4073.291016 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-74" transform="translate(4141.113281 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-72" transform="translate(4188.916016 0)"/>
+    <use xlink:href="#DejaVuSans-Bold-79" transform="translate(4238.232422 0)"/>
    </g>
   </g>
-  <g id="text_22">
-   <!-- Exact local sequence mapping; topology is schematic, not a structure, ligation, or yield prediction. -->
-   <g style="fill: #667085" transform="translate(21.888 365.102588) scale(0.06 -0.06)">
+  <g id="text_18">
+   <!-- The 200 bp target uses 10 nt toeholds and 22 nt barcodes; fragment oligos span 60–104 nt with median 80 nt -->
+   <g style="fill: #667085" transform="translate(21.888 30.058594) scale(0.09 -0.09)">
+    <defs>
+     <path id="DejaVuSans-54" d="M -19 4666
+L 3928 4666
+L 3928 4134
+L 2272 4134
+L 2272 0
+L 1638 0
+L 1638 4134
+L -19 4134
+L -19 4666
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-68" d="M 3513 2113
+L 3513 0
+L 2938 0
+L 2938 2094
+Q 2938 2591 2744 2837
+Q 2550 3084 2163 3084
+Q 1697 3084 1428 2787
+Q 1159 2491 1159 1978
+L 1159 0
+L 581 0
+L 581 4863
+L 1159 4863
+L 1159 2956
+Q 1366 3272 1645 3428
+Q 1925 3584 2291 3584
+Q 2894 3584 3203 3211
+Q 3513 2838 3513 2113
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-65" d="M 3597 1894
+L 3597 1613
+L 953 1613
+Q 991 1019 1311 708
+Q 1631 397 2203 397
+Q 2534 397 2845 478
+Q 3156 559 3463 722
+L 3463 178
+Q 3153 47 2828 -22
+Q 2503 -91 2169 -91
+Q 1331 -91 842 396
+Q 353 884 353 1716
+Q 353 2575 817 3079
+Q 1281 3584 2069 3584
+Q 2775 3584 3186 3129
+Q 3597 2675 3597 1894
+z
+M 3022 2063
+Q 3016 2534 2758 2815
+Q 2500 3097 2075 3097
+Q 1594 3097 1305 2825
+Q 1016 2553 972 2059
+L 3022 2063
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-20" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-30" d="M 2034 4250
+Q 1547 4250 1301 3770
+Q 1056 3291 1056 2328
+Q 1056 1369 1301 889
+Q 1547 409 2034 409
+Q 2525 409 2770 889
+Q 3016 1369 3016 2328
+Q 3016 3291 2770 3770
+Q 2525 4250 2034 4250
+z
+M 2034 4750
+Q 2819 4750 3233 4129
+Q 3647 3509 3647 2328
+Q 3647 1150 3233 529
+Q 2819 -91 2034 -91
+Q 1250 -91 836 529
+Q 422 1150 422 2328
+Q 422 3509 836 4129
+Q 1250 4750 2034 4750
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-70" d="M 1159 525
+L 1159 -1331
+L 581 -1331
+L 581 3500
+L 1159 3500
+L 1159 2969
+Q 1341 3281 1617 3432
+Q 1894 3584 2278 3584
+Q 2916 3584 3314 3078
+Q 3713 2572 3713 1747
+Q 3713 922 3314 415
+Q 2916 -91 2278 -91
+Q 1894 -91 1617 61
+Q 1341 213 1159 525
+z
+M 3116 1747
+Q 3116 2381 2855 2742
+Q 2594 3103 2138 3103
+Q 1681 3103 1420 2742
+Q 1159 2381 1159 1747
+Q 1159 1113 1420 752
+Q 1681 391 2138 391
+Q 2594 391 2855 752
+Q 3116 1113 3116 1747
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-61" d="M 2194 1759
+Q 1497 1759 1228 1600
+Q 959 1441 959 1056
+Q 959 750 1161 570
+Q 1363 391 1709 391
+Q 2188 391 2477 730
+Q 2766 1069 2766 1631
+L 2766 1759
+L 2194 1759
+z
+M 3341 1997
+L 3341 0
+L 2766 0
+L 2766 531
+Q 2569 213 2275 61
+Q 1981 -91 1556 -91
+Q 1019 -91 701 211
+Q 384 513 384 1019
+Q 384 1609 779 1909
+Q 1175 2209 1959 2209
+L 2766 2209
+L 2766 2266
+Q 2766 2663 2505 2880
+Q 2244 3097 1772 3097
+Q 1472 3097 1187 3025
+Q 903 2953 641 2809
+L 641 3341
+Q 956 3463 1253 3523
+Q 1550 3584 1831 3584
+Q 2591 3584 2966 3190
+Q 3341 2797 3341 1997
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-72" d="M 2631 2963
+Q 2534 3019 2420 3045
+Q 2306 3072 2169 3072
+Q 1681 3072 1420 2755
+Q 1159 2438 1159 1844
+L 1159 0
+L 581 0
+L 581 3500
+L 1159 3500
+L 1159 2956
+Q 1341 3275 1631 3429
+Q 1922 3584 2338 3584
+Q 2397 3584 2469 3576
+Q 2541 3569 2628 3553
+L 2631 2963
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-67" d="M 2906 1791
+Q 2906 2416 2648 2759
+Q 2391 3103 1925 3103
+Q 1463 3103 1205 2759
+Q 947 2416 947 1791
+Q 947 1169 1205 825
+Q 1463 481 1925 481
+Q 2391 481 2648 825
+Q 2906 1169 2906 1791
+z
+M 3481 434
+Q 3481 -459 3084 -895
+Q 2688 -1331 1869 -1331
+Q 1566 -1331 1297 -1286
+Q 1028 -1241 775 -1147
+L 775 -588
+Q 1028 -725 1275 -790
+Q 1522 -856 1778 -856
+Q 2344 -856 2625 -561
+Q 2906 -266 2906 331
+L 2906 616
+Q 2728 306 2450 153
+Q 2172 0 1784 0
+Q 1141 0 747 490
+Q 353 981 353 1791
+Q 353 2603 747 3093
+Q 1141 3584 1784 3584
+Q 2172 3584 2450 3431
+Q 2728 3278 2906 2969
+L 2906 3500
+L 3481 3500
+L 3481 434
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-75" d="M 544 1381
+L 544 3500
+L 1119 3500
+L 1119 1403
+Q 1119 906 1312 657
+Q 1506 409 1894 409
+Q 2359 409 2629 706
+Q 2900 1003 2900 1516
+L 2900 3500
+L 3475 3500
+L 3475 0
+L 2900 0
+L 2900 538
+Q 2691 219 2414 64
+Q 2138 -91 1772 -91
+Q 1169 -91 856 284
+Q 544 659 544 1381
+z
+M 1991 3584
+L 1991 3584
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-73" d="M 2834 3397
+L 2834 2853
+Q 2591 2978 2328 3040
+Q 2066 3103 1784 3103
+Q 1356 3103 1142 2972
+Q 928 2841 928 2578
+Q 928 2378 1081 2264
+Q 1234 2150 1697 2047
+L 1894 2003
+Q 2506 1872 2764 1633
+Q 3022 1394 3022 966
+Q 3022 478 2636 193
+Q 2250 -91 1575 -91
+Q 1294 -91 989 -36
+Q 684 19 347 128
+L 347 722
+Q 666 556 975 473
+Q 1284 391 1588 391
+Q 1994 391 2212 530
+Q 2431 669 2431 922
+Q 2431 1156 2273 1281
+Q 2116 1406 1581 1522
+L 1381 1569
+Q 847 1681 609 1914
+Q 372 2147 372 2553
+Q 372 3047 722 3315
+Q 1072 3584 1716 3584
+Q 2034 3584 2315 3537
+Q 2597 3491 2834 3397
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-6f" d="M 1959 3097
+Q 1497 3097 1228 2736
+Q 959 2375 959 1747
+Q 959 1119 1226 758
+Q 1494 397 1959 397
+Q 2419 397 2687 759
+Q 2956 1122 2956 1747
+Q 2956 2369 2687 2733
+Q 2419 3097 1959 3097
+z
+M 1959 3584
+Q 2709 3584 3137 3096
+Q 3566 2609 3566 1747
+Q 3566 888 3137 398
+Q 2709 -91 1959 -91
+Q 1206 -91 779 398
+Q 353 888 353 1747
+Q 353 2609 779 3096
+Q 1206 3584 1959 3584
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-6c" d="M 603 4863
+L 1178 4863
+L 1178 0
+L 603 0
+L 603 4863
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-64" d="M 2906 2969
+L 2906 4863
+L 3481 4863
+L 3481 0
+L 2906 0
+L 2906 525
+Q 2725 213 2448 61
+Q 2172 -91 1784 -91
+Q 1150 -91 751 415
+Q 353 922 353 1747
+Q 353 2572 751 3078
+Q 1150 3584 1784 3584
+Q 2172 3584 2448 3432
+Q 2725 3281 2906 2969
+z
+M 947 1747
+Q 947 1113 1208 752
+Q 1469 391 1925 391
+Q 2381 391 2643 752
+Q 2906 1113 2906 1747
+Q 2906 2381 2643 2742
+Q 2381 3103 1925 3103
+Q 1469 3103 1208 2742
+Q 947 2381 947 1747
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-3b" d="M 750 3309
+L 1409 3309
+L 1409 2516
+L 750 2516
+L 750 3309
+z
+M 750 794
+L 1409 794
+L 1409 256
+L 897 -744
+L 494 -744
+L 750 256
+L 750 794
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-66" d="M 2375 4863
+L 2375 4384
+L 1825 4384
+Q 1516 4384 1395 4259
+Q 1275 4134 1275 3809
+L 1275 3500
+L 2222 3500
+L 2222 3053
+L 1275 3053
+L 1275 0
+L 697 0
+L 697 3053
+L 147 3053
+L 147 3500
+L 697 3500
+L 697 3744
+Q 697 4328 969 4595
+Q 1241 4863 1831 4863
+L 2375 4863
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-6d" d="M 3328 2828
+Q 3544 3216 3844 3400
+Q 4144 3584 4550 3584
+Q 5097 3584 5394 3201
+Q 5691 2819 5691 2113
+L 5691 0
+L 5113 0
+L 5113 2094
+Q 5113 2597 4934 2840
+Q 4756 3084 4391 3084
+Q 3944 3084 3684 2787
+Q 3425 2491 3425 1978
+L 3425 0
+L 2847 0
+L 2847 2094
+Q 2847 2600 2669 2842
+Q 2491 3084 2119 3084
+Q 1678 3084 1418 2786
+Q 1159 2488 1159 1978
+L 1159 0
+L 581 0
+L 581 3500
+L 1159 3500
+L 1159 2956
+Q 1356 3278 1631 3431
+Q 1906 3584 2284 3584
+Q 2666 3584 2933 3390
+Q 3200 3197 3328 2828
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-36" d="M 2113 2584
+Q 1688 2584 1439 2293
+Q 1191 2003 1191 1497
+Q 1191 994 1439 701
+Q 1688 409 2113 409
+Q 2538 409 2786 701
+Q 3034 994 3034 1497
+Q 3034 2003 2786 2293
+Q 2538 2584 2113 2584
+z
+M 3366 4563
+L 3366 3988
+Q 3128 4100 2886 4159
+Q 2644 4219 2406 4219
+Q 1781 4219 1451 3797
+Q 1122 3375 1075 2522
+Q 1259 2794 1537 2939
+Q 1816 3084 2150 3084
+Q 2853 3084 3261 2657
+Q 3669 2231 3669 1497
+Q 3669 778 3244 343
+Q 2819 -91 2113 -91
+Q 1303 -91 875 529
+Q 447 1150 447 2328
+Q 447 3434 972 4092
+Q 1497 4750 2381 4750
+Q 2619 4750 2861 4703
+Q 3103 4656 3366 4563
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-2013" d="M 313 1978
+L 2888 1978
+L 2888 1528
+L 313 1528
+L 313 1978
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-34" d="M 2419 4116
+L 825 1625
+L 2419 1625
+L 2419 4116
+z
+M 2253 4666
+L 3047 4666
+L 3047 1625
+L 3713 1625
+L 3713 1100
+L 3047 1100
+L 3047 0
+L 2419 0
+L 2419 1100
+L 313 1100
+L 313 1709
+L 2253 4666
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-77" d="M 269 3500
+L 844 3500
+L 1563 769
+L 2278 3500
+L 2956 3500
+L 3675 769
+L 4391 3500
+L 4966 3500
+L 4050 0
+L 3372 0
+L 2619 2869
+L 1863 0
+L 1184 0
+L 269 3500
+z
+" transform="scale(0.015625)"/>
+     <path id="DejaVuSans-38" d="M 2034 2216
+Q 1584 2216 1326 1975
+Q 1069 1734 1069 1313
+Q 1069 891 1326 650
+Q 1584 409 2034 409
+Q 2484 409 2743 651
+Q 3003 894 3003 1313
+Q 3003 1734 2745 1975
+Q 2488 2216 2034 2216
+z
+M 1403 2484
+Q 997 2584 770 2862
+Q 544 3141 544 3541
+Q 544 4100 942 4425
+Q 1341 4750 2034 4750
+Q 2731 4750 3128 4425
+Q 3525 4100 3525 3541
+Q 3525 3141 3298 2862
+Q 3072 2584 2669 2484
+Q 3125 2378 3379 2068
+Q 3634 1759 3634 1313
+Q 3634 634 3220 271
+Q 2806 -91 2034 -91
+Q 1263 -91 848 271
+Q 434 634 434 1313
+Q 434 1759 690 2068
+Q 947 2378 1403 2484
+z
+M 1172 3481
+Q 1172 3119 1398 2916
+Q 1625 2713 2034 2713
+Q 2441 2713 2670 2916
+Q 2900 3119 2900 3481
+Q 2900 3844 2670 4047
+Q 2441 4250 2034 4250
+Q 1625 4250 1398 4047
+Q 1172 3844 1172 3481
+z
+" transform="scale(0.015625)"/>
+    </defs>
+    <use xlink:href="#DejaVuSans-54"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(61.083984 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(124.462891 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(185.986328 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(217.773438 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(281.396484 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(345.019531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(408.642578 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(440.429688 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(503.90625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(567.382812 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(599.169922 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(638.378906 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(699.658203 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(739.021484 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(802.498047 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(864.021484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(903.230469 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(935.017578 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(998.396484 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(1050.496094 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(1112.019531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1164.119141 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(1195.90625 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(1259.529297 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1323.152344 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(1354.939453 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(1418.318359 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1457.527344 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(1489.314453 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(1528.523438 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(1589.705078 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(1651.228516 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(1714.607422 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(1775.789062 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(1803.572266 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(1867.048828 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1919.148438 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(1950.935547 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(2012.214844 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(2075.59375 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2139.070312 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(2170.857422 0)"/>
+    <use xlink:href="#DejaVuSans-32" transform="translate(2234.480469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2298.103516 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(2329.890625 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(2393.269531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2432.478516 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(2464.265625 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(2527.742188 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(2589.021484 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(2627.884766 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(2682.865234 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(2744.046875 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(2807.523438 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(2869.046875 0)"/>
+    <use xlink:href="#DejaVuSans-3b" transform="translate(2921.146484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2954.837891 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(2986.625 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3021.830078 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3062.943359 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(3124.222656 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(3187.699219 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3285.111328 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3346.634766 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(3410.013672 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3449.222656 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3481.009766 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3542.191406 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(3569.974609 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(3597.757812 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3661.234375 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(3722.416016 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3774.515625 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(3806.302734 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3858.402344 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(3921.878906 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3983.158203 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(4046.537109 0)"/>
+    <use xlink:href="#DejaVuSans-36" transform="translate(4078.324219 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4141.947266 0)"/>
+    <use xlink:href="#DejaVuSans-2013" transform="translate(4205.570312 0)"/>
+    <use xlink:href="#DejaVuSans-31" transform="translate(4255.570312 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(4319.193359 0)"/>
+    <use xlink:href="#DejaVuSans-34" transform="translate(4382.816406 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(4446.439453 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(4478.226562 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(4541.605469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(4580.814453 0)"/>
+    <use xlink:href="#DejaVuSans-77" transform="translate(4612.601562 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(4694.388672 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(4722.171875 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(4761.380859 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(4824.759766 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(4856.546875 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4953.958984 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(5015.482422 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(5078.958984 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(5106.742188 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(5168.021484 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5231.400391 0)"/>
+    <use xlink:href="#DejaVuSans-38" transform="translate(5263.1875 0)"/>
+    <use xlink:href="#DejaVuSans-30" transform="translate(5326.810547 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(5390.433594 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(5422.220703 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(5485.599609 0)"/>
+   </g>
+  </g>
+  <g id="text_19">
+   <!-- Exact sequence mapping does not establish folding, ligation, yield, or experimental success -->
+   <g style="fill: #667085" transform="translate(21.888 457.16345) scale(0.08 -0.08)">
     <defs>
      <path id="DejaVuSans-45" d="M 628 4666
 L 3578 4666
@@ -3382,13 +3837,6 @@ L 2834 3500
 L 3513 3500
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-6c" d="M 603 4863
-L 1178 4863
-L 1178 0
-L 603 0
-L 603 4863
-z
-" transform="scale(0.015625)"/>
      <path id="DejaVuSans-71" d="M 947 1747
 Q 947 1113 1208 752
 Q 1469 391 1925 391
@@ -3415,21 +3863,6 @@ L 2906 -1331
 L 2906 525
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-3b" d="M 750 3309
-L 1409 3309
-L 1409 2516
-L 750 2516
-L 750 3309
-z
-M 750 794
-L 1409 794
-L 1409 256
-L 897 -744
-L 494 -744
-L 750 256
-L 750 794
-z
-" transform="scale(0.015625)"/>
      <path id="DejaVuSans-2c" d="M 750 794
 L 1409 794
 L 1409 256
@@ -3439,37 +3872,21 @@ L 750 256
 L 750 794
 z
 " transform="scale(0.015625)"/>
-     <path id="DejaVuSans-64" d="M 2906 2969
-L 2906 4863
-L 3481 4863
-L 3481 0
-L 2906 0
-L 2906 525
-Q 2725 213 2448 61
-Q 2172 -91 1784 -91
-Q 1150 -91 751 415
-Q 353 922 353 1747
-Q 353 2572 751 3078
-Q 1150 3584 1784 3584
-Q 2172 3584 2448 3432
-Q 2725 3281 2906 2969
-z
-M 947 1747
-Q 947 1113 1208 752
-Q 1469 391 1925 391
-Q 2381 391 2643 752
-Q 2906 1113 2906 1747
-Q 2906 2381 2643 2742
-Q 2381 3103 1925 3103
-Q 1469 3103 1208 2742
-Q 947 2381 947 1747
-z
-" transform="scale(0.015625)"/>
-     <path id="DejaVuSans-2e" d="M 684 794
-L 1344 794
-L 1344 0
-L 684 0
-L 684 794
+     <path id="DejaVuSans-79" d="M 2059 -325
+Q 1816 -950 1584 -1140
+Q 1353 -1331 966 -1331
+L 506 -1331
+L 506 -850
+L 844 -850
+Q 1081 -850 1212 -737
+Q 1344 -625 1503 -206
+L 1606 56
+L 191 3500
+L 800 3500
+L 1894 763
+L 2988 3500
+L 3597 3500
+L 2059 -325
 z
 " transform="scale(0.015625)"/>
     </defs>
@@ -3479,109 +3896,100 @@ z
     <use xlink:href="#DejaVuSans-63" transform="translate(183.642578 0)"/>
     <use xlink:href="#DejaVuSans-74" transform="translate(238.623047 0)"/>
     <use xlink:href="#DejaVuSans-20" transform="translate(277.832031 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(309.619141 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(337.402344 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(398.583984 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(453.564453 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(514.84375 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(542.626953 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(574.414062 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(626.513672 0)"/>
-    <use xlink:href="#DejaVuSans-71" transform="translate(688.037109 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(751.513672 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(814.892578 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(876.416016 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(939.794922 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(994.775391 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(1056.298828 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(1088.085938 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(1185.498047 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(1246.777344 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(1310.253906 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(1373.730469 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(1401.513672 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(1464.892578 0)"/>
-    <use xlink:href="#DejaVuSans-3b" transform="translate(1528.369141 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(1562.060547 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(1593.847656 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(1633.056641 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(1694.238281 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(1757.714844 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(1818.896484 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(1846.679688 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(1907.861328 0)"/>
-    <use xlink:href="#DejaVuSans-79" transform="translate(1971.337891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2030.517578 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(2062.304688 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(2090.087891 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2142.1875 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(2173.974609 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(2226.074219 0)"/>
-    <use xlink:href="#DejaVuSans-68" transform="translate(2281.054688 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(2344.433594 0)"/>
-    <use xlink:href="#DejaVuSans-6d" transform="translate(2405.957031 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(2503.369141 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(2564.648438 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(2603.857422 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(2631.640625 0)"/>
-    <use xlink:href="#DejaVuSans-2c" transform="translate(2686.621094 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2718.408203 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(2750.195312 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(2813.574219 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(2874.755859 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(2913.964844 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(2945.751953 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3007.03125 0)"/>
-    <use xlink:href="#DejaVuSans-73" transform="translate(3038.818359 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(3090.917969 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3130.126953 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(3171.240234 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(3234.619141 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(3289.599609 0)"/>
-    <use xlink:href="#DejaVuSans-75" transform="translate(3328.808594 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(3392.1875 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(3431.050781 0)"/>
-    <use xlink:href="#DejaVuSans-2c" transform="translate(3492.574219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3524.361328 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(3556.148438 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(3583.931641 0)"/>
-    <use xlink:href="#DejaVuSans-67" transform="translate(3611.714844 0)"/>
-    <use xlink:href="#DejaVuSans-61" transform="translate(3675.191406 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(3736.470703 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(3775.679688 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3803.462891 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(3864.644531 0)"/>
-    <use xlink:href="#DejaVuSans-2c" transform="translate(3928.023438 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(3959.810547 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(3991.597656 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4052.779297 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(4093.892578 0)"/>
-    <use xlink:href="#DejaVuSans-79" transform="translate(4125.679688 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(4184.859375 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4212.642578 0)"/>
-    <use xlink:href="#DejaVuSans-6c" transform="translate(4274.166016 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(4301.949219 0)"/>
-    <use xlink:href="#DejaVuSans-20" transform="translate(4365.425781 0)"/>
-    <use xlink:href="#DejaVuSans-70" transform="translate(4397.212891 0)"/>
-    <use xlink:href="#DejaVuSans-72" transform="translate(4460.689453 0)"/>
-    <use xlink:href="#DejaVuSans-65" transform="translate(4499.552734 0)"/>
-    <use xlink:href="#DejaVuSans-64" transform="translate(4561.076172 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(4624.552734 0)"/>
-    <use xlink:href="#DejaVuSans-63" transform="translate(4652.335938 0)"/>
-    <use xlink:href="#DejaVuSans-74" transform="translate(4707.316406 0)"/>
-    <use xlink:href="#DejaVuSans-69" transform="translate(4746.525391 0)"/>
-    <use xlink:href="#DejaVuSans-6f" transform="translate(4774.308594 0)"/>
-    <use xlink:href="#DejaVuSans-6e" transform="translate(4835.490234 0)"/>
-    <use xlink:href="#DejaVuSans-2e" transform="translate(4898.869141 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(309.619141 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(361.71875 0)"/>
+    <use xlink:href="#DejaVuSans-71" transform="translate(423.242188 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(486.71875 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(550.097656 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(611.621094 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(675 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(729.980469 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(791.503906 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(823.291016 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(920.703125 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(981.982422 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(1045.458984 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(1108.935547 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(1136.71875 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(1200.097656 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1263.574219 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(1295.361328 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(1358.837891 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(1420.019531 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(1481.542969 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1533.642578 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(1565.429688 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(1628.808594 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(1689.990234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(1729.199219 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(1760.986328 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(1822.509766 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(1874.609375 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(1913.818359 0)"/>
+    <use xlink:href="#DejaVuSans-62" transform="translate(1975.097656 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(2038.574219 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(2066.357422 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(2094.140625 0)"/>
+    <use xlink:href="#DejaVuSans-68" transform="translate(2146.240234 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2209.619141 0)"/>
+    <use xlink:href="#DejaVuSans-66" transform="translate(2241.40625 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(2276.611328 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(2337.792969 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(2365.576172 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(2429.052734 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(2456.835938 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(2520.214844 0)"/>
+    <use xlink:href="#DejaVuSans-2c" transform="translate(2583.691406 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(2615.478516 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(2647.265625 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(2675.048828 0)"/>
+    <use xlink:href="#DejaVuSans-67" transform="translate(2702.832031 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(2766.308594 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(2827.587891 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(2866.796875 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(2894.580078 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(2955.761719 0)"/>
+    <use xlink:href="#DejaVuSans-2c" transform="translate(3019.140625 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3050.927734 0)"/>
+    <use xlink:href="#DejaVuSans-79" transform="translate(3082.714844 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(3141.894531 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3169.677734 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(3231.201172 0)"/>
+    <use xlink:href="#DejaVuSans-64" transform="translate(3258.984375 0)"/>
+    <use xlink:href="#DejaVuSans-2c" transform="translate(3322.460938 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3354.248047 0)"/>
+    <use xlink:href="#DejaVuSans-6f" transform="translate(3386.035156 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3447.216797 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(3488.330078 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3520.117188 0)"/>
+    <use xlink:href="#DejaVuSans-78" transform="translate(3579.890625 0)"/>
+    <use xlink:href="#DejaVuSans-70" transform="translate(3639.070312 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3702.546875 0)"/>
+    <use xlink:href="#DejaVuSans-72" transform="translate(3764.070312 0)"/>
+    <use xlink:href="#DejaVuSans-69" transform="translate(3805.183594 0)"/>
+    <use xlink:href="#DejaVuSans-6d" transform="translate(3832.966797 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(3930.378906 0)"/>
+    <use xlink:href="#DejaVuSans-6e" transform="translate(3991.902344 0)"/>
+    <use xlink:href="#DejaVuSans-74" transform="translate(4055.28125 0)"/>
+    <use xlink:href="#DejaVuSans-61" transform="translate(4094.490234 0)"/>
+    <use xlink:href="#DejaVuSans-6c" transform="translate(4155.769531 0)"/>
+    <use xlink:href="#DejaVuSans-20" transform="translate(4183.552734 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(4215.339844 0)"/>
+    <use xlink:href="#DejaVuSans-75" transform="translate(4267.439453 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4330.818359 0)"/>
+    <use xlink:href="#DejaVuSans-63" transform="translate(4385.798828 0)"/>
+    <use xlink:href="#DejaVuSans-65" transform="translate(4440.779297 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(4502.302734 0)"/>
+    <use xlink:href="#DejaVuSans-73" transform="translate(4554.402344 0)"/>
    </g>
   </g>
  </g>
  <defs>
-  <clipPath id="p1ed6e3343e">
-   <rect x="16.416" y="22.248" width="523.058824" height="331.866"/>
+  <clipPath id="pb251acdba2">
+   <rect x="66.275753" y="41.796" width="424.660629" height="401.706"/>
   </clipPath>
-  <clipPath id="p51da927130">
-   <rect x="560.397176" y="22.248" width="523.058824" height="331.866"/>
+  <clipPath id="p764d4c8958">
+   <rect x="607.841218" y="41.796" width="424.660629" height="401.706"/>
   </clipPath>
  </defs>
 </svg>

--- a/src/dnadesign/junction/docs/guides/inspect-and-verify.md
+++ b/src/dnadesign/junction/docs/guides/inspect-and-verify.md
@@ -5,7 +5,7 @@ type: guide
 audience: reviewers of an existing junction design
 owner: dnadesign-maintainers
 status: active
-last_verified: 2026-08-09
+last_verified: 2026-08-10
 ---
 
 # Inspect and verify a bundle
@@ -73,7 +73,7 @@ Follow the [BaseRender integration](../../../baserender/docs/integrations/juncti
 Use a new BaseRender output directory beside the source bundle; never add
 images inside the verified source bundle.
 
-Use the fragment map to check expected strand pairing, the target overview to
+Use the fragment map to check expected strand annealing, the target overview to
 locate all interfaces, and junction details to inspect selected `t/t*`,
 `b/b*`, nick, and strand-end geometry. Light gray edges mark declared
 Watson–Crick pairs. Large requests require explicit fragment or junction
@@ -82,20 +82,23 @@ order rows, and software checks remain in their owning JSON or TSV artifacts;
 the plots do not duplicate them. A plot adds no thermodynamic or experimental
 evidence and is not part of the `junction` plan identity.
 
-### Expected fragment pairing
+### Expected fragment annealing
 
-[![Expected pairing for three selected fragments](../assets/annealed-fragments.svg)](../assets/annealed-fragments.svg)
+[![Expected annealing for three selected fragment pairs](../assets/annealed-fragments.svg)](../assets/annealed-fragments.svg)
 
-This view keeps the two orderable strands antiparallel and marks only the
-pairing declared by the verified record. The unpaired barcode and toehold arms
-remain visible instead of being flattened into a target-only sequence row.
+This view gives every nucleotide the same physical spacing, keeps the two
+orderable strands antiparallel, and marks only the pairing declared by the
+verified record. Rounded outer edges show each contiguous order; categorical
+fills identify its target, toehold, and barcode spans. The unpaired barcode and
+toehold arms remain visible instead of being flattened into a target-only row.
 
 ### Target-scale assembly map
 
 [![Three-way interfaces across one target](../assets/assembly-overview.svg)](../assets/assembly-overview.svg)
 
-This symbolic view answers where the interfaces occur. It omits nucleotide
-letters on purpose; use it to choose a junction for detailed review.
+This symbolic view answers where the interfaces occur. Stable junction IDs and
+target coordinates route into the detail view. It omits nucleotide letters on
+purpose.
 
 ### Selected junction details
 

--- a/src/dnadesign/junction/docs/guides/prepare-a-request.md
+++ b/src/dnadesign/junction/docs/guides/prepare-a-request.md
@@ -5,7 +5,7 @@ type: guide
 audience: users turning exact targets into a reviewed design request
 owner: dnadesign-maintainers
 status: active
-last_verified: 2026-08-09
+last_verified: 2026-08-10
 ---
 
 # Prepare a request
@@ -128,6 +128,14 @@ Review at least:
 - barcode GC and homopolymer bounds; and
 - barcode-to-toehold and barcode-to-barcode forbidden substring lengths.
 
+The Nature study found effective ligation when the nick was at least about six
+bases from the barcode helix and standardized its tested assemblies on a
+10-base toehold. The pooled study also used `t = 10` unless stated otherwise.
+The checked-in examples therefore use 10 nt. The request contract accepts other
+positive lengths for computational work, but the papers do not establish a
+general benefit for making the toehold longer than 10 nt. Treat a different
+value as a new reviewed method choice, not a routine scaling control.
+
 The tool never relaxes these values automatically. Candidate exhaustion fails
 with the original request preserved.
 
@@ -160,6 +168,31 @@ No default minimum is inferred from either paper. Declare the boundary that
 your downstream process has reviewed. Passing it proves only that the emitted
 fragment strings lie inside the caller's length interval; it does not validate
 synthesis, folding, annealing, ligation, or amplification.
+
+Balance the lengths of the **ordered strands**, not the target domains named
+F1, F2, and F3. A first, internal, or last fragment carries a different
+combination of target, toehold, and barcode sequence, so equally sized target
+domains do not produce equally sized orders. `junction` keeps sequence
+separation as the search objective and does not hide a second length-balancing
+score inside it. Use the published order table and BaseRender subtitle to
+review the minimum, maximum, and median. If the spread is unsuitable, revise
+the target length or declared geometry and rerun the complete search.
+
+Supplier limits change, and product lines from one supplier can have different
+windows. As of 2026-08-10, representative official specifications are:
+
+| Pool product | Stated oligo-length window |
+| --- | ---: |
+| [IDT oPools](https://www.idtdna.com/pages/products/custom-dna-rna/dna-oligos/custom-dna-oligos/opools-oligo-pools) | 40–350 bases |
+| [Twist Oligo Pools](https://www.twistbioscience.com/faq/oligo-pools/what-maximum-length-can-be-ordered-oligo-pool) | 20–350 nt |
+| [Agilent SurePrint G7636A](https://www.agilent.com/store/en_US/Prod-G7636A/G7636A) | 30–110 nt |
+
+These links are purchasing context, not built-in profiles or endorsements.
+Set `minimum_fragment_oligo_length` and `max_oligo_length` to the exact route
+you intend to use. If several routes must remain possible, declare their
+reviewed intersection. The planner rejects a candidate path that would emit a
+fragment below the minimum, and it rejects any fragment or recovery primer
+above the maximum before publication.
 
 An arbitrary 5′ primer extension may contain a caller-supplied adapter or Type
 IIS sequence. `junction` does not identify enzymes, design spacers, model

--- a/src/dnadesign/junction/docs/reference/method-v1.md
+++ b/src/dnadesign/junction/docs/reference/method-v1.md
@@ -5,7 +5,7 @@ type: reference
 scope: paper-inspired three-way-junction geometry, string objectives, and reconstruction evidence
 owner: dnadesign-maintainers
 status: active
-last_verified: 2026-08-09
+last_verified: 2026-08-10
 ---
 
 # Method v1
@@ -288,7 +288,8 @@ met.
 
 | Topic | Paper-stated behavior | junction v1 contract |
 | --- | --- | --- |
-| Terminal locus and order length | The pooled Methods text stops when `N - p_(m+1) <= c_max` and states final oligo lengths in `[L - R + 1, L + R - 1]`. For some target lengths, the literal predicate leaves a terminal barcode-bearing oligo longer than the stated geometry. | V1 stops from the current locus, retains another junction when needed, requires a nonempty terminal domain for every candidate, and covers both the `L + R - 1` offset bound and `L - b + t` terminal-complement bound. This correction can produce a terminal fragment order shorter than the preprint's stated lower bound. The v2 request makes the caller declare `minimum_fragment_oligo_length`; infeasible candidate paths are removed before path ranking and barcode work. |
+| Reported order-length interval | The pooled Methods text states final oligo lengths in `[L - R + 1, L + R - 1]`, or 82–110 nt for its default values. Its later strand equations also define shorter coding strands; for example, an internal coding strand is an inter-toehold domain plus one toehold. The interval therefore cannot be treated as a universal bound over every barcode and coding oligo described by those equations. | V1 composes every exact barcode-bearing and complement strand first, then applies the caller's declared synthesis interval to those physical order strings. It does not infer the paper's 82–110-nt statement as a hidden constraint. |
+| Terminal locus and order length | The pooled Methods text stops when `N - p_(m+1) <= c_max`. For some target lengths, the literal predicate leaves a terminal barcode-bearing oligo longer than its stated geometry. | V1 stops from the current locus, retains another junction when needed, requires a nonempty terminal domain for every candidate, and covers both the `L + R - 1` offset bound and `L - b + t` terminal-complement bound. This correction can produce a short terminal order. The v2 request makes the caller declare `minimum_fragment_oligo_length`; infeasible candidate paths are removed before path ranking and barcode work. |
 | Toehold selection scope | The pooled procedure selects a toehold set target by target before global barcode design. | V1 uses a different joint, cross-target-constrained search for all loci in one assembly group. Adding a target may therefore change existing assignments. No comparative laboratory result establishes either search as superior. |
 | Substring exclusion | The pooled method starts with `q = floor(t / 2)` for barcode-to-toehold exclusion and `k = max(floor(b / 4), q + 1)` for barcode-to-barcode exclusion, including reverse complements. | `barcode_toehold_k` and `barcode_pair_k` are fixed request fields. The paper-derived values are documented starting points, never inferred at runtime. |
 | Constraint pressure | The pooled method requires at least `5|T|` admissible barcodes. If its generator returns fewer, the described software reruns while alternating constraint relaxation: increment `k` on even iterations (or whenever `q >= t`) and increment `q` on eligible odd iterations, halting if the threshold still cannot be met. | Attempt and iteration budgets are explicit. Candidate exhaustion fails under the declared `q` and `k`; junction never changes them automatically. A reviewed replacement request may declare different values. |

--- a/src/dnadesign/junction/docs/reference/request.md
+++ b/src/dnadesign/junction/docs/reference/request.md
@@ -5,7 +5,7 @@ type: reference
 scope: dnadesign.junction.request.v2
 owner: dnadesign-maintainers
 status: active
-last_verified: 2026-08-09
+last_verified: 2026-08-10
 ---
 
 # Request contract
@@ -59,6 +59,13 @@ The four iteration/attempt ceilings are 100,000; 10,000,000; 100,000; and
 These are software validity bounds, not validated laboratory defaults. The
 tool never changes them or relaxes `barcode_toehold_k` and `barcode_pair_k`
 silently.
+
+The paper-backed starting value for `toehold_length` is 10 nt. The Nature
+study standardized on 10 bases after testing nick positions and observing
+effective ligation at distances of about six bases or more from the barcode
+helix; the pooled study also used `t = 10` by default. The schema's broader
+integer range supports explicit computational experiments. It does not imply
+that longer toeholds have been experimentally validated by those sources.
 
 `nominal_fragment_oligo_length` controls locus spacing. It is not the Nature
 paper's physical input-oligo length and does not promise equal-length orders.
@@ -133,6 +140,13 @@ terminal domain must jointly yield fragment strands at or above the declared
 floor. The bounded seeded search ranks only feasible sampled paths and always
 includes the lexicographically first feasible path. It does not enumerate the
 Cartesian product of candidate loci.
+
+The interval is a hard synthesis boundary, not a uniformity objective. The
+three fragment roles contain different structural components, so target-domain
+length and ordered-strand length are different quantities. The search does not
+trade toehold separation for a narrower order-length spread. Review actual
+order lengths in `orders/oligos.tsv`; revise the declared geometry when the
+spread is operationally unsuitable.
 
 ## Request-wide resource envelope
 

--- a/src/dnadesign/junction/docs/reference/sources.md
+++ b/src/dnadesign/junction/docs/reference/sources.md
@@ -4,7 +4,7 @@ title: junction sources and scope
 type: reference
 owner: dnadesign-maintainers
 status: active
-last_verified: 2026-08-09
+last_verified: 2026-08-10
 ---
 
 # Sources and scope
@@ -37,6 +37,14 @@ barcode/coding oligo roles, ligation, recovery, and experimental validation.
 The preprint describes pooled oligos, a three-stage string-design procedure,
 construct-specific and universal recovery experiments, and downstream
 hierarchical assembly.
+
+The Nature methods report effective ligation when the nick was about six bases
+or farther from the barcode helix and standardize the reported experiments on
+10-base toeholds. They use individually synthesized oligos with a 120-base
+maximum in that study. The pooled preprint uses `t = 10` by default and states
+`L = 96`, `b = 22`, and `R = 15`, while also defining the exact strand
+composition. Those values motivate the checked-in examples; they are not a
+supplier-independent manufacturing profile.
 
 ## What is implemented
 

--- a/src/dnadesign/junction/examples/three-fragment-review/request.yaml
+++ b/src/dnadesign/junction/examples/three-fragment-review/request.yaml
@@ -29,8 +29,9 @@ targets:
   - id: synthetic-three-fragment-target
     assembly_group_id: compact-review-example
 
-    # Exact synthetic 170 bp target with no asserted biological meaning.
-    sequence: TCATTCTAGGCTAGCTGAGTGCGCTATAAGCGTAGAACTACTACATCACATCCGCTACGCTCTCACCGTAGAGGGACTAGGGTCTATCAGATGATGCTTAGCGGAATAAGGTACAGGTATAATCCGAAACGCTTTGAATTTTGGGGACGCCTGATTAACGTAGTCTGATG
+    # Exact synthetic 200 bp target with no asserted biological meaning. This
+    # length gives the three fragment pairs a less skewed ordering envelope.
+    sequence: TCATTCTAGGCTAGCTGAGTGCGCTATAAGCGTAGAACTACTACATCACATCCGCTACGCTCTCACCGTAGAGGGACTAGGGTCTATCAGATGATGCTTAGCGGAATAAGGTACAGGTATAATCCGAAACGCTTTGAATTTTGGGGACGCCTGATTAACGTAGTCTGATGAACGCCTCTAGCTCACCTTGGATTGACAGG
 
     recovery_primers:
       # Junction validates caller-supplied primers; it does not design them.
@@ -39,7 +40,7 @@ targets:
         binding_sequence: TCATTCTAGGCTAGCTGAGT
         five_prime_extension: ""
       reverse:
-        binding_sequence: CATCAGACTACGTTAATCAG
+        binding_sequence: CCTGTCAATCCAAGGTGAGC
         five_prime_extension: ""
 
 order_policy:
@@ -50,7 +51,7 @@ order_policy:
   primer_purification: review-required
   complement_end_preparation: vendor_5_prime_phosphate
 
-  # This example remains within the paper-scale 96 nt nominal geometry while
-  # allowing terminal fragments to vary under the selected loci.
+  # Hard synthesis bounds apply to every emitted fragment oligo. They are
+  # vendor-neutral inputs, not inferred purchasing recommendations.
   minimum_fragment_oligo_length: 45
   max_oligo_length: 110


### PR DESCRIPTION
## Summary

- document the 10 nt paper-backed toehold starting point and distinguish source evidence from configurable software bounds
- make physical fragment-order limits explicit, fail closed, and visible in the three-fragment example
- replace per-row plot scaling with one nucleotide scale and a consistent target/toehold/barcode visual vocabulary
- render rounded contiguous oligos, stable junction IDs, target coordinates, strand polarity, nicks, and centered nucleotide-level three-way junctions
- split shared renderer policy, geometry, and drawing primitives into bounded modules
- regenerate all three checked-in SVGs and require deterministic byte-for-byte freshness

## Evidence

The Nature study standardized 10-base toeholds after observing effective ligation at about six bases or farther from the barcode helix. The pooled preprint uses the default geometry L=96, b=22, t=10, R=15 and reports an 82-110 nt interval, while its exact strand equations require callers to inspect every emitted physical order. The demo now emits six fragment orders spanning 60-104 nt with median 80 nt under an explicit 45-110 nt boundary.

The plots remain sequence-derived QA views. They do not claim thermodynamic folding, ligation, amplification, yield, or experimental success.

## Verification

- `uv run pytest -q`
- `uv run pytest -q src/dnadesign/baserender/tests/test_three_way_junction_review.py src/dnadesign/baserender/tests/three_way_junction_review`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run python -m dnadesign.devtools.architecture.boundaries --repo-root .`
- `uv run python -m dnadesign.devtools.docs.checks`
- `git diff --check`
