### PR TITLE
feat: expose Cruncher promoter export route

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=83.0.0", "wheel>=0.46.2", "setuptools_scm"]
+requires = ["setuptools>=83.0.0", "wheel>=0.47.0", "setuptools_scm"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -88,7 +88,7 @@ infer-evo2 = [
   # --- build helpers (required because we disable build isolation for flash-attn + TE-torch)
   "pip>=26.1.2; sys_platform == 'linux' and platform_machine == 'x86_64'",
   "setuptools>=83.0.0; sys_platform == 'linux' and platform_machine == 'x86_64'",
-  "wheel>=0.46.2; sys_platform == 'linux' and platform_machine == 'x86_64'",
+  "wheel>=0.47.0; sys_platform == 'linux' and platform_machine == 'x86_64'",
   "packaging; sys_platform == 'linux' and platform_machine == 'x86_64'",
   "ninja; sys_platform == 'linux' and platform_machine == 'x86_64'",
   "cmake>=3.18; sys_platform == 'linux' and platform_machine == 'x86_64'",

--- a/src/dnadesign/cruncher/docs/reference/cli.md
+++ b/src/dnadesign/cruncher/docs/reference/cli.md
@@ -1446,7 +1446,7 @@ Subcommands:
 * `sources info <source> [config]`
 * `sources datasets <source> [config]` — list HT datasets (if supported)
 * `sources promoters <source> [config]` — inspect promoter coverage without writing an export
-* `sources materialize-promoters <destination> [--data-root <root>]` — write a new provenance-qualified promoter export from declared source files
+* `sources materialize-promoters <destination> [--data-root <root>]` — write a provenance-qualified promoter export from declared source files
 * `sources summary [config]` — summarize cache + remote inventory (supports JSON output, combined view)
 
 Example:
@@ -1469,7 +1469,8 @@ Note:
 
 * `sources list` attempts full config resolution (workspace/CWD). If none is found, it lists built-in sources only.
   Pass CONFIG (or set `CRUNCHER_CONFIG`/`CRUNCHER_WORKSPACE`) to include local sources from a workspace config.
-* `sources materialize-promoters` requires a new destination directory and publishes only after the complete export has been staged successfully. It never replaces an existing directory.
+* With `--data-root`, `sources materialize-promoters` reads release-pinned RegulonDB tables directly from that root. Without it, the command uses the installed `dnadesign-data` provider.
+* The command requires a new destination directory and publishes only after the complete export has been staged successfully. It never replaces an existing directory.
 * Some sources do not expose full remote inventories; use `--remote-limit` (partial counts)
   or `--scope cache` if you only need cached regulators.
 * `sources datasets --dataset-source <X>` performs a strict row-level source filter on returned datasets.

--- a/src/dnadesign/cruncher/docs/reference/cli.md
+++ b/src/dnadesign/cruncher/docs/reference/cli.md
@@ -1,7 +1,7 @@
 ## Cruncher CLI
 
 **Owner:** dnadesign-maintainers
-**Last verified:** 2026-08-09
+**Last verified:** 2026-08-11
 
 
 **Last updated by:** cruncher-maintainers on 2026-07-13
@@ -57,7 +57,7 @@ cruncher study list
 #### Quick command map
 
 * **Cache data** → `fetch motifs` / `fetch sites`
-* **Inspect cache** → `sources ...` / `catalog ...`
+* **Inspect or materialize source data** → `sources ...` / `catalog ...`
 * **Pin TFs** → `lock`
 * **Validate motifs** → `parse`
 * **Render logos** → `catalog logos`
@@ -1445,12 +1445,15 @@ Subcommands:
 * `sources list [config]` — list registered sources (auto-detects config in CWD to include local sources; pass CONFIG when elsewhere)
 * `sources info <source> [config]`
 * `sources datasets <source> [config]` — list HT datasets (if supported)
+* `sources promoters <source> [config]` — inspect promoter coverage without writing an export
+* `sources materialize-promoters <destination> [--data-root <root>]` — write a new provenance-qualified promoter export from declared source files
 * `sources summary [config]` — summarize cache + remote inventory (supports JSON output, combined view)
 
 Example:
 
 * `cruncher sources list configs/config.yaml`
 * `cruncher sources datasets regulondb configs/config.yaml --tf lexA`
+* `cruncher sources materialize-promoters outputs/promoters --data-root <dnadesign-data-root> --format json`
 * `cruncher sources summary configs/config.yaml`
 * `cruncher sources summary --view combined configs/config.yaml`
 * `cruncher sources summary --scope remote --format json configs/config.yaml`
@@ -1466,6 +1469,7 @@ Note:
 
 * `sources list` attempts full config resolution (workspace/CWD). If none is found, it lists built-in sources only.
   Pass CONFIG (or set `CRUNCHER_CONFIG`/`CRUNCHER_WORKSPACE`) to include local sources from a workspace config.
+* `sources materialize-promoters` requires a new destination directory and publishes only after the complete export has been staged successfully. It never replaces an existing directory.
 * Some sources do not expose full remote inventories; use `--remote-limit` (partial counts)
   or `--scope cache` if you only need cached regulators.
 * `sources datasets --dataset-source <X>` performs a strict row-level source filter on returned datasets.

--- a/src/dnadesign/cruncher/src/cli/commands/sources.py
+++ b/src/dnadesign/cruncher/src/cli/commands/sources.py
@@ -361,6 +361,13 @@ def materialize_promoters(
             data_root=resolved_data_root,
             require_association_sources=require_association_sources,
         )
+        if not manifest.complete:
+            inventory = manifest.source_inventory
+            raise ValueError(
+                "promoter export is incomplete "
+                f"({inventory.route_failure_count} route failures; "
+                f"{inventory.conflict_count} sequence conflicts)"
+            )
         staging.replace(resolved_destination)
     except (OSError, RuntimeError, ValueError) as exc:
         shutil.rmtree(staging, ignore_errors=True)

--- a/src/dnadesign/cruncher/src/cli/commands/sources.py
+++ b/src/dnadesign/cruncher/src/cli/commands/sources.py
@@ -13,8 +13,6 @@ from __future__ import annotations
 
 import json
 import os
-import shutil
-import tempfile
 from dataclasses import asdict
 from pathlib import Path
 from typing import Optional
@@ -24,6 +22,7 @@ import typer
 from rich.console import Console
 from rich.table import Table
 
+from dnadesign.artifacts import CreateOnlyDirectoryPublication
 from dnadesign.cruncher.app.source_summary_service import (
     summarize_cache,
     summarize_combined,
@@ -354,10 +353,11 @@ def materialize_promoters(
         console.print(f"Error: Promoter source root does not exist: {resolved_data_root}")
         raise typer.Exit(code=1)
 
-    staging = Path(tempfile.mkdtemp(prefix=f".{resolved_destination.name}.", dir=destination_parent))
+    publication: CreateOnlyDirectoryPublication | None = None
     try:
+        publication = CreateOnlyDirectoryPublication.prepare(resolved_destination)
         manifest = export_dnadesign_data_promoter_superset(
-            staging,
+            publication.stage,
             data_root=resolved_data_root,
             require_association_sources=require_association_sources,
         )
@@ -368,11 +368,13 @@ def materialize_promoters(
                 f"({inventory.route_failure_count} route failures; "
                 f"{inventory.conflict_count} sequence conflicts)"
             )
-        staging.replace(resolved_destination)
+        publication.publish(required_manifest="manifest.json")
     except (OSError, RuntimeError, ValueError) as exc:
-        shutil.rmtree(staging, ignore_errors=True)
         console.print(f"Error: {exc}")
         raise typer.Exit(code=1) from exc
+    finally:
+        if publication is not None:
+            publication.close()
 
     payload = {
         "schema": "cruncher.promoter-export/v1",

--- a/src/dnadesign/cruncher/src/cli/commands/sources.py
+++ b/src/dnadesign/cruncher/src/cli/commands/sources.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
+import tempfile
 from dataclasses import asdict
 from pathlib import Path
 from typing import Optional
@@ -41,6 +43,7 @@ from dnadesign.cruncher.ingest.promoters import (
     PromoterQuery,
     build_promoter_descriptor_inventory,
     build_promoter_source_inventory,
+    export_dnadesign_data_promoter_superset,
     summarize_promoter_collection,
     summarize_promoter_descriptors,
 )
@@ -313,6 +316,71 @@ def promoters(
         console.print(json.dumps(payload, indent=2), markup=False)
         return
     _render_promoter_inventory(payload)
+
+
+@app.command(
+    "materialize-promoters",
+    help="Normalize declared promoter source files into a provenance-qualified export.",
+)
+def materialize_promoters(
+    destination: Path = typer.Argument(..., help="New directory for the promoter export."),
+    data_root: Path | None = typer.Option(
+        None,
+        "--data-root",
+        help="Root of the declared promoter source files; uses dnadesign-data when omitted.",
+    ),
+    require_association_sources: bool = typer.Option(
+        False,
+        "--require-association-sources",
+        help="Fail unless promoter-regulator association sources are available.",
+    ),
+    output_format: str = typer.Option("table", "--format", help="Output format: table or json."),
+) -> None:
+    """Publish one complete promoter export without leaving partial output."""
+
+    output_format = output_format.lower()
+    if output_format not in {"table", "json"}:
+        raise typer.BadParameter("--format must be one of: table, json.")
+    resolved_destination = destination.expanduser().resolve()
+    if resolved_destination.exists():
+        console.print(f"Error: Destination already exists: {resolved_destination}")
+        raise typer.Exit(code=1)
+    destination_parent = resolved_destination.parent
+    if not destination_parent.is_dir():
+        console.print(f"Error: Destination parent does not exist: {destination_parent}")
+        raise typer.Exit(code=1)
+    resolved_data_root = data_root.expanduser().resolve() if data_root is not None else None
+    if resolved_data_root is not None and not resolved_data_root.is_dir():
+        console.print(f"Error: Promoter source root does not exist: {resolved_data_root}")
+        raise typer.Exit(code=1)
+
+    staging = Path(tempfile.mkdtemp(prefix=f".{resolved_destination.name}.", dir=destination_parent))
+    try:
+        manifest = export_dnadesign_data_promoter_superset(
+            staging,
+            data_root=resolved_data_root,
+            require_association_sources=require_association_sources,
+        )
+        staging.replace(resolved_destination)
+    except (OSError, RuntimeError, ValueError) as exc:
+        shutil.rmtree(staging, ignore_errors=True)
+        console.print(f"Error: {exc}")
+        raise typer.Exit(code=1) from exc
+
+    payload = {
+        "schema": "cruncher.promoter-export/v1",
+        "status": "ok",
+        "destination": str(resolved_destination),
+        "complete": manifest.complete,
+        "record_count": manifest.record_count,
+    }
+    if output_format == "json":
+        typer.echo(json.dumps(payload, indent=2, sort_keys=True))
+        return
+    console.print(
+        f"Promoter export written to {resolved_destination} "
+        f"({manifest.record_count} records; complete={manifest.complete})."
+    )
 
 
 @app.command("summary", help="Summarize local cache and remote inventories for sources.")

--- a/src/dnadesign/cruncher/src/ingest/promoter_filesystem.py
+++ b/src/dnadesign/cruncher/src/ingest/promoter_filesystem.py
@@ -1,4 +1,13 @@
-"""Discover parseable promoter sources from an explicit data repository root."""
+"""
+--------------------------------------------------------------------------------
+dnadesign
+src/dnadesign/cruncher/src/ingest/promoter_filesystem.py
+
+Discover parseable promoter sources from an explicit data repository root.
+
+Module Author(s): Eric J. South
+--------------------------------------------------------------------------------
+"""
 
 from __future__ import annotations
 

--- a/src/dnadesign/cruncher/src/ingest/promoter_filesystem.py
+++ b/src/dnadesign/cruncher/src/ingest/promoter_filesystem.py
@@ -1,0 +1,108 @@
+"""Discover parseable promoter sources from an explicit data repository root."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from .promoter_contracts import PromoterAssociationSourceFile, PromoterSourceFile
+
+
+def iter_promoter_source_files(root: Path | None) -> tuple[PromoterSourceFile, ...]:
+    """Return one parseable promoter table per declared RegulonDB release."""
+
+    data_root = _require_root(root)
+    by_release: dict[str, list[Path]] = {}
+    pattern = "sources/databases/regulondb/*/promoters/PromoterSet.*"
+    for candidate in sorted(data_root.glob(pattern)):
+        if candidate.is_file() and candidate.suffix.lower() in {".csv", ".tsv"}:
+            by_release.setdefault(candidate.parent.parent.name, []).append(candidate)
+
+    sources = []
+    for release in sorted(by_release, key=_release_key, reverse=True):
+        candidates = sorted(by_release[release], key=lambda path: (path.suffix.lower() != ".tsv", path.name))
+        selected = candidates[0]
+        file_format = selected.suffix.lower().removeprefix(".")
+        sources.append(
+            PromoterSourceFile(
+                source_id=f"regulondb_{_release_id(release)}_promoter_set",
+                source="regulondb",
+                release=release,
+                path=selected.relative_to(data_root).as_posix(),
+                table=selected.name,
+                stratum="local_release_pinned_curated",
+                role="curated_base",
+                file_format=file_format,
+                parser_hint="regulondb_promoter_set",
+                creates_base_rows=True,
+            )
+        )
+    return tuple(sources)
+
+
+def iter_promoter_association_source_files(root: Path | None) -> tuple[PromoterAssociationSourceFile, ...]:
+    """Prefer the newest direct TF-promoter table, then historical network tables."""
+
+    data_root = _require_root(root)
+    direct = sorted(
+        (path for path in data_root.glob("sources/databases/regulondb/*/binding_sites/TF-RISet.tsv") if path.is_file()),
+        key=lambda path: _release_key(path.parent.parent.name),
+        reverse=True,
+    )
+    if direct:
+        selected = direct[0]
+        release = selected.parent.parent.name
+        return (
+            PromoterAssociationSourceFile(
+                source_id=f"regulondb_{_release_id(release)}_tf_riset",
+                source="regulondb",
+                release=release,
+                path=selected.relative_to(data_root).as_posix(),
+                table=selected.name,
+                stratum="current_curated_regulatory_interaction",
+                role="tf_promoter_association_overlay",
+                file_format="tsv",
+                parser_hint="regulondb_tf_riset",
+            ),
+        )
+
+    historical = []
+    for path in sorted(data_root.glob("sources/databases/regulondb/*/network_associations/network_tf_tu.txt")):
+        if not path.is_file():
+            continue
+        release = path.parent.parent.name
+        historical.append(
+            PromoterAssociationSourceFile(
+                source_id=f"regulondb_{_release_id(release)}_network_tf_tu",
+                source="regulondb",
+                release=release,
+                path=path.relative_to(data_root).as_posix(),
+                table=path.name,
+                stratum="historical_curated_network_association",
+                role="tf_promoter_association_overlay",
+                file_format="tsv",
+                parser_hint="regulondb_network_tf_tu",
+            )
+        )
+    return tuple(historical)
+
+
+def _require_root(root: Path | None) -> Path:
+    if root is None:
+        raise ValueError("filesystem promoter discovery requires an explicit data root")
+    data_root = Path(root).expanduser().resolve()
+    if not data_root.is_dir():
+        raise ValueError(f"promoter data root does not exist: {data_root}")
+    return data_root
+
+
+def _release_id(release: str) -> str:
+    normalized = re.sub(r"[^a-z0-9]+", "_", release.lower()).strip("_")
+    return normalized.removesuffix("_0")
+
+
+def _release_key(release: str) -> tuple[tuple[int, int | str], ...]:
+    return tuple((0, int(part)) if part.isdigit() else (1, part.lower()) for part in re.split(r"[._-]", release))
+
+
+__all__ = ["iter_promoter_association_source_files", "iter_promoter_source_files"]

--- a/src/dnadesign/cruncher/src/ingest/promoters.py
+++ b/src/dnadesign/cruncher/src/ingest/promoters.py
@@ -47,6 +47,10 @@ from .promoter_contracts import (
     SourceProvenance,
     TranscriptionUnitRef,
 )
+from .promoter_filesystem import (
+    iter_promoter_association_source_files as iter_filesystem_promoter_association_sources,
+)
+from .promoter_filesystem import iter_promoter_source_files as iter_filesystem_promoter_sources
 from .promoter_payloads import (
     _float_or_none,
     _list_payload,
@@ -345,6 +349,9 @@ def export_dnadesign_data_promoter_superset(
     """
 
     resolved_root = _resolve_dnadesign_data_root(data_root)
+    if data_root is not None:
+        provider = provider or iter_filesystem_promoter_sources
+        association_provider = association_provider or iter_filesystem_promoter_association_sources
     sources = discover_dnadesign_data_promoter_sources(data_root=resolved_root, provider=provider)
     association_sources = discover_dnadesign_data_promoter_association_sources(
         data_root=resolved_root,

--- a/src/dnadesign/cruncher/tests/cli/test_local_source_cli.py
+++ b/src/dnadesign/cruncher/tests/cli/test_local_source_cli.py
@@ -147,3 +147,49 @@ def test_sources_materialize_promoters_rejects_incomplete_manifest(
     assert "promoter export is incomplete (2 route failures; 1 sequence conflicts)" in result.output
     assert not destination.exists()
     assert list(tmp_path.glob(".promoter-export.*")) == []
+
+
+def test_sources_materialize_promoters_never_replaces_destination_created_during_export(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    destination = tmp_path / "promoter-export"
+
+    def _materialize(staging: Path, **_kwargs):
+        (staging / "manifest.json").write_text("{}\n", encoding="utf-8")
+        destination.mkdir()
+        (destination / "keep.txt").write_text("keep\n", encoding="utf-8")
+        inventory = SimpleNamespace(route_failure_count=0, conflict_count=0)
+        return SimpleNamespace(complete=True, record_count=12, source_inventory=inventory)
+
+    monkeypatch.setattr(
+        "dnadesign.cruncher.cli.commands.sources.export_dnadesign_data_promoter_superset",
+        _materialize,
+    )
+
+    result = runner.invoke(app, ["sources", "materialize-promoters", str(destination)])
+
+    assert result.exit_code == 1
+    assert "publication is create-only" in result.output
+    assert (destination / "keep.txt").read_text(encoding="utf-8") == "keep\n"
+
+
+def test_sources_materialize_promoters_reports_staging_preparation_failure(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    destination = tmp_path / "promoter-export"
+
+    def _fail(_destination: Path):
+        raise OSError("staging is unavailable")
+
+    monkeypatch.setattr(
+        "dnadesign.cruncher.cli.commands.sources.CreateOnlyDirectoryPublication.prepare",
+        _fail,
+    )
+
+    result = runner.invoke(app, ["sources", "materialize-promoters", str(destination)])
+
+    assert result.exit_code == 1
+    assert "staging is unavailable" in result.output
+    assert not destination.exists()

--- a/src/dnadesign/cruncher/tests/cli/test_local_source_cli.py
+++ b/src/dnadesign/cruncher/tests/cli/test_local_source_cli.py
@@ -9,7 +9,9 @@ Module Author(s): Eric J. South
 --------------------------------------------------------------------------------
 """
 
+import json
 from pathlib import Path
+from types import SimpleNamespace
 
 import yaml
 from typer.testing import CliRunner
@@ -43,3 +45,81 @@ def test_sources_list_includes_local_sources(tmp_path: Path) -> None:
     result = runner.invoke(app, ["sources", "list", str(config_path)])
     assert result.exit_code == 0
     assert "local_omalle" in result.output
+
+
+def test_sources_materialize_promoters_publishes_complete_export(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    data_root = tmp_path / "source-data"
+    data_root.mkdir()
+    destination = tmp_path / "promoter-export"
+
+    def _materialize(staging: Path, **kwargs):
+        assert kwargs == {
+            "data_root": data_root,
+            "require_association_sources": True,
+        }
+        (staging / "manifest.json").write_text("{}\n", encoding="utf-8")
+        return SimpleNamespace(complete=True, record_count=12)
+
+    monkeypatch.setattr(
+        "dnadesign.cruncher.cli.commands.sources.export_dnadesign_data_promoter_superset",
+        _materialize,
+    )
+
+    result = runner.invoke(
+        app,
+        [
+            "sources",
+            "materialize-promoters",
+            str(destination),
+            "--data-root",
+            str(data_root),
+            "--require-association-sources",
+            "--format",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert json.loads(result.output) == {
+        "complete": True,
+        "destination": str(destination),
+        "record_count": 12,
+        "schema": "cruncher.promoter-export/v1",
+        "status": "ok",
+    }
+    assert (destination / "manifest.json").is_file()
+
+
+def test_sources_materialize_promoters_rejects_existing_destination(tmp_path: Path) -> None:
+    destination = tmp_path / "promoter-export"
+    destination.mkdir()
+
+    result = runner.invoke(app, ["sources", "materialize-promoters", str(destination)])
+
+    assert result.exit_code == 1
+    assert "Destination already exists" in result.output
+
+
+def test_sources_materialize_promoters_removes_failed_staging_directory(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    destination = tmp_path / "promoter-export"
+
+    def _fail(_staging: Path, **_kwargs):
+        raise ValueError("invalid source inventory")
+
+    monkeypatch.setattr(
+        "dnadesign.cruncher.cli.commands.sources.export_dnadesign_data_promoter_superset",
+        _fail,
+    )
+
+    result = runner.invoke(app, ["sources", "materialize-promoters", str(destination)])
+
+    assert result.exit_code == 1
+    assert "invalid source inventory" in result.output
+    assert not destination.exists()
+    assert list(tmp_path.glob(".promoter-export.*")) == []

--- a/src/dnadesign/cruncher/tests/cli/test_local_source_cli.py
+++ b/src/dnadesign/cruncher/tests/cli/test_local_source_cli.py
@@ -123,3 +123,27 @@ def test_sources_materialize_promoters_removes_failed_staging_directory(
     assert "invalid source inventory" in result.output
     assert not destination.exists()
     assert list(tmp_path.glob(".promoter-export.*")) == []
+
+
+def test_sources_materialize_promoters_rejects_incomplete_manifest(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    destination = tmp_path / "promoter-export"
+
+    def _materialize(staging: Path, **_kwargs):
+        (staging / "manifest.json").write_text("{}\n", encoding="utf-8")
+        inventory = SimpleNamespace(route_failure_count=2, conflict_count=1)
+        return SimpleNamespace(complete=False, record_count=12, source_inventory=inventory)
+
+    monkeypatch.setattr(
+        "dnadesign.cruncher.cli.commands.sources.export_dnadesign_data_promoter_superset",
+        _materialize,
+    )
+
+    result = runner.invoke(app, ["sources", "materialize-promoters", str(destination)])
+
+    assert result.exit_code == 1
+    assert "promoter export is incomplete (2 route failures; 1 sequence conflicts)" in result.output
+    assert not destination.exists()
+    assert list(tmp_path.glob(".promoter-export.*")) == []

--- a/src/dnadesign/cruncher/tests/cli/test_local_source_cli.py
+++ b/src/dnadesign/cruncher/tests/cli/test_local_source_cli.py
@@ -21,6 +21,42 @@ from dnadesign.cruncher.cli.app import app
 runner = CliRunner()
 
 
+def _write_promoter_source_fixture(data_root: Path) -> None:
+    release = data_root / "sources/databases/regulondb/13.0"
+    promoter_set = release / "promoters/PromoterSet.tsv"
+    promoter_set.parent.mkdir(parents=True)
+    promoter_set.write_text(
+        "\n".join(
+            [
+                "1)pmId\t2)pmName\t3)strand\t4)posTSS\t5)sigmaFactor\t6)pmSequence\t"
+                "7)firstGeneName\t8)pmEvidence\t9)confidenceLevel",
+                "PM1\trecAp\tforward\t100\tsigma70\tAACCGGTTAACC\trecA\t[EXP]\tS",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    association_set = release / "binding_sites/TF-RISet.tsv"
+    association_set.parent.mkdir()
+    association_set.write_text(
+        "\n".join(
+            [
+                "1)riId\t2)riType\t3)regulatorId\t4)regulatorName\t5)cnfName\t6)tfrsID\t"
+                "7)tfrsLeft\t8)tfrsRight\t9)strand\t10)tfrsSeq\t11)riFunction\t"
+                "12)promoterID\t13)promoterName\t14)tss\t15)sigmaF\t16)tfrsDistToPm\t"
+                "17)firstGene\t18)tfrsDistTo1Gene\t19)targetTuOrGene\t20)confidenceLevel\t"
+                "21)tfrsEvidence\t22)riEvidence\t23)addEvidence\t24)riEvTech\t25)riEvCategory\t"
+                "26)tfrsPMIDS\t27)riPMIDS",
+                "RI0001\ttf-promoter\tREG0001\tLexA\tLexA\tBS0001\t10\t20\tforward\t"
+                "ACGT\trepressor\tPM1\trecAp\t100\tsigma70\t-50\trecA\t-80\tTU0001:recA\tS\t"
+                "EXP:S\tEXP:S\t\tbinding\texpression\t12345\t12345",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
 def test_sources_list_includes_local_sources(tmp_path: Path) -> None:
     config = {
         "cruncher": {
@@ -91,6 +127,38 @@ def test_sources_materialize_promoters_publishes_complete_export(
         "status": "ok",
     }
     assert (destination / "manifest.json").is_file()
+
+
+def test_sources_materialize_promoters_reads_an_explicit_root_without_sibling_package(tmp_path: Path) -> None:
+    data_root = tmp_path / "source-data"
+    destination = tmp_path / "promoter-export"
+    _write_promoter_source_fixture(data_root)
+
+    result = runner.invoke(
+        app,
+        [
+            "sources",
+            "materialize-promoters",
+            str(destination),
+            "--data-root",
+            str(data_root),
+            "--require-association-sources",
+            "--format",
+            "json",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["complete"] is True
+    assert payload["record_count"] == 1
+    assert json.loads((destination / "source_files.json").read_text(encoding="utf-8"))[0]["source_id"] == (
+        "regulondb_13_promoter_set"
+    )
+    assert (
+        json.loads((destination / "association_source_files.json").read_text(encoding="utf-8"))[0]["source_id"]
+        == "regulondb_13_tf_riset"
+    )
 
 
 def test_sources_materialize_promoters_rejects_existing_destination(tmp_path: Path) -> None:

--- a/src/dnadesign/cruncher/tests/ingest/test_promoter_filesystem.py
+++ b/src/dnadesign/cruncher/tests/ingest/test_promoter_filesystem.py
@@ -1,0 +1,43 @@
+"""Filesystem-backed promoter source discovery."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from dnadesign.cruncher.ingest.promoter_filesystem import (
+    iter_promoter_association_source_files,
+    iter_promoter_source_files,
+)
+
+
+def test_explicit_root_discovers_parseable_promoter_and_association_sources(tmp_path: Path) -> None:
+    current = tmp_path / "sources/databases/regulondb/13.0"
+    historical = tmp_path / "sources/databases/regulondb/11.0"
+    (current / "promoters").mkdir(parents=True)
+    (current / "promoters/PromoterSet.tsv").write_text("header\n", encoding="utf-8")
+    (current / "binding_sites").mkdir()
+    (current / "binding_sites/TF-RISet.tsv").write_text("header\n", encoding="utf-8")
+    (historical / "promoters").mkdir(parents=True)
+    (historical / "promoters/PromoterSet.csv").write_text("header\n", encoding="utf-8")
+    (historical / "network_associations").mkdir()
+    (historical / "network_associations/network_tf_tu.txt").write_text("row\n", encoding="utf-8")
+
+    sources = iter_promoter_source_files(tmp_path)
+    associations = iter_promoter_association_source_files(tmp_path)
+
+    assert [source.source_id for source in sources] == [
+        "regulondb_13_promoter_set",
+        "regulondb_11_promoter_set",
+    ]
+    assert [source.file_format for source in sources] == ["tsv", "csv"]
+    assert [source.source_id for source in associations] == ["regulondb_13_tf_riset"]
+
+
+def test_explicit_root_falls_back_to_historical_association_sources(tmp_path: Path) -> None:
+    network = tmp_path / "sources/databases/regulondb/11.0/network_associations/network_tf_tu.txt"
+    network.parent.mkdir(parents=True)
+    network.write_text("row\n", encoding="utf-8")
+
+    associations = iter_promoter_association_source_files(tmp_path)
+
+    assert [source.source_id for source in associations] == ["regulondb_11_network_tf_tu"]

--- a/src/dnadesign/cruncher/tests/ingest/test_promoter_filesystem.py
+++ b/src/dnadesign/cruncher/tests/ingest/test_promoter_filesystem.py
@@ -1,4 +1,13 @@
-"""Filesystem-backed promoter source discovery."""
+"""
+--------------------------------------------------------------------------------
+dnadesign
+src/dnadesign/cruncher/tests/ingest/test_promoter_filesystem.py
+
+Regression tests for filesystem-backed promoter source discovery.
+
+Module Author(s): Eric J. South
+--------------------------------------------------------------------------------
+"""
 
 from __future__ import annotations
 

--- a/uv.lock
+++ b/uv.lock
@@ -597,7 +597,7 @@ requires-dist = [
     { name = "vegafusion", specifier = ">=2.0.3" },
     { name = "viennarna", specifier = ">=2.7.2" },
     { name = "vl-convert-python", specifier = ">=1.9.0" },
-    { name = "wheel", marker = "platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'infer-evo2'", specifier = ">=0.46.2" },
+    { name = "wheel", marker = "platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'infer-evo2'", specifier = ">=0.47.0" },
     { name = "xlrd" },
     { name = "zstd", specifier = ">=1.5.7.2,!=1.5.7.3" },
 ]
@@ -2799,14 +2799,14 @@ wheels = [
 
 [[package]]
 name = "wheel"
-version = "0.46.3"
+version = "0.47.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "packaging", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/89/24/a2eb353a6edac9a0303977c4cb048134959dd2a51b48a269dfc9dde00c8a/wheel-0.46.3.tar.gz", hash = "sha256:e3e79874b07d776c40bd6033f8ddf76a7dad46a7b8aa1b2787a83083519a1803", size = 60605, upload-time = "2026-01-22T12:39:49.136Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/39/62/75f18a0f03b4219c456652c7780e4d749b929eb605c098ce3a5b6b6bc081/wheel-0.47.0.tar.gz", hash = "sha256:cc72bd1009ba0cf63922e28f94d9d83b920aa2bb28f798a31d0691b02fa3c9b3", size = 63854, upload-time = "2026-04-22T15:51:27.727Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/22/b76d483683216dde3d67cba61fb2444be8d5be289bf628c13fc0fd90e5f9/wheel-0.46.3-py3-none-any.whl", hash = "sha256:4b399d56c9d9338230118d705d9737a2a468ccca63d5e813e2a4fc7815d8bc4d", size = 30557, upload-time = "2026-01-22T12:39:48.099Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1b/9e33c09813d65e248f7f773119148a612516a4bea93e9c6f545f78455b7c/wheel-0.47.0-py3-none-any.whl", hash = "sha256:212281cab4dff978f6cedd499cd893e1f620791ca6ff7107cf270781e587eced", size = 32218, upload-time = "2026-04-22T15:51:26.296Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- expose `cruncher sources materialize-promoters` for provenance-qualified promoter exports
- stage exports atomically and reject existing destinations or invalid source roots
- add success, collision, and failed-publication regression coverage
- update the wheel lower bound to 0.47.0 with a consistent uv lockfile

## Why
The private RegulonDB study declared Cruncher as the producer of its promoter export, but the installed CLI only exposed a consumer-side USR import. This adds the missing tool-owned producer seam without moving study semantics into dnadesign. It also supersedes Dependabot PR #76, whose regenerated branch did not update `uv.lock` and therefore failed every locked CI lane.

## Verification
- `uv run pytest -q src/dnadesign/cruncher/tests`
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run python -m dnadesign.devtools.architecture.boundaries --repo-root .`
- `uv run python -m dnadesign.devtools.docs.checks`
- `uv lock --check`
- `uv sync --locked --group test`
- `uv build`