### PR TITLE
Fix OPAL 3D camera persistence

### DIFF
--- a/src/dnadesign/opal/src/analysis/notebook_components/three_axis_camera_state.py
+++ b/src/dnadesign/opal/src/analysis/notebook_components/three_axis_camera_state.py
@@ -42,12 +42,17 @@ def render_three_axis_camera_state(*, mo: Any, revision: str) -> Any:
   const bind = (plot) => {{
     if (plot.layout?.scene?.uirevision !== revision) return;
     const saved = cameras[revision];
-    if (saved && !cameraMatches(plot._fullLayout?.scene?.camera, saved) && host.Plotly?.relayout) {{
+    const activeCamera = plot._fullLayout?.scene?.camera;
+    if (saved && activeCamera && !cameraMatches(activeCamera, saved) && host.Plotly?.relayout) {{
       plot.style.visibility = "hidden";
-      Promise.resolve(host.Plotly.relayout(plot, {{"scene.camera": saved}})).then(
-        () => reveal(plot),
-        () => reveal(plot),
-      );
+      try {{
+        Promise.resolve(host.Plotly.relayout(plot, {{"scene.camera": saved}})).then(
+          () => reveal(plot),
+          () => reveal(plot),
+        );
+      }} catch {{
+        reveal(plot);
+      }}
     }} else {{
       reveal(plot);
     }}
@@ -77,18 +82,21 @@ def render_three_axis_camera_state(*, mo: Any, revision: str) -> Any:
   const scan = () => {{
     if (scanning) return;
     scanning = true;
-    observe(host.document);
-    const visit = (root) => {{
-      for (const element of root.querySelectorAll("*")) {{
-        if (element.classList?.contains("js-plotly-plot")) bind(element);
-        if (element.shadowRoot) {{
-          observe(element.shadowRoot);
-          visit(element.shadowRoot);
+    try {{
+      observe(host.document);
+      const visit = (root) => {{
+        for (const element of root.querySelectorAll("*")) {{
+          if (element.classList?.contains("js-plotly-plot")) bind(element);
+          if (element.shadowRoot) {{
+            observe(element.shadowRoot);
+            visit(element.shadowRoot);
+          }}
         }}
-      }}
-    }};
-    visit(host.document);
-    scanning = false;
+      }};
+      visit(host.document);
+    }} finally {{
+      scanning = false;
+    }}
   }};
 
   let attempts = 40;

--- a/src/dnadesign/opal/src/analysis/notebook_components/three_axis_camera_state.py
+++ b/src/dnadesign/opal/src/analysis/notebook_components/three_axis_camera_state.py
@@ -42,7 +42,7 @@ def render_three_axis_camera_state(*, mo: Any, revision: str) -> Any:
   const bind = (plot) => {{
     if (plot.layout?.scene?.uirevision !== revision) return;
     const saved = cameras[revision];
-    if (saved && !cameraMatches(plot.layout.scene.camera, saved) && host.Plotly?.relayout) {{
+    if (saved && !cameraMatches(plot._fullLayout?.scene?.camera, saved) && host.Plotly?.relayout) {{
       plot.style.visibility = "hidden";
       Promise.resolve(host.Plotly.relayout(plot, {{"scene.camera": saved}})).then(
         () => reveal(plot),

--- a/src/dnadesign/opal/tests/notebooks/test_three_axis_camera_state.py
+++ b/src/dnadesign/opal/tests/notebooks/test_three_axis_camera_state.py
@@ -12,7 +12,6 @@ Module Author(s): Eric J. South
 from __future__ import annotations
 
 import json
-import re
 import subprocess
 
 
@@ -27,12 +26,13 @@ def test_camera_restore_failure_reveals_plot_and_allows_later_binding() -> None:
             return {"text": text, "width": width, "height": height}
 
     rendered = render_three_axis_camera_state(mo=_Mo(), revision="three_axis_scatter_v1:camera")
-    match = re.search(r"<script>\s*(.*?)\s*</script>", rendered["text"], flags=re.DOTALL)
-    assert match is not None
+    _prefix, opening, tail = rendered["text"].partition("<script>")
+    script, closing, _suffix = tail.rpartition("</script>")
+    assert opening and closing
 
     completed = subprocess.run(
         ("node", "-e", _NODE_HARNESS),
-        input=match.group(1),
+        input=script.strip(),
         check=True,
         capture_output=True,
         text=True,

--- a/src/dnadesign/opal/tests/notebooks/test_three_axis_camera_state.py
+++ b/src/dnadesign/opal/tests/notebooks/test_three_axis_camera_state.py
@@ -1,0 +1,134 @@
+"""
+--------------------------------------------------------------------------------
+dnadesign
+src/dnadesign/opal/tests/notebooks/test_three_axis_camera_state.py
+
+Exercises the generated three-axis camera binding against reactive plot failures.
+
+Module Author(s): Eric J. South
+--------------------------------------------------------------------------------
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+
+
+def test_camera_restore_failure_reveals_plot_and_allows_later_binding() -> None:
+    from dnadesign.opal.src.analysis.notebook_components.three_axis_camera_state import (
+        render_three_axis_camera_state,
+    )
+
+    class _Mo:
+        @staticmethod
+        def iframe(text: str, *, width: str, height: str) -> dict[str, str]:
+            return {"text": text, "width": width, "height": height}
+
+    rendered = render_three_axis_camera_state(mo=_Mo(), revision="three_axis_scatter_v1:camera")
+    match = re.search(r"<script>\s*(.*?)\s*</script>", rendered["text"], flags=re.DOTALL)
+    assert match is not None
+
+    completed = subprocess.run(
+        ("node", "-e", _NODE_HARNESS),
+        input=match.group(1),
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    result = json.loads(completed.stdout)
+
+    assert result == {
+        "failed_plot_hidden": False,
+        "later_plot_bound": True,
+        "relayout_calls": 1,
+        "script_error": None,
+    }
+
+
+_NODE_HARNESS = r"""
+const fs = require("fs");
+const source = fs.readFileSync(0, "utf8");
+const revision = "three_axis_scatter_v1:camera";
+const observers = [];
+const elements = [];
+const timers = [];
+let relayoutCalls = 0;
+
+class MutationObserver {
+  constructor(callback) {
+    this.callback = callback;
+    observers.push(this);
+  }
+  observe() {}
+  disconnect() {}
+}
+
+const document = {
+  querySelectorAll() {
+    return elements;
+  },
+};
+const host = {
+  document,
+  MutationObserver,
+  Plotly: {
+    relayout() {
+      relayoutCalls += 1;
+      throw new Error("forced synchronous relayout failure");
+    },
+  },
+  setTimeout(callback) {
+    timers.push(callback);
+  },
+};
+host.__opalThreeAxisCameras = {
+  [revision]: {
+    up: {x: 0, y: 0, z: 1},
+    center: {x: 0.1, y: 0.2, z: 0},
+    eye: {x: 2.2, y: -0.4, z: 0.8},
+    projection: {type: "perspective"},
+  },
+};
+global.parent = host;
+
+const makePlot = () => ({
+  classList: {contains: (value) => value === "js-plotly-plot"},
+  dataset: {},
+  layout: {
+    scene: {
+      uirevision: revision,
+      camera: {eye: {x: 1.55, y: 1.55, z: 1.2}},
+    },
+  },
+  _fullLayout: {
+    scene: {camera: {eye: {x: 1.55, y: 1.55, z: 1.2}}},
+  },
+  on() {},
+  style: {},
+});
+
+const failedPlot = makePlot();
+elements.push(failedPlot);
+let scriptError = null;
+try {
+  eval(source);
+} catch (error) {
+  scriptError = error.message;
+}
+
+host.Plotly.relayout = () => Promise.resolve();
+const laterPlot = makePlot();
+elements.push(laterPlot);
+for (const observer of [...observers]) observer.callback();
+
+setImmediate(() => {
+  process.stdout.write(JSON.stringify({
+    failed_plot_hidden: failedPlot.style.visibility === "hidden",
+    later_plot_bound: laterPlot.dataset.opalCameraRevision === revision,
+    relayout_calls: relayoutCalls,
+    script_error: scriptError,
+  }));
+});
+"""

--- a/src/dnadesign/opal/tests/notebooks/test_three_axis_scatter_notebook.py
+++ b/src/dnadesign/opal/tests/notebooks/test_three_axis_scatter_notebook.py
@@ -357,6 +357,7 @@ def test_three_axis_widget_uses_marimo_plotly_happy_path() -> None:
     assert 'plot.style.visibility = "hidden"' in widget["items"][0]["text"]
     assert "plotly_relayout" in widget["items"][0]["text"]
     assert "scene.camera" in widget["items"][0]["text"]
+    assert "plot._fullLayout?.scene?.camera" in widget["items"][0]["text"]
     restore_position = widget["items"][0]["text"].index("if (saved && !cameraMatches")
     binding_position = widget["items"][0]["text"].index("if (plot.dataset.opalCameraRevision")
     assert restore_position < binding_position

--- a/src/dnadesign/opal/tests/notebooks/test_three_axis_scatter_notebook.py
+++ b/src/dnadesign/opal/tests/notebooks/test_three_axis_scatter_notebook.py
@@ -358,7 +358,7 @@ def test_three_axis_widget_uses_marimo_plotly_happy_path() -> None:
     assert "plotly_relayout" in widget["items"][0]["text"]
     assert "scene.camera" in widget["items"][0]["text"]
     assert "plot._fullLayout?.scene?.camera" in widget["items"][0]["text"]
-    restore_position = widget["items"][0]["text"].index("if (saved && !cameraMatches")
+    restore_position = widget["items"][0]["text"].index("if (saved && activeCamera")
     binding_position = widget["items"][0]["text"].index("if (plot.dataset.opalCameraRevision")
     assert restore_position < binding_position
     assert widget["items"][0]["width"] == "0"


### PR DESCRIPTION
Summary:
- restore the browser-retained 3D camera from Plotly active full layout
- keep orientation stable across reactive view, round, and overlay changes
- add a causal notebook renderer contract test

Verification:
- full OPAL test suite
- all pre-commit hooks
- live Marimo dogfood across selection view, round, and selected-overlay transitions