### PR TITLE
Harden Junction dissimilarity labels

### DIFF
--- a/src/dnadesign/junction/docs/assets/sequence-dissimilarity.svg
+++ b/src/dnadesign/junction/docs/assets/sequence-dissimilarity.svg
@@ -4661,1254 +4661,1038 @@ L 651.445875 311.22
    <g id="matplotlib.axis_4">
     <g id="ytick_13">
      <g id="line2d_37"/>
-     <g id="text_182">
-      <!-- junction-0001 -->
-      <g style="fill: #24313d" transform="translate(373.076547 91.807336) scale(0.085 -0.085)">
-       <use xlink:href="#DejaVuSans-6a"/>
-       <use xlink:href="#DejaVuSans-75" transform="translate(27.783203 0)"/>
-       <use xlink:href="#DejaVuSans-6e" transform="translate(91.162109 0)"/>
-       <use xlink:href="#DejaVuSans-63" transform="translate(154.541016 0)"/>
-       <use xlink:href="#DejaVuSans-74" transform="translate(209.521484 0)"/>
-       <use xlink:href="#DejaVuSans-69" transform="translate(248.730469 0)"/>
-       <use xlink:href="#DejaVuSans-6f" transform="translate(276.513672 0)"/>
-       <use xlink:href="#DejaVuSans-6e" transform="translate(337.695312 0)"/>
-       <use xlink:href="#DejaVuSans-2d" transform="translate(401.074219 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(437.158203 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(500.78125 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(564.404297 0)"/>
-       <use xlink:href="#DejaVuSans-31" transform="translate(628.027344 0)"/>
-      </g>
-     </g>
     </g>
     <g id="ytick_14">
      <g id="line2d_38"/>
-     <g id="text_183">
-      <!-- junction-0002 -->
-      <g style="fill: #24313d" transform="translate(373.076547 113.011336) scale(0.085 -0.085)">
-       <use xlink:href="#DejaVuSans-6a"/>
-       <use xlink:href="#DejaVuSans-75" transform="translate(27.783203 0)"/>
-       <use xlink:href="#DejaVuSans-6e" transform="translate(91.162109 0)"/>
-       <use xlink:href="#DejaVuSans-63" transform="translate(154.541016 0)"/>
-       <use xlink:href="#DejaVuSans-74" transform="translate(209.521484 0)"/>
-       <use xlink:href="#DejaVuSans-69" transform="translate(248.730469 0)"/>
-       <use xlink:href="#DejaVuSans-6f" transform="translate(276.513672 0)"/>
-       <use xlink:href="#DejaVuSans-6e" transform="translate(337.695312 0)"/>
-       <use xlink:href="#DejaVuSans-2d" transform="translate(401.074219 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(437.158203 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(500.78125 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(564.404297 0)"/>
-       <use xlink:href="#DejaVuSans-32" transform="translate(628.027344 0)"/>
-      </g>
-     </g>
     </g>
     <g id="ytick_15">
      <g id="line2d_39"/>
-     <g id="text_184">
-      <!-- junction-0003 -->
-      <g style="fill: #24313d" transform="translate(373.076547 134.215336) scale(0.085 -0.085)">
-       <use xlink:href="#DejaVuSans-6a"/>
-       <use xlink:href="#DejaVuSans-75" transform="translate(27.783203 0)"/>
-       <use xlink:href="#DejaVuSans-6e" transform="translate(91.162109 0)"/>
-       <use xlink:href="#DejaVuSans-63" transform="translate(154.541016 0)"/>
-       <use xlink:href="#DejaVuSans-74" transform="translate(209.521484 0)"/>
-       <use xlink:href="#DejaVuSans-69" transform="translate(248.730469 0)"/>
-       <use xlink:href="#DejaVuSans-6f" transform="translate(276.513672 0)"/>
-       <use xlink:href="#DejaVuSans-6e" transform="translate(337.695312 0)"/>
-       <use xlink:href="#DejaVuSans-2d" transform="translate(401.074219 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(437.158203 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(500.78125 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(564.404297 0)"/>
-       <use xlink:href="#DejaVuSans-33" transform="translate(628.027344 0)"/>
-      </g>
-     </g>
     </g>
     <g id="ytick_16">
      <g id="line2d_40"/>
-     <g id="text_185">
-      <!-- junction-0004 -->
-      <g style="fill: #24313d" transform="translate(373.076547 155.419336) scale(0.085 -0.085)">
-       <use xlink:href="#DejaVuSans-6a"/>
-       <use xlink:href="#DejaVuSans-75" transform="translate(27.783203 0)"/>
-       <use xlink:href="#DejaVuSans-6e" transform="translate(91.162109 0)"/>
-       <use xlink:href="#DejaVuSans-63" transform="translate(154.541016 0)"/>
-       <use xlink:href="#DejaVuSans-74" transform="translate(209.521484 0)"/>
-       <use xlink:href="#DejaVuSans-69" transform="translate(248.730469 0)"/>
-       <use xlink:href="#DejaVuSans-6f" transform="translate(276.513672 0)"/>
-       <use xlink:href="#DejaVuSans-6e" transform="translate(337.695312 0)"/>
-       <use xlink:href="#DejaVuSans-2d" transform="translate(401.074219 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(437.158203 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(500.78125 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(564.404297 0)"/>
-       <use xlink:href="#DejaVuSans-34" transform="translate(628.027344 0)"/>
-      </g>
-     </g>
     </g>
     <g id="ytick_17">
      <g id="line2d_41"/>
-     <g id="text_186">
-      <!-- junction-0005 -->
-      <g style="fill: #24313d" transform="translate(373.076547 176.623336) scale(0.085 -0.085)">
-       <use xlink:href="#DejaVuSans-6a"/>
-       <use xlink:href="#DejaVuSans-75" transform="translate(27.783203 0)"/>
-       <use xlink:href="#DejaVuSans-6e" transform="translate(91.162109 0)"/>
-       <use xlink:href="#DejaVuSans-63" transform="translate(154.541016 0)"/>
-       <use xlink:href="#DejaVuSans-74" transform="translate(209.521484 0)"/>
-       <use xlink:href="#DejaVuSans-69" transform="translate(248.730469 0)"/>
-       <use xlink:href="#DejaVuSans-6f" transform="translate(276.513672 0)"/>
-       <use xlink:href="#DejaVuSans-6e" transform="translate(337.695312 0)"/>
-       <use xlink:href="#DejaVuSans-2d" transform="translate(401.074219 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(437.158203 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(500.78125 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(564.404297 0)"/>
-       <use xlink:href="#DejaVuSans-35" transform="translate(628.027344 0)"/>
-      </g>
-     </g>
     </g>
     <g id="ytick_18">
      <g id="line2d_42"/>
-     <g id="text_187">
-      <!-- junction-0006 -->
-      <g style="fill: #24313d" transform="translate(373.076547 197.827336) scale(0.085 -0.085)">
-       <use xlink:href="#DejaVuSans-6a"/>
-       <use xlink:href="#DejaVuSans-75" transform="translate(27.783203 0)"/>
-       <use xlink:href="#DejaVuSans-6e" transform="translate(91.162109 0)"/>
-       <use xlink:href="#DejaVuSans-63" transform="translate(154.541016 0)"/>
-       <use xlink:href="#DejaVuSans-74" transform="translate(209.521484 0)"/>
-       <use xlink:href="#DejaVuSans-69" transform="translate(248.730469 0)"/>
-       <use xlink:href="#DejaVuSans-6f" transform="translate(276.513672 0)"/>
-       <use xlink:href="#DejaVuSans-6e" transform="translate(337.695312 0)"/>
-       <use xlink:href="#DejaVuSans-2d" transform="translate(401.074219 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(437.158203 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(500.78125 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(564.404297 0)"/>
-       <use xlink:href="#DejaVuSans-36" transform="translate(628.027344 0)"/>
-      </g>
-     </g>
     </g>
     <g id="ytick_19">
      <g id="line2d_43"/>
-     <g id="text_188">
-      <!-- junction-0007 -->
-      <g style="fill: #24313d" transform="translate(373.076547 219.031336) scale(0.085 -0.085)">
-       <use xlink:href="#DejaVuSans-6a"/>
-       <use xlink:href="#DejaVuSans-75" transform="translate(27.783203 0)"/>
-       <use xlink:href="#DejaVuSans-6e" transform="translate(91.162109 0)"/>
-       <use xlink:href="#DejaVuSans-63" transform="translate(154.541016 0)"/>
-       <use xlink:href="#DejaVuSans-74" transform="translate(209.521484 0)"/>
-       <use xlink:href="#DejaVuSans-69" transform="translate(248.730469 0)"/>
-       <use xlink:href="#DejaVuSans-6f" transform="translate(276.513672 0)"/>
-       <use xlink:href="#DejaVuSans-6e" transform="translate(337.695312 0)"/>
-       <use xlink:href="#DejaVuSans-2d" transform="translate(401.074219 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(437.158203 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(500.78125 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(564.404297 0)"/>
-       <use xlink:href="#DejaVuSans-37" transform="translate(628.027344 0)"/>
-      </g>
-     </g>
     </g>
     <g id="ytick_20">
      <g id="line2d_44"/>
-     <g id="text_189">
-      <!-- junction-0008 -->
-      <g style="fill: #24313d" transform="translate(373.076547 240.235336) scale(0.085 -0.085)">
-       <use xlink:href="#DejaVuSans-6a"/>
-       <use xlink:href="#DejaVuSans-75" transform="translate(27.783203 0)"/>
-       <use xlink:href="#DejaVuSans-6e" transform="translate(91.162109 0)"/>
-       <use xlink:href="#DejaVuSans-63" transform="translate(154.541016 0)"/>
-       <use xlink:href="#DejaVuSans-74" transform="translate(209.521484 0)"/>
-       <use xlink:href="#DejaVuSans-69" transform="translate(248.730469 0)"/>
-       <use xlink:href="#DejaVuSans-6f" transform="translate(276.513672 0)"/>
-       <use xlink:href="#DejaVuSans-6e" transform="translate(337.695312 0)"/>
-       <use xlink:href="#DejaVuSans-2d" transform="translate(401.074219 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(437.158203 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(500.78125 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(564.404297 0)"/>
-       <use xlink:href="#DejaVuSans-38" transform="translate(628.027344 0)"/>
-      </g>
-     </g>
     </g>
     <g id="ytick_21">
      <g id="line2d_45"/>
-     <g id="text_190">
-      <!-- junction-0009 -->
-      <g style="fill: #24313d" transform="translate(373.076547 261.439336) scale(0.085 -0.085)">
-       <use xlink:href="#DejaVuSans-6a"/>
-       <use xlink:href="#DejaVuSans-75" transform="translate(27.783203 0)"/>
-       <use xlink:href="#DejaVuSans-6e" transform="translate(91.162109 0)"/>
-       <use xlink:href="#DejaVuSans-63" transform="translate(154.541016 0)"/>
-       <use xlink:href="#DejaVuSans-74" transform="translate(209.521484 0)"/>
-       <use xlink:href="#DejaVuSans-69" transform="translate(248.730469 0)"/>
-       <use xlink:href="#DejaVuSans-6f" transform="translate(276.513672 0)"/>
-       <use xlink:href="#DejaVuSans-6e" transform="translate(337.695312 0)"/>
-       <use xlink:href="#DejaVuSans-2d" transform="translate(401.074219 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(437.158203 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(500.78125 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(564.404297 0)"/>
-       <use xlink:href="#DejaVuSans-39" transform="translate(628.027344 0)"/>
-      </g>
-     </g>
     </g>
     <g id="ytick_22">
      <g id="line2d_46"/>
-     <g id="text_191">
-      <!-- junction-0010 -->
-      <g style="fill: #24313d" transform="translate(373.076547 282.643336) scale(0.085 -0.085)">
-       <use xlink:href="#DejaVuSans-6a"/>
-       <use xlink:href="#DejaVuSans-75" transform="translate(27.783203 0)"/>
-       <use xlink:href="#DejaVuSans-6e" transform="translate(91.162109 0)"/>
-       <use xlink:href="#DejaVuSans-63" transform="translate(154.541016 0)"/>
-       <use xlink:href="#DejaVuSans-74" transform="translate(209.521484 0)"/>
-       <use xlink:href="#DejaVuSans-69" transform="translate(248.730469 0)"/>
-       <use xlink:href="#DejaVuSans-6f" transform="translate(276.513672 0)"/>
-       <use xlink:href="#DejaVuSans-6e" transform="translate(337.695312 0)"/>
-       <use xlink:href="#DejaVuSans-2d" transform="translate(401.074219 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(437.158203 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(500.78125 0)"/>
-       <use xlink:href="#DejaVuSans-31" transform="translate(564.404297 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(628.027344 0)"/>
-      </g>
-     </g>
     </g>
     <g id="ytick_23">
      <g id="line2d_47"/>
-     <g id="text_192">
-      <!-- junction-0011 -->
-      <g style="fill: #24313d" transform="translate(373.076547 303.847336) scale(0.085 -0.085)">
-       <use xlink:href="#DejaVuSans-6a"/>
-       <use xlink:href="#DejaVuSans-75" transform="translate(27.783203 0)"/>
-       <use xlink:href="#DejaVuSans-6e" transform="translate(91.162109 0)"/>
-       <use xlink:href="#DejaVuSans-63" transform="translate(154.541016 0)"/>
-       <use xlink:href="#DejaVuSans-74" transform="translate(209.521484 0)"/>
-       <use xlink:href="#DejaVuSans-69" transform="translate(248.730469 0)"/>
-       <use xlink:href="#DejaVuSans-6f" transform="translate(276.513672 0)"/>
-       <use xlink:href="#DejaVuSans-6e" transform="translate(337.695312 0)"/>
-       <use xlink:href="#DejaVuSans-2d" transform="translate(401.074219 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(437.158203 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(500.78125 0)"/>
-       <use xlink:href="#DejaVuSans-31" transform="translate(564.404297 0)"/>
-       <use xlink:href="#DejaVuSans-31" transform="translate(628.027344 0)"/>
-      </g>
-     </g>
     </g>
     <g id="ytick_24">
      <g id="line2d_48"/>
-     <g id="text_193">
-      <!-- junction-0012 -->
-      <g style="fill: #24313d" transform="translate(373.076547 325.051336) scale(0.085 -0.085)">
-       <use xlink:href="#DejaVuSans-6a"/>
-       <use xlink:href="#DejaVuSans-75" transform="translate(27.783203 0)"/>
-       <use xlink:href="#DejaVuSans-6e" transform="translate(91.162109 0)"/>
-       <use xlink:href="#DejaVuSans-63" transform="translate(154.541016 0)"/>
-       <use xlink:href="#DejaVuSans-74" transform="translate(209.521484 0)"/>
-       <use xlink:href="#DejaVuSans-69" transform="translate(248.730469 0)"/>
-       <use xlink:href="#DejaVuSans-6f" transform="translate(276.513672 0)"/>
-       <use xlink:href="#DejaVuSans-6e" transform="translate(337.695312 0)"/>
-       <use xlink:href="#DejaVuSans-2d" transform="translate(401.074219 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(437.158203 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(500.78125 0)"/>
-       <use xlink:href="#DejaVuSans-31" transform="translate(564.404297 0)"/>
-       <use xlink:href="#DejaVuSans-32" transform="translate(628.027344 0)"/>
-      </g>
-     </g>
     </g>
    </g>
-   <g id="text_194">
+   <g id="text_182">
     <!-- — -->
     <g style="fill: #24313d" transform="translate(440.937812 90.923469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-2014"/>
     </g>
    </g>
-   <g id="text_195">
+   <g id="text_183">
     <!-- 15 -->
     <g style="fill: #24313d" transform="translate(459.423312 90.923469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_196">
+   <g id="text_184">
     <!-- 12 -->
     <g style="fill: #24313d" transform="translate(479.066937 90.923469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_197">
+   <g id="text_185">
     <!-- 14 -->
     <g style="fill: #24313d" transform="translate(498.710562 90.923469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_198">
+   <g id="text_186">
     <!-- 15 -->
     <g style="fill: #24313d" transform="translate(518.354187 90.923469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_199">
+   <g id="text_187">
     <!-- 16 -->
     <g style="fill: #24313d" transform="translate(537.997812 90.923469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_200">
+   <g id="text_188">
     <!-- 14 -->
     <g style="fill: #24313d" transform="translate(557.641437 90.923469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_201">
+   <g id="text_189">
     <!-- 14 -->
     <g style="fill: #24313d" transform="translate(577.285062 90.923469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_202">
+   <g id="text_190">
     <!-- 14 -->
     <g style="fill: #24313d" transform="translate(596.928687 90.923469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_203">
+   <g id="text_191">
     <!-- 14 -->
     <g style="fill: #24313d" transform="translate(616.572312 90.923469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_204">
+   <g id="text_192">
     <!-- 13 -->
     <g style="fill: #24313d" transform="translate(636.215937 90.923469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_205">
+   <g id="text_193">
     <!-- 12 -->
     <g style="fill: #24313d" transform="translate(655.859562 90.923469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_206">
+   <g id="text_194">
     <!-- 15 -->
     <g style="fill: #24313d" transform="translate(439.779687 112.127469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_207">
+   <g id="text_195">
     <!-- — -->
     <g style="fill: #24313d" transform="translate(460.581437 112.127469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-2014"/>
     </g>
    </g>
-   <g id="text_208">
+   <g id="text_196">
     <!-- 13 -->
     <g style="fill: #24313d" transform="translate(479.066937 112.127469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_209">
+   <g id="text_197">
     <!-- 13 -->
     <g style="fill: #24313d" transform="translate(498.710562 112.127469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_210">
+   <g id="text_198">
     <!-- 16 -->
     <g style="fill: #24313d" transform="translate(518.354187 112.127469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_211">
+   <g id="text_199">
     <!-- 11 -->
     <g style="fill: #24313d" transform="translate(537.997812 112.127469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_212">
+   <g id="text_200">
     <!-- 13 -->
     <g style="fill: #24313d" transform="translate(557.641437 112.127469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_213">
+   <g id="text_201">
     <!-- 14 -->
     <g style="fill: #24313d" transform="translate(577.285062 112.127469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_214">
+   <g id="text_202">
     <!-- 13 -->
     <g style="fill: #24313d" transform="translate(596.928687 112.127469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_215">
+   <g id="text_203">
     <!-- 13 -->
     <g style="fill: #24313d" transform="translate(616.572312 112.127469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_216">
+   <g id="text_204">
     <!-- 15 -->
     <g style="fill: #24313d" transform="translate(636.215937 112.127469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_217">
+   <g id="text_205">
     <!-- 13 -->
     <g style="fill: #24313d" transform="translate(655.859562 112.127469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_218">
+   <g id="text_206">
     <!-- 12 -->
     <g style="fill: #24313d" transform="translate(439.779687 133.331469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_219">
+   <g id="text_207">
     <!-- 13 -->
     <g style="fill: #24313d" transform="translate(459.423312 133.331469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_220">
+   <g id="text_208">
     <!-- — -->
     <g style="fill: #24313d" transform="translate(480.225062 133.331469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-2014"/>
     </g>
    </g>
-   <g id="text_221">
+   <g id="text_209">
     <!-- 13 -->
     <g style="fill: #24313d" transform="translate(498.710562 133.331469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_222">
+   <g id="text_210">
     <!-- 13 -->
     <g style="fill: #24313d" transform="translate(518.354187 133.331469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_223">
+   <g id="text_211">
     <!-- 14 -->
     <g style="fill: #24313d" transform="translate(537.997812 133.331469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_224">
+   <g id="text_212">
     <!-- 14 -->
     <g style="fill: #24313d" transform="translate(557.641437 133.331469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_225">
+   <g id="text_213">
     <!-- 17 -->
     <g style="fill: #24313d" transform="translate(577.285062 133.331469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_226">
+   <g id="text_214">
     <!-- 15 -->
     <g style="fill: #24313d" transform="translate(596.928687 133.331469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_227">
+   <g id="text_215">
     <!-- 14 -->
     <g style="fill: #24313d" transform="translate(616.572312 133.331469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_228">
+   <g id="text_216">
     <!-- 17 -->
     <g style="fill: #24313d" transform="translate(636.215937 133.331469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_229">
+   <g id="text_217">
     <!-- 13 -->
     <g style="fill: #24313d" transform="translate(655.859562 133.331469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_230">
+   <g id="text_218">
     <!-- 14 -->
     <g style="fill: #24313d" transform="translate(439.779687 154.535469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_231">
+   <g id="text_219">
     <!-- 13 -->
     <g style="fill: #24313d" transform="translate(459.423312 154.535469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_232">
+   <g id="text_220">
     <!-- 13 -->
     <g style="fill: #24313d" transform="translate(479.066937 154.535469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_233">
+   <g id="text_221">
     <!-- — -->
     <g style="fill: #24313d" transform="translate(499.868687 154.535469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-2014"/>
     </g>
    </g>
-   <g id="text_234">
+   <g id="text_222">
     <!-- 13 -->
     <g style="fill: #24313d" transform="translate(518.354187 154.535469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_235">
+   <g id="text_223">
     <!-- 13 -->
     <g style="fill: #24313d" transform="translate(537.997812 154.535469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_236">
+   <g id="text_224">
     <!-- 16 -->
     <g style="fill: #24313d" transform="translate(557.641437 154.535469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_237">
+   <g id="text_225">
     <!-- 15 -->
     <g style="fill: #24313d" transform="translate(577.285062 154.535469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_238">
+   <g id="text_226">
     <!-- 12 -->
     <g style="fill: #24313d" transform="translate(596.928687 154.535469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_239">
+   <g id="text_227">
     <!-- 15 -->
     <g style="fill: #24313d" transform="translate(616.572312 154.535469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_240">
+   <g id="text_228">
     <!-- 13 -->
     <g style="fill: #24313d" transform="translate(636.215937 154.535469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_241">
+   <g id="text_229">
     <!-- 15 -->
     <g style="fill: #24313d" transform="translate(655.859562 154.535469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_242">
+   <g id="text_230">
     <!-- 15 -->
     <g style="fill: #24313d" transform="translate(439.779687 175.739469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_243">
+   <g id="text_231">
     <!-- 16 -->
     <g style="fill: #24313d" transform="translate(459.423312 175.739469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_244">
+   <g id="text_232">
     <!-- 13 -->
     <g style="fill: #24313d" transform="translate(479.066937 175.739469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_245">
+   <g id="text_233">
     <!-- 13 -->
     <g style="fill: #24313d" transform="translate(498.710562 175.739469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_246">
+   <g id="text_234">
     <!-- — -->
     <g style="fill: #24313d" transform="translate(519.512312 175.739469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-2014"/>
     </g>
    </g>
-   <g id="text_247">
+   <g id="text_235">
     <!-- 14 -->
     <g style="fill: #24313d" transform="translate(537.997812 175.739469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_248">
+   <g id="text_236">
     <!-- 14 -->
     <g style="fill: #24313d" transform="translate(557.641437 175.739469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_249">
+   <g id="text_237">
     <!-- 13 -->
     <g style="fill: #24313d" transform="translate(577.285062 175.739469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_250">
+   <g id="text_238">
     <!-- 13 -->
     <g style="fill: #24313d" transform="translate(596.928687 175.739469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_251">
+   <g id="text_239">
     <!-- 15 -->
     <g style="fill: #24313d" transform="translate(616.572312 175.739469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_252">
+   <g id="text_240">
     <!-- 14 -->
     <g style="fill: #24313d" transform="translate(636.215937 175.739469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_253">
+   <g id="text_241">
     <!-- 15 -->
     <g style="fill: #24313d" transform="translate(655.859562 175.739469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_254">
+   <g id="text_242">
     <!-- 16 -->
     <g style="fill: #24313d" transform="translate(439.779687 196.943469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_255">
+   <g id="text_243">
     <!-- 11 -->
     <g style="fill: #24313d" transform="translate(459.423312 196.943469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_256">
+   <g id="text_244">
     <!-- 14 -->
     <g style="fill: #24313d" transform="translate(479.066937 196.943469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_257">
+   <g id="text_245">
     <!-- 13 -->
     <g style="fill: #24313d" transform="translate(498.710562 196.943469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_258">
+   <g id="text_246">
     <!-- 14 -->
     <g style="fill: #24313d" transform="translate(518.354187 196.943469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_259">
+   <g id="text_247">
     <!-- — -->
     <g style="fill: #24313d" transform="translate(539.155937 196.943469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-2014"/>
     </g>
    </g>
-   <g id="text_260">
+   <g id="text_248">
     <!-- 12 -->
     <g style="fill: #24313d" transform="translate(557.641437 196.943469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_261">
+   <g id="text_249">
     <!-- 13 -->
     <g style="fill: #24313d" transform="translate(577.285062 196.943469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_262">
+   <g id="text_250">
     <!-- 15 -->
     <g style="fill: #24313d" transform="translate(596.928687 196.943469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_263">
+   <g id="text_251">
     <!-- 14 -->
     <g style="fill: #24313d" transform="translate(616.572312 196.943469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_264">
+   <g id="text_252">
     <!-- 14 -->
     <g style="fill: #24313d" transform="translate(636.215937 196.943469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_265">
+   <g id="text_253">
     <!-- 13 -->
     <g style="fill: #24313d" transform="translate(655.859562 196.943469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_266">
+   <g id="text_254">
     <!-- 14 -->
     <g style="fill: #24313d" transform="translate(439.779687 218.147469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_267">
+   <g id="text_255">
     <!-- 13 -->
     <g style="fill: #24313d" transform="translate(459.423312 218.147469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_268">
+   <g id="text_256">
     <!-- 14 -->
     <g style="fill: #24313d" transform="translate(479.066937 218.147469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_269">
+   <g id="text_257">
     <!-- 16 -->
     <g style="fill: #24313d" transform="translate(498.710562 218.147469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_270">
+   <g id="text_258">
     <!-- 14 -->
     <g style="fill: #24313d" transform="translate(518.354187 218.147469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_271">
+   <g id="text_259">
     <!-- 12 -->
     <g style="fill: #24313d" transform="translate(537.997812 218.147469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_272">
+   <g id="text_260">
     <!-- — -->
     <g style="fill: #24313d" transform="translate(558.799562 218.147469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-2014"/>
     </g>
    </g>
-   <g id="text_273">
+   <g id="text_261">
     <!-- 15 -->
     <g style="fill: #24313d" transform="translate(577.285062 218.147469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_274">
+   <g id="text_262">
     <!-- 16 -->
     <g style="fill: #24313d" transform="translate(596.928687 218.147469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_275">
+   <g id="text_263">
     <!-- 13 -->
     <g style="fill: #24313d" transform="translate(616.572312 218.147469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_276">
+   <g id="text_264">
     <!-- 16 -->
     <g style="fill: #24313d" transform="translate(636.215937 218.147469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_277">
+   <g id="text_265">
     <!-- 15 -->
     <g style="fill: #24313d" transform="translate(655.859562 218.147469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_278">
+   <g id="text_266">
     <!-- 14 -->
     <g style="fill: #24313d" transform="translate(439.779687 239.351469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_279">
+   <g id="text_267">
     <!-- 14 -->
     <g style="fill: #24313d" transform="translate(459.423312 239.351469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_280">
+   <g id="text_268">
     <!-- 17 -->
     <g style="fill: #24313d" transform="translate(479.066937 239.351469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_281">
+   <g id="text_269">
     <!-- 15 -->
     <g style="fill: #24313d" transform="translate(498.710562 239.351469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_282">
+   <g id="text_270">
     <!-- 13 -->
     <g style="fill: #24313d" transform="translate(518.354187 239.351469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_283">
+   <g id="text_271">
     <!-- 13 -->
     <g style="fill: #24313d" transform="translate(537.997812 239.351469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_284">
+   <g id="text_272">
     <!-- 15 -->
     <g style="fill: #24313d" transform="translate(557.641437 239.351469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_285">
+   <g id="text_273">
     <!-- — -->
     <g style="fill: #24313d" transform="translate(578.443187 239.351469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-2014"/>
     </g>
    </g>
-   <g id="text_286">
+   <g id="text_274">
     <!-- 11 -->
     <g style="fill: #24313d" transform="translate(596.928687 239.351469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_287">
+   <g id="text_275">
     <!-- 14 -->
     <g style="fill: #24313d" transform="translate(616.572312 239.351469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_288">
+   <g id="text_276">
     <!-- 12 -->
     <g style="fill: #24313d" transform="translate(636.215937 239.351469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_289">
+   <g id="text_277">
     <!-- 12 -->
     <g style="fill: #24313d" transform="translate(655.859562 239.351469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_290">
+   <g id="text_278">
     <!-- 14 -->
     <g style="fill: #24313d" transform="translate(439.779687 260.555469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_291">
+   <g id="text_279">
     <!-- 13 -->
     <g style="fill: #24313d" transform="translate(459.423312 260.555469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_292">
+   <g id="text_280">
     <!-- 15 -->
     <g style="fill: #24313d" transform="translate(479.066937 260.555469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_293">
+   <g id="text_281">
     <!-- 12 -->
     <g style="fill: #24313d" transform="translate(498.710562 260.555469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_294">
+   <g id="text_282">
     <!-- 13 -->
     <g style="fill: #24313d" transform="translate(518.354187 260.555469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_295">
+   <g id="text_283">
     <!-- 15 -->
     <g style="fill: #24313d" transform="translate(537.997812 260.555469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_296">
+   <g id="text_284">
     <!-- 16 -->
     <g style="fill: #24313d" transform="translate(557.641437 260.555469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_297">
+   <g id="text_285">
     <!-- 11 -->
     <g style="fill: #24313d" transform="translate(577.285062 260.555469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_298">
+   <g id="text_286">
     <!-- — -->
     <g style="fill: #24313d" transform="translate(598.086812 260.555469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-2014"/>
     </g>
    </g>
-   <g id="text_299">
+   <g id="text_287">
     <!-- 13 -->
     <g style="fill: #24313d" transform="translate(616.572312 260.555469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_300">
+   <g id="text_288">
     <!-- 13 -->
     <g style="fill: #24313d" transform="translate(636.215937 260.555469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_301">
+   <g id="text_289">
     <!-- 14 -->
     <g style="fill: #24313d" transform="translate(655.859562 260.555469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_302">
+   <g id="text_290">
     <!-- 14 -->
     <g style="fill: #24313d" transform="translate(439.779687 281.759469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_303">
+   <g id="text_291">
     <!-- 13 -->
     <g style="fill: #24313d" transform="translate(459.423312 281.759469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_304">
+   <g id="text_292">
     <!-- 14 -->
     <g style="fill: #24313d" transform="translate(479.066937 281.759469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_305">
+   <g id="text_293">
     <!-- 15 -->
     <g style="fill: #24313d" transform="translate(498.710562 281.759469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_306">
+   <g id="text_294">
     <!-- 15 -->
     <g style="fill: #24313d" transform="translate(518.354187 281.759469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_307">
+   <g id="text_295">
     <!-- 14 -->
     <g style="fill: #24313d" transform="translate(537.997812 281.759469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_308">
+   <g id="text_296">
     <!-- 13 -->
     <g style="fill: #24313d" transform="translate(557.641437 281.759469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_309">
+   <g id="text_297">
     <!-- 14 -->
     <g style="fill: #24313d" transform="translate(577.285062 281.759469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_310">
+   <g id="text_298">
     <!-- 13 -->
     <g style="fill: #24313d" transform="translate(596.928687 281.759469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_311">
+   <g id="text_299">
     <!-- — -->
     <g style="fill: #24313d" transform="translate(617.730437 281.759469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-2014"/>
     </g>
    </g>
-   <g id="text_312">
+   <g id="text_300">
     <!-- 12 -->
     <g style="fill: #24313d" transform="translate(636.215937 281.759469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_313">
+   <g id="text_301">
     <!-- 11 -->
     <g style="fill: #24313d" transform="translate(655.859562 281.759469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_314">
+   <g id="text_302">
     <!-- 13 -->
     <g style="fill: #24313d" transform="translate(439.779687 302.963469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_315">
+   <g id="text_303">
     <!-- 15 -->
     <g style="fill: #24313d" transform="translate(459.423312 302.963469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_316">
+   <g id="text_304">
     <!-- 17 -->
     <g style="fill: #24313d" transform="translate(479.066937 302.963469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-37" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_317">
+   <g id="text_305">
     <!-- 13 -->
     <g style="fill: #24313d" transform="translate(498.710562 302.963469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_318">
+   <g id="text_306">
     <!-- 14 -->
     <g style="fill: #24313d" transform="translate(518.354187 302.963469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_319">
+   <g id="text_307">
     <!-- 14 -->
     <g style="fill: #24313d" transform="translate(537.997812 302.963469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_320">
+   <g id="text_308">
     <!-- 16 -->
     <g style="fill: #24313d" transform="translate(557.641437 302.963469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-36" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_321">
+   <g id="text_309">
     <!-- 12 -->
     <g style="fill: #24313d" transform="translate(577.285062 302.963469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_322">
+   <g id="text_310">
     <!-- 13 -->
     <g style="fill: #24313d" transform="translate(596.928687 302.963469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_323">
+   <g id="text_311">
     <!-- 12 -->
     <g style="fill: #24313d" transform="translate(616.572312 302.963469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_324">
+   <g id="text_312">
     <!-- — -->
     <g style="fill: #24313d" transform="translate(637.374062 302.963469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-2014"/>
     </g>
    </g>
-   <g id="text_325">
+   <g id="text_313">
     <!-- 11 -->
     <g style="fill: #24313d" transform="translate(655.859562 302.963469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_326">
+   <g id="text_314">
     <!-- 12 -->
     <g style="fill: #24313d" transform="translate(439.779687 324.167469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_327">
+   <g id="text_315">
     <!-- 13 -->
     <g style="fill: #24313d" transform="translate(459.423312 324.167469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_328">
+   <g id="text_316">
     <!-- 13 -->
     <g style="fill: #24313d" transform="translate(479.066937 324.167469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_329">
+   <g id="text_317">
     <!-- 15 -->
     <g style="fill: #24313d" transform="translate(498.710562 324.167469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_330">
+   <g id="text_318">
     <!-- 15 -->
     <g style="fill: #24313d" transform="translate(518.354187 324.167469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_331">
+   <g id="text_319">
     <!-- 13 -->
     <g style="fill: #24313d" transform="translate(537.997812 324.167469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-33" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_332">
+   <g id="text_320">
     <!-- 15 -->
     <g style="fill: #24313d" transform="translate(557.641437 324.167469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-35" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_333">
+   <g id="text_321">
     <!-- 12 -->
     <g style="fill: #24313d" transform="translate(577.285062 324.167469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-32" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_334">
+   <g id="text_322">
     <!-- 14 -->
     <g style="fill: #24313d" transform="translate(596.928687 324.167469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-34" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_335">
+   <g id="text_323">
     <!-- 11 -->
     <g style="fill: #24313d" transform="translate(616.572312 324.167469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_336">
+   <g id="text_324">
     <!-- 11 -->
     <g style="fill: #24313d" transform="translate(636.215937 324.167469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-31"/>
      <use xlink:href="#DejaVuSans-31" transform="translate(63.623047 0)"/>
     </g>
    </g>
-   <g id="text_337">
+   <g id="text_325">
     <!-- — -->
     <g style="fill: #24313d" transform="translate(657.017687 324.167469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-2014"/>
     </g>
    </g>
-   <g id="text_338">
+   <g id="text_326">
     <!-- Barcodes -->
     <g style="fill: #24313d" transform="translate(523.195719 51.418844) scale(0.13 -0.13)">
      <defs>
@@ -6894,7 +6678,7 @@ L 1015.675875 311.22
    <g id="matplotlib.axis_5">
     <g id="xtick_25">
      <g id="line2d_49"/>
-     <g id="text_339">
+     <g id="text_327">
       <!-- junction-0001 -->
       <g style="fill: #24313d" transform="translate(780.988202 387.786043) rotate(-55) scale(0.085 -0.085)">
        <use xlink:href="#DejaVuSans-6a"/>
@@ -6915,7 +6699,7 @@ L 1015.675875 311.22
     </g>
     <g id="xtick_26">
      <g id="line2d_50"/>
-     <g id="text_340">
+     <g id="text_328">
       <!-- junction-0002 -->
       <g style="fill: #24313d" transform="translate(800.631827 387.786043) rotate(-55) scale(0.085 -0.085)">
        <use xlink:href="#DejaVuSans-6a"/>
@@ -6936,7 +6720,7 @@ L 1015.675875 311.22
     </g>
     <g id="xtick_27">
      <g id="line2d_51"/>
-     <g id="text_341">
+     <g id="text_329">
       <!-- junction-0003 -->
       <g style="fill: #24313d" transform="translate(820.275452 387.786043) rotate(-55) scale(0.085 -0.085)">
        <use xlink:href="#DejaVuSans-6a"/>
@@ -6957,7 +6741,7 @@ L 1015.675875 311.22
     </g>
     <g id="xtick_28">
      <g id="line2d_52"/>
-     <g id="text_342">
+     <g id="text_330">
       <!-- junction-0004 -->
       <g style="fill: #24313d" transform="translate(839.919077 387.786043) rotate(-55) scale(0.085 -0.085)">
        <use xlink:href="#DejaVuSans-6a"/>
@@ -6978,7 +6762,7 @@ L 1015.675875 311.22
     </g>
     <g id="xtick_29">
      <g id="line2d_53"/>
-     <g id="text_343">
+     <g id="text_331">
       <!-- junction-0005 -->
       <g style="fill: #24313d" transform="translate(859.562702 387.786043) rotate(-55) scale(0.085 -0.085)">
        <use xlink:href="#DejaVuSans-6a"/>
@@ -6999,7 +6783,7 @@ L 1015.675875 311.22
     </g>
     <g id="xtick_30">
      <g id="line2d_54"/>
-     <g id="text_344">
+     <g id="text_332">
       <!-- junction-0006 -->
       <g style="fill: #24313d" transform="translate(879.206327 387.786043) rotate(-55) scale(0.085 -0.085)">
        <use xlink:href="#DejaVuSans-6a"/>
@@ -7020,7 +6804,7 @@ L 1015.675875 311.22
     </g>
     <g id="xtick_31">
      <g id="line2d_55"/>
-     <g id="text_345">
+     <g id="text_333">
       <!-- junction-0007 -->
       <g style="fill: #24313d" transform="translate(898.849952 387.786043) rotate(-55) scale(0.085 -0.085)">
        <use xlink:href="#DejaVuSans-6a"/>
@@ -7041,7 +6825,7 @@ L 1015.675875 311.22
     </g>
     <g id="xtick_32">
      <g id="line2d_56"/>
-     <g id="text_346">
+     <g id="text_334">
       <!-- junction-0008 -->
       <g style="fill: #24313d" transform="translate(918.493577 387.786043) rotate(-55) scale(0.085 -0.085)">
        <use xlink:href="#DejaVuSans-6a"/>
@@ -7062,7 +6846,7 @@ L 1015.675875 311.22
     </g>
     <g id="xtick_33">
      <g id="line2d_57"/>
-     <g id="text_347">
+     <g id="text_335">
       <!-- junction-0009 -->
       <g style="fill: #24313d" transform="translate(938.137202 387.786043) rotate(-55) scale(0.085 -0.085)">
        <use xlink:href="#DejaVuSans-6a"/>
@@ -7083,7 +6867,7 @@ L 1015.675875 311.22
     </g>
     <g id="xtick_34">
      <g id="line2d_58"/>
-     <g id="text_348">
+     <g id="text_336">
       <!-- junction-0010 -->
       <g style="fill: #24313d" transform="translate(957.780827 387.786043) rotate(-55) scale(0.085 -0.085)">
        <use xlink:href="#DejaVuSans-6a"/>
@@ -7104,7 +6888,7 @@ L 1015.675875 311.22
     </g>
     <g id="xtick_35">
      <g id="line2d_59"/>
-     <g id="text_349">
+     <g id="text_337">
       <!-- junction-0011 -->
       <g style="fill: #24313d" transform="translate(977.424452 387.786043) rotate(-55) scale(0.085 -0.085)">
        <use xlink:href="#DejaVuSans-6a"/>
@@ -7125,7 +6909,7 @@ L 1015.675875 311.22
     </g>
     <g id="xtick_36">
      <g id="line2d_60"/>
-     <g id="text_350">
+     <g id="text_338">
       <!-- junction-0012 -->
       <g style="fill: #24313d" transform="translate(997.068077 387.786043) rotate(-55) scale(0.085 -0.085)">
        <use xlink:href="#DejaVuSans-6a"/>
@@ -7148,1122 +6932,906 @@ L 1015.675875 311.22
    <g id="matplotlib.axis_6">
     <g id="ytick_25">
      <g id="line2d_61"/>
-     <g id="text_351">
-      <!-- junction-0001 -->
-      <g style="fill: #24313d" transform="translate(737.306547 91.807336) scale(0.085 -0.085)">
-       <use xlink:href="#DejaVuSans-6a"/>
-       <use xlink:href="#DejaVuSans-75" transform="translate(27.783203 0)"/>
-       <use xlink:href="#DejaVuSans-6e" transform="translate(91.162109 0)"/>
-       <use xlink:href="#DejaVuSans-63" transform="translate(154.541016 0)"/>
-       <use xlink:href="#DejaVuSans-74" transform="translate(209.521484 0)"/>
-       <use xlink:href="#DejaVuSans-69" transform="translate(248.730469 0)"/>
-       <use xlink:href="#DejaVuSans-6f" transform="translate(276.513672 0)"/>
-       <use xlink:href="#DejaVuSans-6e" transform="translate(337.695312 0)"/>
-       <use xlink:href="#DejaVuSans-2d" transform="translate(401.074219 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(437.158203 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(500.78125 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(564.404297 0)"/>
-       <use xlink:href="#DejaVuSans-31" transform="translate(628.027344 0)"/>
-      </g>
-     </g>
     </g>
     <g id="ytick_26">
      <g id="line2d_62"/>
-     <g id="text_352">
-      <!-- junction-0002 -->
-      <g style="fill: #24313d" transform="translate(737.306547 113.011336) scale(0.085 -0.085)">
-       <use xlink:href="#DejaVuSans-6a"/>
-       <use xlink:href="#DejaVuSans-75" transform="translate(27.783203 0)"/>
-       <use xlink:href="#DejaVuSans-6e" transform="translate(91.162109 0)"/>
-       <use xlink:href="#DejaVuSans-63" transform="translate(154.541016 0)"/>
-       <use xlink:href="#DejaVuSans-74" transform="translate(209.521484 0)"/>
-       <use xlink:href="#DejaVuSans-69" transform="translate(248.730469 0)"/>
-       <use xlink:href="#DejaVuSans-6f" transform="translate(276.513672 0)"/>
-       <use xlink:href="#DejaVuSans-6e" transform="translate(337.695312 0)"/>
-       <use xlink:href="#DejaVuSans-2d" transform="translate(401.074219 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(437.158203 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(500.78125 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(564.404297 0)"/>
-       <use xlink:href="#DejaVuSans-32" transform="translate(628.027344 0)"/>
-      </g>
-     </g>
     </g>
     <g id="ytick_27">
      <g id="line2d_63"/>
-     <g id="text_353">
-      <!-- junction-0003 -->
-      <g style="fill: #24313d" transform="translate(737.306547 134.215336) scale(0.085 -0.085)">
-       <use xlink:href="#DejaVuSans-6a"/>
-       <use xlink:href="#DejaVuSans-75" transform="translate(27.783203 0)"/>
-       <use xlink:href="#DejaVuSans-6e" transform="translate(91.162109 0)"/>
-       <use xlink:href="#DejaVuSans-63" transform="translate(154.541016 0)"/>
-       <use xlink:href="#DejaVuSans-74" transform="translate(209.521484 0)"/>
-       <use xlink:href="#DejaVuSans-69" transform="translate(248.730469 0)"/>
-       <use xlink:href="#DejaVuSans-6f" transform="translate(276.513672 0)"/>
-       <use xlink:href="#DejaVuSans-6e" transform="translate(337.695312 0)"/>
-       <use xlink:href="#DejaVuSans-2d" transform="translate(401.074219 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(437.158203 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(500.78125 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(564.404297 0)"/>
-       <use xlink:href="#DejaVuSans-33" transform="translate(628.027344 0)"/>
-      </g>
-     </g>
     </g>
     <g id="ytick_28">
      <g id="line2d_64"/>
-     <g id="text_354">
-      <!-- junction-0004 -->
-      <g style="fill: #24313d" transform="translate(737.306547 155.419336) scale(0.085 -0.085)">
-       <use xlink:href="#DejaVuSans-6a"/>
-       <use xlink:href="#DejaVuSans-75" transform="translate(27.783203 0)"/>
-       <use xlink:href="#DejaVuSans-6e" transform="translate(91.162109 0)"/>
-       <use xlink:href="#DejaVuSans-63" transform="translate(154.541016 0)"/>
-       <use xlink:href="#DejaVuSans-74" transform="translate(209.521484 0)"/>
-       <use xlink:href="#DejaVuSans-69" transform="translate(248.730469 0)"/>
-       <use xlink:href="#DejaVuSans-6f" transform="translate(276.513672 0)"/>
-       <use xlink:href="#DejaVuSans-6e" transform="translate(337.695312 0)"/>
-       <use xlink:href="#DejaVuSans-2d" transform="translate(401.074219 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(437.158203 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(500.78125 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(564.404297 0)"/>
-       <use xlink:href="#DejaVuSans-34" transform="translate(628.027344 0)"/>
-      </g>
-     </g>
     </g>
     <g id="ytick_29">
      <g id="line2d_65"/>
-     <g id="text_355">
-      <!-- junction-0005 -->
-      <g style="fill: #24313d" transform="translate(737.306547 176.623336) scale(0.085 -0.085)">
-       <use xlink:href="#DejaVuSans-6a"/>
-       <use xlink:href="#DejaVuSans-75" transform="translate(27.783203 0)"/>
-       <use xlink:href="#DejaVuSans-6e" transform="translate(91.162109 0)"/>
-       <use xlink:href="#DejaVuSans-63" transform="translate(154.541016 0)"/>
-       <use xlink:href="#DejaVuSans-74" transform="translate(209.521484 0)"/>
-       <use xlink:href="#DejaVuSans-69" transform="translate(248.730469 0)"/>
-       <use xlink:href="#DejaVuSans-6f" transform="translate(276.513672 0)"/>
-       <use xlink:href="#DejaVuSans-6e" transform="translate(337.695312 0)"/>
-       <use xlink:href="#DejaVuSans-2d" transform="translate(401.074219 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(437.158203 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(500.78125 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(564.404297 0)"/>
-       <use xlink:href="#DejaVuSans-35" transform="translate(628.027344 0)"/>
-      </g>
-     </g>
     </g>
     <g id="ytick_30">
      <g id="line2d_66"/>
-     <g id="text_356">
-      <!-- junction-0006 -->
-      <g style="fill: #24313d" transform="translate(737.306547 197.827336) scale(0.085 -0.085)">
-       <use xlink:href="#DejaVuSans-6a"/>
-       <use xlink:href="#DejaVuSans-75" transform="translate(27.783203 0)"/>
-       <use xlink:href="#DejaVuSans-6e" transform="translate(91.162109 0)"/>
-       <use xlink:href="#DejaVuSans-63" transform="translate(154.541016 0)"/>
-       <use xlink:href="#DejaVuSans-74" transform="translate(209.521484 0)"/>
-       <use xlink:href="#DejaVuSans-69" transform="translate(248.730469 0)"/>
-       <use xlink:href="#DejaVuSans-6f" transform="translate(276.513672 0)"/>
-       <use xlink:href="#DejaVuSans-6e" transform="translate(337.695312 0)"/>
-       <use xlink:href="#DejaVuSans-2d" transform="translate(401.074219 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(437.158203 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(500.78125 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(564.404297 0)"/>
-       <use xlink:href="#DejaVuSans-36" transform="translate(628.027344 0)"/>
-      </g>
-     </g>
     </g>
     <g id="ytick_31">
      <g id="line2d_67"/>
-     <g id="text_357">
-      <!-- junction-0007 -->
-      <g style="fill: #24313d" transform="translate(737.306547 219.031336) scale(0.085 -0.085)">
-       <use xlink:href="#DejaVuSans-6a"/>
-       <use xlink:href="#DejaVuSans-75" transform="translate(27.783203 0)"/>
-       <use xlink:href="#DejaVuSans-6e" transform="translate(91.162109 0)"/>
-       <use xlink:href="#DejaVuSans-63" transform="translate(154.541016 0)"/>
-       <use xlink:href="#DejaVuSans-74" transform="translate(209.521484 0)"/>
-       <use xlink:href="#DejaVuSans-69" transform="translate(248.730469 0)"/>
-       <use xlink:href="#DejaVuSans-6f" transform="translate(276.513672 0)"/>
-       <use xlink:href="#DejaVuSans-6e" transform="translate(337.695312 0)"/>
-       <use xlink:href="#DejaVuSans-2d" transform="translate(401.074219 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(437.158203 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(500.78125 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(564.404297 0)"/>
-       <use xlink:href="#DejaVuSans-37" transform="translate(628.027344 0)"/>
-      </g>
-     </g>
     </g>
     <g id="ytick_32">
      <g id="line2d_68"/>
-     <g id="text_358">
-      <!-- junction-0008 -->
-      <g style="fill: #24313d" transform="translate(737.306547 240.235336) scale(0.085 -0.085)">
-       <use xlink:href="#DejaVuSans-6a"/>
-       <use xlink:href="#DejaVuSans-75" transform="translate(27.783203 0)"/>
-       <use xlink:href="#DejaVuSans-6e" transform="translate(91.162109 0)"/>
-       <use xlink:href="#DejaVuSans-63" transform="translate(154.541016 0)"/>
-       <use xlink:href="#DejaVuSans-74" transform="translate(209.521484 0)"/>
-       <use xlink:href="#DejaVuSans-69" transform="translate(248.730469 0)"/>
-       <use xlink:href="#DejaVuSans-6f" transform="translate(276.513672 0)"/>
-       <use xlink:href="#DejaVuSans-6e" transform="translate(337.695312 0)"/>
-       <use xlink:href="#DejaVuSans-2d" transform="translate(401.074219 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(437.158203 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(500.78125 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(564.404297 0)"/>
-       <use xlink:href="#DejaVuSans-38" transform="translate(628.027344 0)"/>
-      </g>
-     </g>
     </g>
     <g id="ytick_33">
      <g id="line2d_69"/>
-     <g id="text_359">
-      <!-- junction-0009 -->
-      <g style="fill: #24313d" transform="translate(737.306547 261.439336) scale(0.085 -0.085)">
-       <use xlink:href="#DejaVuSans-6a"/>
-       <use xlink:href="#DejaVuSans-75" transform="translate(27.783203 0)"/>
-       <use xlink:href="#DejaVuSans-6e" transform="translate(91.162109 0)"/>
-       <use xlink:href="#DejaVuSans-63" transform="translate(154.541016 0)"/>
-       <use xlink:href="#DejaVuSans-74" transform="translate(209.521484 0)"/>
-       <use xlink:href="#DejaVuSans-69" transform="translate(248.730469 0)"/>
-       <use xlink:href="#DejaVuSans-6f" transform="translate(276.513672 0)"/>
-       <use xlink:href="#DejaVuSans-6e" transform="translate(337.695312 0)"/>
-       <use xlink:href="#DejaVuSans-2d" transform="translate(401.074219 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(437.158203 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(500.78125 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(564.404297 0)"/>
-       <use xlink:href="#DejaVuSans-39" transform="translate(628.027344 0)"/>
-      </g>
-     </g>
     </g>
     <g id="ytick_34">
      <g id="line2d_70"/>
-     <g id="text_360">
-      <!-- junction-0010 -->
-      <g style="fill: #24313d" transform="translate(737.306547 282.643336) scale(0.085 -0.085)">
-       <use xlink:href="#DejaVuSans-6a"/>
-       <use xlink:href="#DejaVuSans-75" transform="translate(27.783203 0)"/>
-       <use xlink:href="#DejaVuSans-6e" transform="translate(91.162109 0)"/>
-       <use xlink:href="#DejaVuSans-63" transform="translate(154.541016 0)"/>
-       <use xlink:href="#DejaVuSans-74" transform="translate(209.521484 0)"/>
-       <use xlink:href="#DejaVuSans-69" transform="translate(248.730469 0)"/>
-       <use xlink:href="#DejaVuSans-6f" transform="translate(276.513672 0)"/>
-       <use xlink:href="#DejaVuSans-6e" transform="translate(337.695312 0)"/>
-       <use xlink:href="#DejaVuSans-2d" transform="translate(401.074219 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(437.158203 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(500.78125 0)"/>
-       <use xlink:href="#DejaVuSans-31" transform="translate(564.404297 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(628.027344 0)"/>
-      </g>
-     </g>
     </g>
     <g id="ytick_35">
      <g id="line2d_71"/>
-     <g id="text_361">
-      <!-- junction-0011 -->
-      <g style="fill: #24313d" transform="translate(737.306547 303.847336) scale(0.085 -0.085)">
-       <use xlink:href="#DejaVuSans-6a"/>
-       <use xlink:href="#DejaVuSans-75" transform="translate(27.783203 0)"/>
-       <use xlink:href="#DejaVuSans-6e" transform="translate(91.162109 0)"/>
-       <use xlink:href="#DejaVuSans-63" transform="translate(154.541016 0)"/>
-       <use xlink:href="#DejaVuSans-74" transform="translate(209.521484 0)"/>
-       <use xlink:href="#DejaVuSans-69" transform="translate(248.730469 0)"/>
-       <use xlink:href="#DejaVuSans-6f" transform="translate(276.513672 0)"/>
-       <use xlink:href="#DejaVuSans-6e" transform="translate(337.695312 0)"/>
-       <use xlink:href="#DejaVuSans-2d" transform="translate(401.074219 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(437.158203 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(500.78125 0)"/>
-       <use xlink:href="#DejaVuSans-31" transform="translate(564.404297 0)"/>
-       <use xlink:href="#DejaVuSans-31" transform="translate(628.027344 0)"/>
-      </g>
-     </g>
     </g>
     <g id="ytick_36">
      <g id="line2d_72"/>
-     <g id="text_362">
-      <!-- junction-0012 -->
-      <g style="fill: #24313d" transform="translate(737.306547 325.051336) scale(0.085 -0.085)">
-       <use xlink:href="#DejaVuSans-6a"/>
-       <use xlink:href="#DejaVuSans-75" transform="translate(27.783203 0)"/>
-       <use xlink:href="#DejaVuSans-6e" transform="translate(91.162109 0)"/>
-       <use xlink:href="#DejaVuSans-63" transform="translate(154.541016 0)"/>
-       <use xlink:href="#DejaVuSans-74" transform="translate(209.521484 0)"/>
-       <use xlink:href="#DejaVuSans-69" transform="translate(248.730469 0)"/>
-       <use xlink:href="#DejaVuSans-6f" transform="translate(276.513672 0)"/>
-       <use xlink:href="#DejaVuSans-6e" transform="translate(337.695312 0)"/>
-       <use xlink:href="#DejaVuSans-2d" transform="translate(401.074219 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(437.158203 0)"/>
-       <use xlink:href="#DejaVuSans-30" transform="translate(500.78125 0)"/>
-       <use xlink:href="#DejaVuSans-31" transform="translate(564.404297 0)"/>
-       <use xlink:href="#DejaVuSans-32" transform="translate(628.027344 0)"/>
-      </g>
-     </g>
     </g>
    </g>
-   <g id="text_363">
+   <g id="text_339">
     <!-- — -->
     <g style="fill: #24313d" transform="translate(805.167812 90.923469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-2014"/>
     </g>
    </g>
-   <g id="text_364">
+   <g id="text_340">
     <!-- 4 -->
     <g style="fill: #24313d" transform="translate(826.357375 90.923469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-34"/>
     </g>
    </g>
-   <g id="text_365">
+   <g id="text_341">
     <!-- 4 -->
     <g style="fill: #24313d" transform="translate(846.001 90.923469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-34"/>
     </g>
    </g>
-   <g id="text_366">
+   <g id="text_342">
     <!-- 6 -->
     <g style="fill: #24313d" transform="translate(865.644625 90.923469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-36"/>
     </g>
    </g>
-   <g id="text_367">
+   <g id="text_343">
     <!-- 4 -->
     <g style="fill: #24313d" transform="translate(885.28825 90.923469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-34"/>
     </g>
    </g>
-   <g id="text_368">
+   <g id="text_344">
     <!-- 4 -->
     <g style="fill: #24313d" transform="translate(904.931875 90.923469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-34"/>
     </g>
    </g>
-   <g id="text_369">
+   <g id="text_345">
     <!-- 4 -->
     <g style="fill: #24313d" transform="translate(924.5755 90.923469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-34"/>
     </g>
    </g>
-   <g id="text_370">
+   <g id="text_346">
     <!-- 4 -->
     <g style="fill: #24313d" transform="translate(944.219125 90.923469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-34"/>
     </g>
    </g>
-   <g id="text_371">
+   <g id="text_347">
     <!-- 4 -->
     <g style="fill: #24313d" transform="translate(963.86275 90.923469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-34"/>
     </g>
    </g>
-   <g id="text_372">
+   <g id="text_348">
     <!-- 5 -->
     <g style="fill: #24313d" transform="translate(983.506375 90.923469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-35"/>
     </g>
    </g>
-   <g id="text_373">
+   <g id="text_349">
     <!-- 4 -->
     <g style="fill: #24313d" transform="translate(1003.15 90.923469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-34"/>
     </g>
    </g>
-   <g id="text_374">
+   <g id="text_350">
     <!-- 4 -->
     <g style="fill: #24313d" transform="translate(1022.793625 90.923469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-34"/>
     </g>
    </g>
-   <g id="text_375">
+   <g id="text_351">
     <!-- 4 -->
     <g style="fill: #24313d" transform="translate(806.71375 112.127469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-34"/>
     </g>
    </g>
-   <g id="text_376">
+   <g id="text_352">
     <!-- — -->
     <g style="fill: #24313d" transform="translate(824.811437 112.127469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-2014"/>
     </g>
    </g>
-   <g id="text_377">
+   <g id="text_353">
     <!-- 4 -->
     <g style="fill: #24313d" transform="translate(846.001 112.127469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-34"/>
     </g>
    </g>
-   <g id="text_378">
+   <g id="text_354">
     <!-- 4 -->
     <g style="fill: #24313d" transform="translate(865.644625 112.127469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-34"/>
     </g>
    </g>
-   <g id="text_379">
+   <g id="text_355">
     <!-- 3 -->
     <g style="fill: #24313d" transform="translate(885.28825 112.127469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-33"/>
     </g>
    </g>
-   <g id="text_380">
+   <g id="text_356">
     <!-- 5 -->
     <g style="fill: #24313d" transform="translate(904.931875 112.127469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-35"/>
     </g>
    </g>
-   <g id="text_381">
+   <g id="text_357">
     <!-- 5 -->
     <g style="fill: #24313d" transform="translate(924.5755 112.127469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-35"/>
     </g>
    </g>
-   <g id="text_382">
+   <g id="text_358">
     <!-- 5 -->
     <g style="fill: #24313d" transform="translate(944.219125 112.127469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-35"/>
     </g>
    </g>
-   <g id="text_383">
+   <g id="text_359">
     <!-- 3 -->
     <g style="fill: #24313d" transform="translate(963.86275 112.127469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-33"/>
     </g>
    </g>
-   <g id="text_384">
+   <g id="text_360">
     <!-- 5 -->
     <g style="fill: #24313d" transform="translate(983.506375 112.127469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-35"/>
     </g>
    </g>
-   <g id="text_385">
+   <g id="text_361">
     <!-- 3 -->
     <g style="fill: #24313d" transform="translate(1003.15 112.127469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-33"/>
     </g>
    </g>
-   <g id="text_386">
+   <g id="text_362">
     <!-- 4 -->
     <g style="fill: #24313d" transform="translate(1022.793625 112.127469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-34"/>
     </g>
    </g>
-   <g id="text_387">
+   <g id="text_363">
     <!-- 4 -->
     <g style="fill: #24313d" transform="translate(806.71375 133.331469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-34"/>
     </g>
    </g>
-   <g id="text_388">
+   <g id="text_364">
     <!-- 4 -->
     <g style="fill: #24313d" transform="translate(826.357375 133.331469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-34"/>
     </g>
    </g>
-   <g id="text_389">
+   <g id="text_365">
     <!-- — -->
     <g style="fill: #24313d" transform="translate(844.455062 133.331469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-2014"/>
     </g>
    </g>
-   <g id="text_390">
+   <g id="text_366">
     <!-- 3 -->
     <g style="fill: #24313d" transform="translate(865.644625 133.331469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-33"/>
     </g>
    </g>
-   <g id="text_391">
+   <g id="text_367">
     <!-- 5 -->
     <g style="fill: #24313d" transform="translate(885.28825 133.331469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-35"/>
     </g>
    </g>
-   <g id="text_392">
+   <g id="text_368">
     <!-- 4 -->
     <g style="fill: #24313d" transform="translate(904.931875 133.331469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-34"/>
     </g>
    </g>
-   <g id="text_393">
+   <g id="text_369">
     <!-- 5 -->
     <g style="fill: #24313d" transform="translate(924.5755 133.331469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-35"/>
     </g>
    </g>
-   <g id="text_394">
+   <g id="text_370">
     <!-- 4 -->
     <g style="fill: #24313d" transform="translate(944.219125 133.331469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-34"/>
     </g>
    </g>
-   <g id="text_395">
+   <g id="text_371">
     <!-- 4 -->
     <g style="fill: #24313d" transform="translate(963.86275 133.331469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-34"/>
     </g>
    </g>
-   <g id="text_396">
+   <g id="text_372">
     <!-- 4 -->
     <g style="fill: #24313d" transform="translate(983.506375 133.331469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-34"/>
     </g>
    </g>
-   <g id="text_397">
+   <g id="text_373">
     <!-- 4 -->
     <g style="fill: #24313d" transform="translate(1003.15 133.331469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-34"/>
     </g>
    </g>
-   <g id="text_398">
+   <g id="text_374">
     <!-- 3 -->
     <g style="fill: #24313d" transform="translate(1022.793625 133.331469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-33"/>
     </g>
    </g>
-   <g id="text_399">
+   <g id="text_375">
     <!-- 6 -->
     <g style="fill: #24313d" transform="translate(806.71375 154.535469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-36"/>
     </g>
    </g>
-   <g id="text_400">
+   <g id="text_376">
     <!-- 4 -->
     <g style="fill: #24313d" transform="translate(826.357375 154.535469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-34"/>
     </g>
    </g>
-   <g id="text_401">
+   <g id="text_377">
     <!-- 3 -->
     <g style="fill: #24313d" transform="translate(846.001 154.535469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-33"/>
     </g>
    </g>
-   <g id="text_402">
+   <g id="text_378">
     <!-- — -->
     <g style="fill: #24313d" transform="translate(864.098687 154.535469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-2014"/>
     </g>
    </g>
-   <g id="text_403">
+   <g id="text_379">
     <!-- 4 -->
     <g style="fill: #24313d" transform="translate(885.28825 154.535469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-34"/>
     </g>
    </g>
-   <g id="text_404">
+   <g id="text_380">
     <!-- 5 -->
     <g style="fill: #24313d" transform="translate(904.931875 154.535469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-35"/>
     </g>
    </g>
-   <g id="text_405">
+   <g id="text_381">
     <!-- 5 -->
     <g style="fill: #24313d" transform="translate(924.5755 154.535469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-35"/>
     </g>
    </g>
-   <g id="text_406">
+   <g id="text_382">
     <!-- 4 -->
     <g style="fill: #24313d" transform="translate(944.219125 154.535469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-34"/>
     </g>
    </g>
-   <g id="text_407">
+   <g id="text_383">
     <!-- 4 -->
     <g style="fill: #24313d" transform="translate(963.86275 154.535469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-34"/>
     </g>
    </g>
-   <g id="text_408">
+   <g id="text_384">
     <!-- 4 -->
     <g style="fill: #24313d" transform="translate(983.506375 154.535469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-34"/>
     </g>
    </g>
-   <g id="text_409">
+   <g id="text_385">
     <!-- 4 -->
     <g style="fill: #24313d" transform="translate(1003.15 154.535469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-34"/>
     </g>
    </g>
-   <g id="text_410">
+   <g id="text_386">
     <!-- 3 -->
     <g style="fill: #24313d" transform="translate(1022.793625 154.535469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-33"/>
     </g>
    </g>
-   <g id="text_411">
+   <g id="text_387">
     <!-- 4 -->
     <g style="fill: #24313d" transform="translate(806.71375 175.739469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-34"/>
     </g>
    </g>
-   <g id="text_412">
+   <g id="text_388">
     <!-- 3 -->
     <g style="fill: #24313d" transform="translate(826.357375 175.739469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-33"/>
     </g>
    </g>
-   <g id="text_413">
+   <g id="text_389">
     <!-- 5 -->
     <g style="fill: #24313d" transform="translate(846.001 175.739469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-35"/>
     </g>
    </g>
-   <g id="text_414">
+   <g id="text_390">
     <!-- 4 -->
     <g style="fill: #24313d" transform="translate(865.644625 175.739469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-34"/>
     </g>
    </g>
-   <g id="text_415">
+   <g id="text_391">
     <!-- — -->
     <g style="fill: #24313d" transform="translate(883.742312 175.739469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-2014"/>
     </g>
    </g>
-   <g id="text_416">
+   <g id="text_392">
     <!-- 5 -->
     <g style="fill: #24313d" transform="translate(904.931875 175.739469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-35"/>
     </g>
    </g>
-   <g id="text_417">
+   <g id="text_393">
     <!-- 5 -->
     <g style="fill: #24313d" transform="translate(924.5755 175.739469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-35"/>
     </g>
    </g>
-   <g id="text_418">
+   <g id="text_394">
     <!-- 3 -->
     <g style="fill: #24313d" transform="translate(944.219125 175.739469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-33"/>
     </g>
    </g>
-   <g id="text_419">
+   <g id="text_395">
     <!-- 5 -->
     <g style="fill: #24313d" transform="translate(963.86275 175.739469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-35"/>
     </g>
    </g>
-   <g id="text_420">
+   <g id="text_396">
     <!-- 5 -->
     <g style="fill: #24313d" transform="translate(983.506375 175.739469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-35"/>
     </g>
    </g>
-   <g id="text_421">
+   <g id="text_397">
     <!-- 4 -->
     <g style="fill: #24313d" transform="translate(1003.15 175.739469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-34"/>
     </g>
    </g>
-   <g id="text_422">
+   <g id="text_398">
     <!-- 5 -->
     <g style="fill: #24313d" transform="translate(1022.793625 175.739469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-35"/>
     </g>
    </g>
-   <g id="text_423">
+   <g id="text_399">
     <!-- 4 -->
     <g style="fill: #24313d" transform="translate(806.71375 196.943469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-34"/>
     </g>
    </g>
-   <g id="text_424">
+   <g id="text_400">
     <!-- 5 -->
     <g style="fill: #24313d" transform="translate(826.357375 196.943469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-35"/>
     </g>
    </g>
-   <g id="text_425">
+   <g id="text_401">
     <!-- 4 -->
     <g style="fill: #24313d" transform="translate(846.001 196.943469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-34"/>
     </g>
    </g>
-   <g id="text_426">
+   <g id="text_402">
     <!-- 5 -->
     <g style="fill: #24313d" transform="translate(865.644625 196.943469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-35"/>
     </g>
    </g>
-   <g id="text_427">
+   <g id="text_403">
     <!-- 5 -->
     <g style="fill: #24313d" transform="translate(885.28825 196.943469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-35"/>
     </g>
    </g>
-   <g id="text_428">
+   <g id="text_404">
     <!-- — -->
     <g style="fill: #24313d" transform="translate(903.385937 196.943469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-2014"/>
     </g>
    </g>
-   <g id="text_429">
+   <g id="text_405">
     <!-- 3 -->
     <g style="fill: #24313d" transform="translate(924.5755 196.943469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-33"/>
     </g>
    </g>
-   <g id="text_430">
+   <g id="text_406">
     <!-- 3 -->
     <g style="fill: #24313d" transform="translate(944.219125 196.943469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-33"/>
     </g>
    </g>
-   <g id="text_431">
+   <g id="text_407">
     <!-- 3 -->
     <g style="fill: #24313d" transform="translate(963.86275 196.943469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-33"/>
     </g>
    </g>
-   <g id="text_432">
+   <g id="text_408">
     <!-- 3 -->
     <g style="fill: #24313d" transform="translate(983.506375 196.943469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-33"/>
     </g>
    </g>
-   <g id="text_433">
+   <g id="text_409">
     <!-- 4 -->
     <g style="fill: #24313d" transform="translate(1003.15 196.943469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-34"/>
     </g>
    </g>
-   <g id="text_434">
+   <g id="text_410">
     <!-- 4 -->
     <g style="fill: #24313d" transform="translate(1022.793625 196.943469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-34"/>
     </g>
    </g>
-   <g id="text_435">
+   <g id="text_411">
     <!-- 4 -->
     <g style="fill: #24313d" transform="translate(806.71375 218.147469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-34"/>
     </g>
    </g>
-   <g id="text_436">
+   <g id="text_412">
     <!-- 5 -->
     <g style="fill: #24313d" transform="translate(826.357375 218.147469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-35"/>
     </g>
    </g>
-   <g id="text_437">
+   <g id="text_413">
     <!-- 5 -->
     <g style="fill: #24313d" transform="translate(846.001 218.147469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-35"/>
     </g>
    </g>
-   <g id="text_438">
+   <g id="text_414">
     <!-- 5 -->
     <g style="fill: #24313d" transform="translate(865.644625 218.147469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-35"/>
     </g>
    </g>
-   <g id="text_439">
+   <g id="text_415">
     <!-- 5 -->
     <g style="fill: #24313d" transform="translate(885.28825 218.147469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-35"/>
     </g>
    </g>
-   <g id="text_440">
+   <g id="text_416">
     <!-- 3 -->
     <g style="fill: #24313d" transform="translate(904.931875 218.147469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-33"/>
     </g>
    </g>
-   <g id="text_441">
+   <g id="text_417">
     <!-- — -->
     <g style="fill: #24313d" transform="translate(923.029562 218.147469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-2014"/>
     </g>
    </g>
-   <g id="text_442">
+   <g id="text_418">
     <!-- 3 -->
     <g style="fill: #24313d" transform="translate(944.219125 218.147469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-33"/>
     </g>
    </g>
-   <g id="text_443">
+   <g id="text_419">
     <!-- 3 -->
     <g style="fill: #24313d" transform="translate(963.86275 218.147469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-33"/>
     </g>
    </g>
-   <g id="text_444">
+   <g id="text_420">
     <!-- 4 -->
     <g style="fill: #24313d" transform="translate(983.506375 218.147469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-34"/>
     </g>
    </g>
-   <g id="text_445">
+   <g id="text_421">
     <!-- 4 -->
     <g style="fill: #24313d" transform="translate(1003.15 218.147469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-34"/>
     </g>
    </g>
-   <g id="text_446">
+   <g id="text_422">
     <!-- 5 -->
     <g style="fill: #24313d" transform="translate(1022.793625 218.147469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-35"/>
     </g>
    </g>
-   <g id="text_447">
+   <g id="text_423">
     <!-- 4 -->
     <g style="fill: #24313d" transform="translate(806.71375 239.351469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-34"/>
     </g>
    </g>
-   <g id="text_448">
+   <g id="text_424">
     <!-- 5 -->
     <g style="fill: #24313d" transform="translate(826.357375 239.351469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-35"/>
     </g>
    </g>
-   <g id="text_449">
+   <g id="text_425">
     <!-- 4 -->
     <g style="fill: #24313d" transform="translate(846.001 239.351469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-34"/>
     </g>
    </g>
-   <g id="text_450">
+   <g id="text_426">
     <!-- 4 -->
     <g style="fill: #24313d" transform="translate(865.644625 239.351469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-34"/>
     </g>
    </g>
-   <g id="text_451">
+   <g id="text_427">
     <!-- 3 -->
     <g style="fill: #24313d" transform="translate(885.28825 239.351469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-33"/>
     </g>
    </g>
-   <g id="text_452">
+   <g id="text_428">
     <!-- 3 -->
     <g style="fill: #24313d" transform="translate(904.931875 239.351469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-33"/>
     </g>
    </g>
-   <g id="text_453">
+   <g id="text_429">
     <!-- 3 -->
     <g style="fill: #24313d" transform="translate(924.5755 239.351469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-33"/>
     </g>
    </g>
-   <g id="text_454">
+   <g id="text_430">
     <!-- — -->
     <g style="fill: #24313d" transform="translate(942.673187 239.351469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-2014"/>
     </g>
    </g>
-   <g id="text_455">
+   <g id="text_431">
     <!-- 4 -->
     <g style="fill: #24313d" transform="translate(963.86275 239.351469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-34"/>
     </g>
    </g>
-   <g id="text_456">
+   <g id="text_432">
     <!-- 5 -->
     <g style="fill: #24313d" transform="translate(983.506375 239.351469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-35"/>
     </g>
    </g>
-   <g id="text_457">
+   <g id="text_433">
     <!-- 5 -->
     <g style="fill: #24313d" transform="translate(1003.15 239.351469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-35"/>
     </g>
    </g>
-   <g id="text_458">
+   <g id="text_434">
     <!-- 5 -->
     <g style="fill: #24313d" transform="translate(1022.793625 239.351469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-35"/>
     </g>
    </g>
-   <g id="text_459">
+   <g id="text_435">
     <!-- 4 -->
     <g style="fill: #24313d" transform="translate(806.71375 260.555469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-34"/>
     </g>
    </g>
-   <g id="text_460">
+   <g id="text_436">
     <!-- 3 -->
     <g style="fill: #24313d" transform="translate(826.357375 260.555469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-33"/>
     </g>
    </g>
-   <g id="text_461">
+   <g id="text_437">
     <!-- 4 -->
     <g style="fill: #24313d" transform="translate(846.001 260.555469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-34"/>
     </g>
    </g>
-   <g id="text_462">
+   <g id="text_438">
     <!-- 4 -->
     <g style="fill: #24313d" transform="translate(865.644625 260.555469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-34"/>
     </g>
    </g>
-   <g id="text_463">
+   <g id="text_439">
     <!-- 5 -->
     <g style="fill: #24313d" transform="translate(885.28825 260.555469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-35"/>
     </g>
    </g>
-   <g id="text_464">
+   <g id="text_440">
     <!-- 3 -->
     <g style="fill: #24313d" transform="translate(904.931875 260.555469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-33"/>
     </g>
    </g>
-   <g id="text_465">
+   <g id="text_441">
     <!-- 3 -->
     <g style="fill: #24313d" transform="translate(924.5755 260.555469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-33"/>
     </g>
    </g>
-   <g id="text_466">
+   <g id="text_442">
     <!-- 4 -->
     <g style="fill: #24313d" transform="translate(944.219125 260.555469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-34"/>
     </g>
    </g>
-   <g id="text_467">
+   <g id="text_443">
     <!-- — -->
     <g style="fill: #24313d" transform="translate(962.316812 260.555469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-2014"/>
     </g>
    </g>
-   <g id="text_468">
+   <g id="text_444">
     <!-- 5 -->
     <g style="fill: #24313d" transform="translate(983.506375 260.555469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-35"/>
     </g>
    </g>
-   <g id="text_469">
+   <g id="text_445">
     <!-- 6 -->
     <g style="fill: #24313d" transform="translate(1003.15 260.555469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-36"/>
     </g>
    </g>
-   <g id="text_470">
+   <g id="text_446">
     <!-- 4 -->
     <g style="fill: #24313d" transform="translate(1022.793625 260.555469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-34"/>
     </g>
    </g>
-   <g id="text_471">
+   <g id="text_447">
     <!-- 5 -->
     <g style="fill: #24313d" transform="translate(806.71375 281.759469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-35"/>
     </g>
    </g>
-   <g id="text_472">
+   <g id="text_448">
     <!-- 5 -->
     <g style="fill: #24313d" transform="translate(826.357375 281.759469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-35"/>
     </g>
    </g>
-   <g id="text_473">
+   <g id="text_449">
     <!-- 4 -->
     <g style="fill: #24313d" transform="translate(846.001 281.759469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-34"/>
     </g>
    </g>
-   <g id="text_474">
+   <g id="text_450">
     <!-- 4 -->
     <g style="fill: #24313d" transform="translate(865.644625 281.759469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-34"/>
     </g>
    </g>
-   <g id="text_475">
+   <g id="text_451">
     <!-- 5 -->
     <g style="fill: #24313d" transform="translate(885.28825 281.759469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-35"/>
     </g>
    </g>
-   <g id="text_476">
+   <g id="text_452">
     <!-- 3 -->
     <g style="fill: #24313d" transform="translate(904.931875 281.759469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-33"/>
     </g>
    </g>
-   <g id="text_477">
+   <g id="text_453">
     <!-- 4 -->
     <g style="fill: #24313d" transform="translate(924.5755 281.759469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-34"/>
     </g>
    </g>
-   <g id="text_478">
+   <g id="text_454">
     <!-- 5 -->
     <g style="fill: #24313d" transform="translate(944.219125 281.759469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-35"/>
     </g>
    </g>
-   <g id="text_479">
+   <g id="text_455">
     <!-- 5 -->
     <g style="fill: #24313d" transform="translate(963.86275 281.759469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-35"/>
     </g>
    </g>
-   <g id="text_480">
+   <g id="text_456">
     <!-- — -->
     <g style="fill: #24313d" transform="translate(981.960437 281.759469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-2014"/>
     </g>
    </g>
-   <g id="text_481">
+   <g id="text_457">
     <!-- 4 -->
     <g style="fill: #24313d" transform="translate(1003.15 281.759469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-34"/>
     </g>
    </g>
-   <g id="text_482">
+   <g id="text_458">
     <!-- 4 -->
     <g style="fill: #24313d" transform="translate(1022.793625 281.759469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-34"/>
     </g>
    </g>
-   <g id="text_483">
+   <g id="text_459">
     <!-- 4 -->
     <g style="fill: #24313d" transform="translate(806.71375 302.963469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-34"/>
     </g>
    </g>
-   <g id="text_484">
+   <g id="text_460">
     <!-- 3 -->
     <g style="fill: #24313d" transform="translate(826.357375 302.963469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-33"/>
     </g>
    </g>
-   <g id="text_485">
+   <g id="text_461">
     <!-- 4 -->
     <g style="fill: #24313d" transform="translate(846.001 302.963469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-34"/>
     </g>
    </g>
-   <g id="text_486">
+   <g id="text_462">
     <!-- 4 -->
     <g style="fill: #24313d" transform="translate(865.644625 302.963469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-34"/>
     </g>
    </g>
-   <g id="text_487">
+   <g id="text_463">
     <!-- 4 -->
     <g style="fill: #24313d" transform="translate(885.28825 302.963469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-34"/>
     </g>
    </g>
-   <g id="text_488">
+   <g id="text_464">
     <!-- 4 -->
     <g style="fill: #24313d" transform="translate(904.931875 302.963469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-34"/>
     </g>
    </g>
-   <g id="text_489">
+   <g id="text_465">
     <!-- 4 -->
     <g style="fill: #24313d" transform="translate(924.5755 302.963469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-34"/>
     </g>
    </g>
-   <g id="text_490">
+   <g id="text_466">
     <!-- 5 -->
     <g style="fill: #24313d" transform="translate(944.219125 302.963469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-35"/>
     </g>
    </g>
-   <g id="text_491">
+   <g id="text_467">
     <!-- 6 -->
     <g style="fill: #24313d" transform="translate(963.86275 302.963469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-36"/>
     </g>
    </g>
-   <g id="text_492">
+   <g id="text_468">
     <!-- 4 -->
     <g style="fill: #24313d" transform="translate(983.506375 302.963469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-34"/>
     </g>
    </g>
-   <g id="text_493">
+   <g id="text_469">
     <!-- — -->
     <g style="fill: #24313d" transform="translate(1001.604062 302.963469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-2014"/>
     </g>
    </g>
-   <g id="text_494">
+   <g id="text_470">
     <!-- 4 -->
     <g style="fill: #24313d" transform="translate(1022.793625 302.963469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-34"/>
     </g>
    </g>
-   <g id="text_495">
+   <g id="text_471">
     <!-- 4 -->
     <g style="fill: #24313d" transform="translate(806.71375 324.167469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-34"/>
     </g>
    </g>
-   <g id="text_496">
+   <g id="text_472">
     <!-- 4 -->
     <g style="fill: #24313d" transform="translate(826.357375 324.167469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-34"/>
     </g>
    </g>
-   <g id="text_497">
+   <g id="text_473">
     <!-- 3 -->
     <g style="fill: #24313d" transform="translate(846.001 324.167469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-33"/>
     </g>
    </g>
-   <g id="text_498">
+   <g id="text_474">
     <!-- 3 -->
     <g style="fill: #24313d" transform="translate(865.644625 324.167469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-33"/>
     </g>
    </g>
-   <g id="text_499">
+   <g id="text_475">
     <!-- 5 -->
     <g style="fill: #24313d" transform="translate(885.28825 324.167469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-35"/>
     </g>
    </g>
-   <g id="text_500">
+   <g id="text_476">
     <!-- 4 -->
     <g style="fill: #24313d" transform="translate(904.931875 324.167469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-34"/>
     </g>
    </g>
-   <g id="text_501">
+   <g id="text_477">
     <!-- 5 -->
     <g style="fill: #24313d" transform="translate(924.5755 324.167469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-35"/>
     </g>
    </g>
-   <g id="text_502">
+   <g id="text_478">
     <!-- 5 -->
     <g style="fill: #24313d" transform="translate(944.219125 324.167469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-35"/>
     </g>
    </g>
-   <g id="text_503">
+   <g id="text_479">
     <!-- 4 -->
     <g style="fill: #24313d" transform="translate(963.86275 324.167469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-34"/>
     </g>
    </g>
-   <g id="text_504">
+   <g id="text_480">
     <!-- 4 -->
     <g style="fill: #24313d" transform="translate(983.506375 324.167469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-34"/>
     </g>
    </g>
-   <g id="text_505">
+   <g id="text_481">
     <!-- 4 -->
     <g style="fill: #24313d" transform="translate(1003.15 324.167469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-34"/>
     </g>
    </g>
-   <g id="text_506">
+   <g id="text_482">
     <!-- — -->
     <g style="fill: #24313d" transform="translate(1021.247687 324.167469) scale(0.085 -0.085)">
      <use xlink:href="#DejaVuSans-2014"/>
     </g>
    </g>
-   <g id="text_507">
+   <g id="text_483">
     <!-- Toehold + barcode -->
     <g style="fill: #24313d" transform="translate(856.695953 51.418844) scale(0.13 -0.13)">
      <defs>
@@ -8487,7 +8055,7 @@ L 315.837 113.43
    <g id="matplotlib.axis_8">
     <g id="ytick_37">
      <g id="line2d_73"/>
-     <g id="text_508">
+     <g id="text_484">
       <!-- 8 -->
       <g style="fill: #68717d" transform="translate(331.136 321.083112) scale(0.08 -0.08)">
        <use xlink:href="#DejaVuSans-38"/>
@@ -8496,7 +8064,7 @@ L 315.837 113.43
     </g>
     <g id="ytick_38">
      <g id="line2d_74"/>
-     <g id="text_509">
+     <g id="text_485">
       <!-- 9 -->
       <g style="fill: #68717d" transform="translate(331.136 286.823072) scale(0.08 -0.08)">
        <use xlink:href="#DejaVuSans-39"/>
@@ -8505,7 +8073,7 @@ L 315.837 113.43
     </g>
     <g id="ytick_39">
      <g id="line2d_75"/>
-     <g id="text_510">
+     <g id="text_486">
       <!-- 10 -->
       <g style="fill: #68717d" transform="translate(331.136 252.563033) scale(0.08 -0.08)">
        <use xlink:href="#DejaVuSans-31"/>
@@ -8515,7 +8083,7 @@ L 315.837 113.43
     </g>
     <g id="ytick_40">
      <g id="line2d_76"/>
-     <g id="text_511">
+     <g id="text_487">
       <!-- 11 -->
       <g style="fill: #68717d" transform="translate(331.136 218.302993) scale(0.08 -0.08)">
        <use xlink:href="#DejaVuSans-31"/>
@@ -8525,7 +8093,7 @@ L 315.837 113.43
     </g>
     <g id="ytick_41">
      <g id="line2d_77"/>
-     <g id="text_512">
+     <g id="text_488">
       <!-- 12 -->
       <g style="fill: #68717d" transform="translate(331.136 184.042953) scale(0.08 -0.08)">
        <use xlink:href="#DejaVuSans-31"/>
@@ -8535,7 +8103,7 @@ L 315.837 113.43
     </g>
     <g id="ytick_42">
      <g id="line2d_78"/>
-     <g id="text_513">
+     <g id="text_489">
       <!-- 13 -->
       <g style="fill: #68717d" transform="translate(331.136 149.782913) scale(0.08 -0.08)">
        <use xlink:href="#DejaVuSans-31"/>
@@ -8545,7 +8113,7 @@ L 315.837 113.43
     </g>
     <g id="ytick_43">
      <g id="line2d_79"/>
-     <g id="text_514">
+     <g id="text_490">
       <!-- 14 -->
       <g style="fill: #68717d" transform="translate(331.136 115.522874) scale(0.08 -0.08)">
        <use xlink:href="#DejaVuSans-31"/>
@@ -8625,7 +8193,7 @@ L 680.067 113.43
    <g id="matplotlib.axis_10">
     <g id="ytick_44">
      <g id="line2d_80"/>
-     <g id="text_515">
+     <g id="text_491">
       <!-- 11 -->
       <g style="fill: #68717d" transform="translate(695.366 326.229375) scale(0.08 -0.08)">
        <use xlink:href="#DejaVuSans-31"/>
@@ -8635,7 +8203,7 @@ L 680.067 113.43
     </g>
     <g id="ytick_45">
      <g id="line2d_81"/>
-     <g id="text_516">
+     <g id="text_492">
       <!-- 12 -->
       <g style="fill: #68717d" transform="translate(695.366 286.899375) scale(0.08 -0.08)">
        <use xlink:href="#DejaVuSans-31"/>
@@ -8645,7 +8213,7 @@ L 680.067 113.43
     </g>
     <g id="ytick_46">
      <g id="line2d_82"/>
-     <g id="text_517">
+     <g id="text_493">
       <!-- 13 -->
       <g style="fill: #68717d" transform="translate(695.366 247.569375) scale(0.08 -0.08)">
        <use xlink:href="#DejaVuSans-31"/>
@@ -8655,7 +8223,7 @@ L 680.067 113.43
     </g>
     <g id="ytick_47">
      <g id="line2d_83"/>
-     <g id="text_518">
+     <g id="text_494">
       <!-- 14 -->
       <g style="fill: #68717d" transform="translate(695.366 208.239375) scale(0.08 -0.08)">
        <use xlink:href="#DejaVuSans-31"/>
@@ -8665,7 +8233,7 @@ L 680.067 113.43
     </g>
     <g id="ytick_48">
      <g id="line2d_84"/>
-     <g id="text_519">
+     <g id="text_495">
       <!-- 15 -->
       <g style="fill: #68717d" transform="translate(695.366 168.909375) scale(0.08 -0.08)">
        <use xlink:href="#DejaVuSans-31"/>
@@ -8675,7 +8243,7 @@ L 680.067 113.43
     </g>
     <g id="ytick_49">
      <g id="line2d_85"/>
-     <g id="text_520">
+     <g id="text_496">
       <!-- 16 -->
       <g style="fill: #68717d" transform="translate(695.366 129.579375) scale(0.08 -0.08)">
        <use xlink:href="#DejaVuSans-31"/>
@@ -8685,7 +8253,7 @@ L 680.067 113.43
     </g>
     <g id="ytick_50">
      <g id="line2d_86"/>
-     <g id="text_521">
+     <g id="text_497">
       <!-- 17 -->
       <g style="fill: #68717d" transform="translate(695.366 90.249375) scale(0.08 -0.08)">
        <use xlink:href="#DejaVuSans-31"/>
@@ -8765,7 +8333,7 @@ L 1044.297 113.43
    <g id="matplotlib.axis_12">
     <g id="ytick_51">
      <g id="line2d_87"/>
-     <g id="text_522">
+     <g id="text_498">
       <!-- 3.0 -->
       <g style="fill: #68717d" transform="translate(1059.596 326.229375) scale(0.08 -0.08)">
        <use xlink:href="#DejaVuSans-33"/>
@@ -8776,7 +8344,7 @@ L 1044.297 113.43
     </g>
     <g id="ytick_52">
      <g id="line2d_88"/>
-     <g id="text_523">
+     <g id="text_499">
       <!-- 3.5 -->
       <g style="fill: #68717d" transform="translate(1059.596 286.899375) scale(0.08 -0.08)">
        <use xlink:href="#DejaVuSans-33"/>
@@ -8787,7 +8355,7 @@ L 1044.297 113.43
     </g>
     <g id="ytick_53">
      <g id="line2d_89"/>
-     <g id="text_524">
+     <g id="text_500">
       <!-- 4.0 -->
       <g style="fill: #68717d" transform="translate(1059.596 247.569375) scale(0.08 -0.08)">
        <use xlink:href="#DejaVuSans-34"/>
@@ -8798,7 +8366,7 @@ L 1044.297 113.43
     </g>
     <g id="ytick_54">
      <g id="line2d_90"/>
-     <g id="text_525">
+     <g id="text_501">
       <!-- 4.5 -->
       <g style="fill: #68717d" transform="translate(1059.596 208.239375) scale(0.08 -0.08)">
        <use xlink:href="#DejaVuSans-34"/>
@@ -8809,7 +8377,7 @@ L 1044.297 113.43
     </g>
     <g id="ytick_55">
      <g id="line2d_91"/>
-     <g id="text_526">
+     <g id="text_502">
       <!-- 5.0 -->
       <g style="fill: #68717d" transform="translate(1059.596 168.909375) scale(0.08 -0.08)">
        <use xlink:href="#DejaVuSans-35"/>
@@ -8820,7 +8388,7 @@ L 1044.297 113.43
     </g>
     <g id="ytick_56">
      <g id="line2d_92"/>
-     <g id="text_527">
+     <g id="text_503">
       <!-- 5.5 -->
       <g style="fill: #68717d" transform="translate(1059.596 129.579375) scale(0.08 -0.08)">
        <use xlink:href="#DejaVuSans-35"/>
@@ -8831,7 +8399,7 @@ L 1044.297 113.43
     </g>
     <g id="ytick_57">
      <g id="line2d_93"/>
-     <g id="text_528">
+     <g id="text_504">
       <!-- 6.0 -->
       <g style="fill: #68717d" transform="translate(1059.596 90.249375) scale(0.08 -0.08)">
        <use xlink:href="#DejaVuSans-36"/>
@@ -8843,7 +8411,7 @@ L 1044.297 113.43
    </g>
    <g id="LineCollection_3"/>
   </g>
-  <g id="text_529">
+  <g id="text_505">
    <!-- Pairwise string metrics show how the selected junctions differ -->
    <g style="fill: #24313d" transform="translate(212.381406 20.593031) scale(0.19 -0.19)">
     <defs>
@@ -9338,7 +8906,7 @@ z
     <use xlink:href="#DejaVuSans-Bold-72" transform="translate(3475.109375 0)"/>
    </g>
   </g>
-  <g id="text_530">
+  <g id="text_506">
    <!-- gene-scale-example · 12 junctions · thermodynamic screening not run -->
    <g style="fill: #68717d" transform="translate(344.994062 39.518203) scale(0.115 -0.115)">
     <defs>

--- a/src/dnadesign/junction/presentation/sequence_review/plot.py
+++ b/src/dnadesign/junction/presentation/sequence_review/plot.py
@@ -11,12 +11,14 @@ Module Author(s): Eric J. South
 
 from __future__ import annotations
 
+import hashlib
 import re
 from io import BytesIO
 from typing import Sequence
 
 import matplotlib
 import numpy as np
+from matplotlib.backends.backend_agg import FigureCanvasAgg
 from matplotlib.backends.backend_svg import FigureCanvasSVG
 from matplotlib.colors import LinearSegmentedColormap
 from matplotlib.figure import Figure
@@ -33,10 +35,36 @@ _BARCODE = "#75B9B4"
 _BARCODE_DARK = "#286F6B"
 _COMBINED = "#A99BC3"
 _COMBINED_DARK = "#5E4B7A"
+_LEFT_MARGIN_MIN = 0.065
+_LEFT_MARGIN_MAX = 0.24
+_LABEL_PADDING_POINTS = 4.0
+_DISPLAY_LABEL_MAX = 28
+_DISPLAY_TARGET_MAX = 14
+_DISPLAY_LOCAL_MAX = 13
 
 
 def _safe_identifier(value: str) -> str:
     return re.sub(r"[^A-Za-z0-9_.:/-]+", "-", value).strip("-") or "junction"
+
+
+def _compact_display_identifier(value: str, *, maximum: int) -> str:
+    safe = _safe_identifier(value)
+    if len(safe) <= maximum:
+        return safe
+    digest = hashlib.sha256(value.encode("utf-8")).hexdigest()[:8]
+    return f"{safe[: maximum - len(digest) - 1]}~{digest}"
+
+
+def _unique_display_tokens(values: Sequence[str], *, maximum: int) -> dict[str, str]:
+    distinct = tuple(sorted(set(values)))
+    tokens = {value: _compact_display_identifier(value, maximum=maximum) for value in distinct}
+    if len(set(tokens.values())) == len(tokens):
+        return tokens
+    ordinal_width = max(2, len(str(len(distinct))))
+    return {
+        value: (f"{_safe_identifier(value)[: maximum - ordinal_width - 1]}~{ordinal:0{ordinal_width}d}")
+        for ordinal, value in enumerate(distinct, start=1)
+    }
 
 
 def _labels(
@@ -46,10 +74,22 @@ def _labels(
     selected = tuple(review.junctions[index] for index in selection.indices)
     local = tuple(junction.junction_id.rsplit(":", 1)[-1] for junction in selected)
     if len(local) == len(set(local)):
-        return tuple(_safe_identifier(label) for label in local)
-    return tuple(
-        _safe_identifier(f"{junction.target_id}/{junction.junction_id.rsplit(':', 1)[-1]}") for junction in selected
+        tokens = _unique_display_tokens(local, maximum=_DISPLAY_LABEL_MAX)
+        return tuple(tokens[label] for label in local)
+    target_tokens = _unique_display_tokens(
+        tuple(junction.target_id for junction in selected),
+        maximum=_DISPLAY_TARGET_MAX,
     )
+    labels = tuple(
+        f"{target_tokens[junction.target_id]}/"
+        f"{_compact_display_identifier(junction.junction_id.rsplit(':', 1)[-1], maximum=_DISPLAY_LOCAL_MAX)}"
+        for junction in selected
+    )
+    if len(labels) == len(set(labels)):
+        return labels
+    sources = tuple(f"{junction.target_id}/{junction.junction_id.rsplit(':', 1)[-1]}" for junction in selected)
+    tokens = _unique_display_tokens(sources, maximum=_DISPLAY_LABEL_MAX)
+    return tuple(tokens[source] for source in sources)
 
 
 def _color_map(name: str, light: str, dark: str) -> LinearSegmentedColormap:
@@ -67,7 +107,16 @@ def _limits(matrix: np.ndarray) -> tuple[float, float]:
     return minimum, maximum
 
 
-def _draw_matrix(axis, matrix: np.ndarray, *, labels: tuple[str, ...], title: str, cmap, gid: str) -> None:
+def _draw_matrix(
+    axis,
+    matrix: np.ndarray,
+    *,
+    labels: tuple[str, ...],
+    title: str,
+    cmap,
+    gid: str,
+    show_y_labels: bool,
+) -> None:
     axis.set_gid(gid)
     masked = np.ma.array(matrix, mask=np.eye(matrix.shape[0], dtype=bool))
     boundaries = np.arange(matrix.shape[0] + 1, dtype=np.float64) - 0.5
@@ -85,7 +134,10 @@ def _draw_matrix(axis, matrix: np.ndarray, *, labels: tuple[str, ...], title: st
     axis.set_ylim(matrix.shape[0] - 0.5, -0.5)
     axis.set_title(title, fontsize=13.0, color=_INK, pad=12, fontweight="normal")
     axis.set_xticks(range(len(labels)), labels=labels, rotation=55, ha="right", rotation_mode="anchor")
-    axis.set_yticks(range(len(labels)), labels=labels)
+    axis.set_yticks(
+        range(len(labels)),
+        labels=labels if show_y_labels else ("",) * len(labels),
+    )
     tick_size = 8.5 if len(labels) <= 12 else 7.0
     axis.tick_params(axis="both", which="both", length=0, labelsize=tick_size, colors=_INK)
     for spine in axis.spines.values():
@@ -102,6 +154,23 @@ def _draw_matrix(axis, matrix: np.ndarray, *, labels: tuple[str, ...], title: st
     colorbar.solids.set_rasterized(False)
     colorbar.outline.set_visible(False)
     colorbar.ax.tick_params(labelsize=8, colors=_MUTED, length=0)
+
+
+def _left_margin_for_visible_labels(figure: Figure, axis) -> float:
+    """Reserve bounded space for the first matrix's rendered row labels."""
+
+    canvas = FigureCanvasAgg(figure)
+    canvas.draw()
+    renderer = canvas.get_renderer()
+    labels = [label for label in axis.get_yticklabels() if label.get_text()]
+    if not labels:
+        return _LEFT_MARGIN_MIN
+    leftmost = min(label.get_window_extent(renderer).x0 for label in labels)
+    padding = _LABEL_PADDING_POINTS * figure.dpi / 72.0
+    if leftmost >= padding:
+        return _LEFT_MARGIN_MIN
+    required = _LEFT_MARGIN_MIN + (padding - leftmost) / figure.bbox.width
+    return min(_LEFT_MARGIN_MAX, required)
 
 
 def plot_sequence_dissimilarity(
@@ -161,7 +230,7 @@ def plot_sequence_dissimilarity(
             "combined",
         ),
     )
-    for axis, (matrix, title, cmap, suffix) in zip(axes, panels, strict=True):
+    for index, (axis, (matrix, title, cmap, suffix)) in enumerate(zip(axes, panels, strict=True)):
         axis.set_facecolor(_BACKGROUND)
         _draw_matrix(
             axis,
@@ -170,8 +239,16 @@ def plot_sequence_dissimilarity(
             title=title,
             cmap=cmap,
             gid=f"junction-sequence-dissimilarity:{suffix}",
+            show_y_labels=index == 0,
         )
-    figure.subplots_adjust(left=0.065, right=0.965, top=0.81, bottom=0.19, wspace=0.42)
+    figure.subplots_adjust(
+        left=_LEFT_MARGIN_MIN,
+        right=0.965,
+        top=0.81,
+        bottom=0.19,
+        wspace=0.42,
+    )
+    figure.subplots_adjust(left=_left_margin_for_visible_labels(figure, axes[0]))
     return figure
 
 

--- a/src/dnadesign/junction/presentation/sequence_review/plot.py
+++ b/src/dnadesign/junction/presentation/sequence_review/plot.py
@@ -163,8 +163,6 @@ def _left_margin_for_visible_labels(figure: Figure, axis) -> float:
     canvas.draw()
     renderer = canvas.get_renderer()
     labels = [label for label in axis.get_yticklabels() if label.get_text()]
-    if not labels:
-        return _LEFT_MARGIN_MIN
     leftmost = min(label.get_window_extent(renderer).x0 for label in labels)
     padding = _LABEL_PADDING_POINTS * figure.dpi / 72.0
     if leftmost >= padding:

--- a/src/dnadesign/junction/tests/test_sequence_dissimilarity_plot.py
+++ b/src/dnadesign/junction/tests/test_sequence_dissimilarity_plot.py
@@ -18,6 +18,7 @@ import matplotlib
 import matplotlib.pyplot as plt
 import pytest
 import yaml
+from matplotlib.backends.backend_agg import FigureCanvasAgg
 
 from dnadesign.junction.contracts import parse_request
 from dnadesign.junction.design.planner import design_junction
@@ -117,6 +118,97 @@ def test_large_group_requires_an_explicit_bounded_subset(monkeypatch: pytest.Mon
     try:
         assert len(figure.axes[0].get_xticklabels()) == 12
         assert "12 of 25 junctions" in figure.texts[1].get_text()
+    finally:
+        plt.close(figure)
+
+
+@pytest.mark.parametrize("identifier_length", [128, 256])
+def test_multi_target_matrix_labels_fit_once_without_repeating_between_panels(
+    identifier_length: int,
+) -> None:
+    payload = _review(junction_count=24).model_dump(mode="json")
+    for index, junction in enumerate(payload["junctions"]):
+        group = index // 6 + 1
+        target_id = f"candidate-{'x' * (identifier_length - 13)}-{group:02d}"
+        junction["target_id"] = target_id
+        junction["junction_id"] = f"{target_id}:junction-{index % 6 + 1:04d}"
+    review = JunctionSequenceDissimilarityV1.model_validate(payload)
+    assert all(len(junction.target_id) == identifier_length for junction in review.junctions)
+
+    figure = plot_sequence_dissimilarity(review)
+    try:
+        matrix_axes = [axis for axis in figure.axes if axis.get_gid()]
+        canvas = FigureCanvasAgg(figure)
+        canvas.draw()
+        renderer = canvas.get_renderer()
+        visible_row_labels = [label for label in matrix_axes[0].get_yticklabels() if label.get_text()]
+        assert all(label.get_window_extent(renderer).x0 >= figure.bbox.x0 for label in visible_row_labels)
+        assert all(label.get_text() for label in matrix_axes[0].get_yticklabels())
+        assert all("~" in label.get_text() for label in visible_row_labels)
+        assert len({label.get_text() for label in visible_row_labels}) == len(visible_row_labels)
+        assert all(label.get_text() == "" for axis in matrix_axes[1:] for label in axis.get_yticklabels())
+    finally:
+        plt.close(figure)
+
+
+def test_compacted_target_labels_remain_unique_if_hash_suffixes_collide(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class _CollisionDigest:
+        @staticmethod
+        def hexdigest() -> str:
+            return "0" * 64
+
+    monkeypatch.setattr(plot_module.hashlib, "sha256", lambda _value: _CollisionDigest())
+    payload = _review(junction_count=4).model_dump(mode="json")
+    for index, junction in enumerate(payload["junctions"]):
+        target_id = f"{'shared-long-target-prefix-' * 4}{index // 2 + 1:02d}"
+        junction["target_id"] = target_id
+        junction["junction_id"] = f"{target_id}:junction-{index % 2 + 1:04d}"
+    review = JunctionSequenceDissimilarityV1.model_validate(payload)
+
+    figure = plot_sequence_dissimilarity(review)
+    try:
+        labels = [label.get_text() for label in figure.axes[0].get_yticklabels()]
+        assert len(set(labels)) == len(labels) == 4
+    finally:
+        plt.close(figure)
+
+
+def test_display_labels_remain_unique_after_identifier_sanitization() -> None:
+    payload = _review(junction_count=3).model_dump(mode="json")
+    identifiers = (
+        ("target-a", "target-a:a b"),
+        ("target-a", "target-a:a?b"),
+        ("target-b", "target-b:a b"),
+    )
+    for junction, (target_id, junction_id) in zip(payload["junctions"], identifiers, strict=True):
+        junction["target_id"] = target_id
+        junction["junction_id"] = junction_id
+    review = JunctionSequenceDissimilarityV1.model_validate(payload)
+
+    figure = plot_sequence_dissimilarity(review)
+    try:
+        labels = [label.get_text() for label in figure.axes[0].get_yticklabels()]
+        assert len(set(labels)) == len(labels) == 3
+    finally:
+        plt.close(figure)
+
+
+def test_wide_compacted_labels_fit_at_the_larger_tick_size() -> None:
+    payload = _review(junction_count=12).model_dump(mode="json")
+    for index, junction in enumerate(payload["junctions"]):
+        junction["junction_id"] = f"target-a:{'W' * 256}{index:02d}"
+    review = JunctionSequenceDissimilarityV1.model_validate(payload)
+
+    figure = plot_sequence_dissimilarity(review)
+    try:
+        canvas = FigureCanvasAgg(figure)
+        canvas.draw()
+        renderer = canvas.get_renderer()
+        labels = [label for label in figure.axes[0].get_yticklabels() if label.get_text()]
+        assert all(label.get_window_extent(renderer).x0 >= figure.bbox.x0 for label in labels)
+        assert len({label.get_text() for label in labels}) == len(labels) == 12
     finally:
         plt.close(figure)
 


### PR DESCRIPTION
## What changed

- compact long Junction display labels without changing full evidence identifiers
- enforce unique completed labels across punctuation normalization, target prefixes, and digest collisions
- measure a bounded left margin from rendered glyphs so wide labels do not clip
- show row labels once across the three dissimilarity matrices
- regenerate the deterministic documentation SVG

## Why

A real four-target, 68-junction dogfood run exposed clipped and potentially colliding heatmap labels. The plot needed bounded display aliases while preserving exact contract IDs.

## Validation

- 287 Junction tests passed
- 11 focused plot regressions passed
- architecture boundaries and 366 documentation checks pass
- Ruff, formatting, pre-commit, diff hygiene, and independent adversarial review pass
- tracked diff contains no private candidate IDs, sequences, or machine paths